### PR TITLE
chore(config): update default datastore from local-lvm to local-zfs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -60,7 +60,7 @@ module "vms" {
   }
 
   environment       = var.environment
-  default_datastore = "local-lvm"
+  default_datastore = "local-zfs"
 
   proxmox_api_token       = var.proxmox_api_token
   proxmox_api_endpoint    = var.proxmox_api_endpoint
@@ -85,7 +85,7 @@ module "containers" {
   }
 
   environment       = var.environment
-  default_datastore = "local-lvm"
+  default_datastore = "local-zfs"
 
   depends_on = [module.pools, module.storage]
 }

--- a/modules/proxmox-vm/variables.tf
+++ b/modules/proxmox-vm/variables.tf
@@ -81,7 +81,7 @@ variable "environment" {
 variable "default_datastore" {
   description = "Default datastore for VM storage"
   type        = string
-  default     = "local-lvm"
+  default     = "local-zfs"
 }
 
 variable "proxmox_api_endpoint" {


### PR DESCRIPTION
## Summary
- Updated default datastore configuration from local-lvm to local-zfs
- Changed main.tf module parameters for vms and containers  
- Updated default value in modules/proxmox-vm/variables.tf

## Benefits
- Improved storage performance with ZFS
- Better data integrity and snapshot capabilities
- Aligns with modern Proxmox best practices

🤖 Generated with Claude Code