### PR TITLE
fix: correct CIDR notation from /32 to /24 for standard LAN hosts

### DIFF
--- a/docs/INFRASTRUCTURE_NUMBERING.md
+++ b/docs/INFRASTRUCTURE_NUMBERING.md
@@ -111,40 +111,40 @@ Heavy I/O workloads run as full VMs:
 
 ## Network Addressing
 
-All resources use /32 host addresses in the management network.
+All resources use /24 CIDR notation for host addresses on the management network.
 
 Example configuration uses 192.168.1.0/24:
 
 ### Infrastructure (100-110)
 
-- 192.168.1.100/32 - ansible
-- 192.168.1.101/32 - ansible-2
-- 192.168.1.102/32 - pve-scripts-local
+- 192.168.1.100/24 - ansible
+- 192.168.1.101/24 - ansible-2
+- 192.168.1.102/24 - pve-scripts-local
 
 ### AI Development (150-169)
 
-- 192.168.1.150/32 - claude-code-01
-- 192.168.1.151/32 - claude-code-02
-- 192.168.1.161/32 - gemini-01
-- 192.168.1.162/32 - gemini-02
+- 192.168.1.150/24 - claude-code-01
+- 192.168.1.151/24 - claude-code-02
+- 192.168.1.161/24 - gemini-01
+- 192.168.1.162/24 - gemini-02
 
 ### Cribl Stream (171-179)
 
-- 192.168.1.171/32 - cribl-stream-1
-- 192.168.1.172/32 - cribl-stream-2
+- 192.168.1.171/24 - cribl-stream-1
+- 192.168.1.172/24 - cribl-stream-2
 
 ### Cribl Edge (181-189)
 
-- 192.168.1.181/32 - cribl-edge-01
-- 192.168.1.182/32 - cribl-edge-02
+- 192.168.1.181/24 - cribl-edge-01
+- 192.168.1.182/24 - cribl-edge-02
 
 ### Splunk Management (190-199)
 
-- 192.168.1.199/32 - splunk-mgmt
+- 192.168.1.199/24 - splunk-mgmt
 
 ### VMs (200+)
 
-- 192.168.1.200/32 - splunk-vm
+- 192.168.1.200/24 - splunk-vm
 
 ---
 

--- a/docs/MANAGING_REAL_VALUES.md
+++ b/docs/MANAGING_REAL_VALUES.md
@@ -1,15 +1,18 @@
 # Managing Real Infrastructure Values
 
-**Critical Security Pattern**: This repository uses placeholder values in all committed files. Real infrastructure details are maintained locally and never committed to git.
+**Critical Security Pattern**: This repository uses placeholder values in all committed files.
+Real infrastructure details are maintained locally and never committed to git.
 
 ## The Pattern
 
 ### Committed Files (Public/Safe)
+
 - `terraform.tfvars.example` - Placeholder RFC 1918 addresses (192.168.1.x)
 - All documentation uses example IPs and names
 - No real infrastructure topology exposed
 
 ### Local Files (Private/Gitignored)
+
 - `terraform.tfvars` - Your real IP addresses, hostnames, and configuration
 - Protected by `.gitignore` entries: `*.tfvars` and `terraform.tfvars`
 
@@ -31,7 +34,7 @@ proxmox_api_endpoint = "https://proxmox.example.com:8006/api2/json"
 vms = {
   "splunk-idx1" = {
     vm_id = 100
-    ipv4_address = "192.168.1.100/32"
+    ipv4_address = "192.168.1.100/24"
     # ...
   }
 }
@@ -41,7 +44,7 @@ proxmox_api_endpoint = "https://pve.your-real-domain.local:8006/api2/json"
 vms = {
   "splunk-idx1" = {
     vm_id = 100
-    ipv4_address = "YOUR_REAL_IP/32"  # Your actual network address
+    ipv4_address = "YOUR_REAL_IP/24"  # Your actual network address
     # ...
   }
 }
@@ -62,17 +65,20 @@ grep tfvars .gitignore
 ## What Values to Replace
 
 ### Network Configuration
+
 - **IP Addresses**: Replace all 192.168.1.x placeholder addresses with your actual network addresses
-- **Subnet Mask**: Adjust /32 if using different subnet design
+- **Subnet Mask**: Use /24 for standard LAN (matches your network's actual CIDR)
 - **Gateway**: Replace example gateway with your actual gateway
 - **DNS**: Update DNS servers if specified
 
 ### Proxmox Configuration
+
 - **API Endpoint**: Your actual Proxmox hostname or IP address
 - **Node Name**: Your actual Proxmox node name (check Proxmox UI)
 - **Domain**: Your actual internal domain name
 
 ### VM/Container IDs
+
 - **IDs**: Use the v2.0 numbering scheme as-is, or adjust if you have existing VMs with ID conflicts
 - **Names**: Modify if you prefer different naming conventions
 
@@ -153,6 +159,7 @@ fi
 ### Example Values in Docs
 
 All documentation uses **example values only**:
+
 - IPs: 192.168.1.x (RFC 1918 private range)
 - Domains: example.com, pve.example.com
 - Hostnames: Generic names (proxmox, pve)
@@ -160,6 +167,7 @@ All documentation uses **example values only**:
 ### Real Values Documentation
 
 Document your real infrastructure in:
+
 - **Private notes** (not in git)
 - **Password manager** (Bitwarden, 1Password, etc.)
 - **Separate private repo** (if needed)
@@ -170,6 +178,7 @@ Document your real infrastructure in:
 ### "My changes aren't being applied"
 
 Check if you're editing the example file instead of the real one:
+
 ```bash
 ls -la terraform.tfvars*
 # Should show both:
@@ -201,11 +210,12 @@ git commit -m "your message"
 
 ## Summary
 
-```
+```text
 ✅ Committed:     terraform.tfvars.example (192.168.1.x placeholders)
 ❌ Never commit:  terraform.tfvars (your real IP addresses)
 ✅ Gitignored:    *.tfvars, terraform.tfvars
 ✅ Secret values: Via Doppler (TF_VAR_* environment variables)
 ```
 
-This pattern ensures your public repository reveals no sensitive infrastructure details while maintaining a clear template for users.
+This pattern ensures your public repository reveals no sensitive infrastructure details
+while maintaining a clear template for users.

--- a/docs/TEMPLATE_CREATION.md
+++ b/docs/TEMPLATE_CREATION.md
@@ -54,6 +54,7 @@ wget https://cloud.debian.org/images/cloud/trixie/latest/debian-13-generic-amd64
 ```
 
 **Why cloud images?**
+
 - Pre-installed cloud-init and qemu-guest-agent
 - Optimized for virtual environments
 - Small size (~350MB)
@@ -181,11 +182,11 @@ qm clone 9001 999 --name test-clone
 
 # Configure cloud-init
 qm set 999 --ciuser debian --cipassword test123 --sshkeys ~/.ssh/authorized_keys
-qm set 999 --ipconfig0 ip=10.0.1.99/32,gw=10.0.1.1
+qm set 999 --ipconfig0 ip=192.168.1.99/24,gw=192.168.1.1
 
 # Start and verify
 qm start 999
-ssh debian@10.0.1.99
+ssh debian@192.168.1.99
 
 # Cleanup
 qm stop 999
@@ -202,8 +203,8 @@ clone_template = {
 }
 
 ip_config = {
-  ipv4_address = "10.0.1.100/32"
-  ipv4_gateway = "10.0.1.1"
+  ipv4_address = "192.168.1.100/24"
+  ipv4_gateway = "192.168.1.1"
 }
 
 user_account = {
@@ -214,6 +215,7 @@ user_account = {
 ```
 
 Cloud-init applies:
+
 - Network configuration (static IP)
 - User account creation
 - SSH key installation
@@ -222,14 +224,17 @@ Cloud-init applies:
 ## Troubleshooting
 
 **VM won't boot after cloning:**
+
 - Check boot order: `qm config 9001 | grep boot`
 - Verify disk attached: `qm config 9001 | grep scsi0`
 
 **Cloud-init not applying configuration:**
+
 - Check cloud-init drive exists: `qm config 9001 | grep ide2`
 - View cloud-init logs: `journalctl -u cloud-init`
 
 **Network not configured:**
+
 - Verify DHCP available on vmbr0 during first boot
 - Check cloud-init network config: `cat /etc/network/interfaces.d/50-cloud-init`
 

--- a/docs/splunk-cluster-spec.md
+++ b/docs/splunk-cluster-spec.md
@@ -24,8 +24,6 @@ internal cluster communication.
 4. Provide centralized logging for homelab infrastructure
 5. Maintain DRY principles in infrastructure code
 
-
-
 ---
 
 ## Architecture
@@ -34,10 +32,9 @@ internal cluster communication.
 
 | Component | ID | IP | Specs | Storage | Purpose |
 | --- | --- | --- | --- | --- | --- |
-| splunk-mgmt (LXC) | 205 | 192.168.1.205/32 | 3 cores, 3GB RAM, 100GB | local-zfs | All-in-one management |
-| splunk-idx1 (VM) | 100 | 192.168.1.100/32 | 6 cores, 6GB RAM, 200GB | local-zfs | Indexer 1 |
-| splunk-idx2 (VM) | 101 | 192.168.1.101/32 | 6 cores, 6GB RAM, 200GB | local-zfs | Indexer 2 |
-
+| splunk-mgmt (LXC) | 205 | 192.168.1.205/24 | 3 cores, 3GB RAM, 100GB | local-zfs | All-in-one management |
+| splunk-idx1 (VM) | 100 | 192.168.1.100/24 | 6 cores, 6GB RAM, 200GB | local-zfs | Indexer 1 |
+| splunk-idx2 (VM) | 101 | 192.168.1.101/24 | 6 cores, 6GB RAM, 200GB | local-zfs | Indexer 2 |
 
 **Total Resource Allocation**: 15 cores, 15GB RAM, 500GB storage
 
@@ -47,7 +44,7 @@ internal cluster communication.
 
 - Domain: `pve.example.com`
 - Network: 192.168.1.0/24
-- IP Format: /32 per host
+- IP Format: /24 per host
 - Gateway: 192.168.1.1
 - Bridge: vmbr0
 - Existing VMs: Example IDs (100, 110)
@@ -55,7 +52,7 @@ internal cluster communication.
 **Example Environment** (from `terraform.tfvars.example`):
 
 - Network: 192.168.1.0/24 (placeholder values)
-- IP Format: /32 per host
+- IP Format: /24 per host
 - Pool: "logging" (existing)
 
 ### Splunk Configuration
@@ -75,8 +72,7 @@ internal cluster communication.
 
 - Replication Factor: 2
 - Search Factor: 1
-- Cluster Master URI: [https://192.168.1.205:8089](https://192.168.1.205:8089)
-
+- Cluster Master URI: <https://192.168.1.205:8089>
 
 ---
 
@@ -106,7 +102,6 @@ internal cluster communication.
 - ALLOW outbound only to 192.168.1.0/24
 - NO internet access
 
-
 **Port Matrix**:
 
 | Port | Protocol | Purpose | Allowed From |
@@ -118,30 +113,34 @@ internal cluster communication.
 | 8080 | TCP | Replication | Splunk cluster only |
 | 9887 | TCP | Clustering | Splunk cluster only |
 
-
 ---
 
 ## Secrets Management
 
 ### Approach: File-Based (Simplified)
 
-**Rationale**: Proxmox is air-gapped with no internet access. Cloud-based secrets management (Vault, BWS) is not viable. File-based approach prioritizes simplicity.
+**Rationale**: Proxmox is air-gapped with no internet access. Cloud-based secrets management
+(Vault, BWS) is not viable. File-based approach prioritizes simplicity.
 
 **Local (Mac)**:
+
 - Doppler: Stores Proxmox API credentials for Terraform execution
 - SSH Keys: `~/.ssh/id_rsa_pve` (Proxmox), `~/.ssh/id_rsa_vm` (VMs)
 
 **Proxmox Host**:
+
 - Splunk Package: `/opt/splunk-packages/splunk-10.0.2-e2d18b4767e9-linux-amd64.deb`
 - Files staged manually on Proxmox host
 - No secrets service required
 
 **Terraform State**:
+
 - S3 Backend: `terraform-proxmox-state-useast2-${aws_account_id}`
 - DynamoDB Locking: `terraform-proxmox-locks-useast2`
 - Encryption: Enabled
 
 **Splunk Credentials** (managed by Ansible role):
+
 - Admin password: Set by Ansible during initial installation (must be provided via Ansible Vault or --extra-vars)
 - Cluster secret key: Set by Ansible for cluster communication (must be provided via Ansible Vault or --extra-vars)
 - **IMPORTANT**: No hardcoded defaults - credentials must be supplied securely for each deployment
@@ -167,18 +166,20 @@ internal cluster communication.
 **Solution**: Create reusable `modules/splunk-indexer/`
 
 **Module Interface**:
+
 ```hcl
 module "splunk_idx1" {
   source      = "./modules/splunk-indexer"
   vm_id       = 100
   name        = "splunk-idx1"
-  ip_address  = "192.168.1.100/32"  # Example IP
+  ip_address  = "192.168.1.100/24"  # Example IP
   node_name   = var.proxmox_node
   pool_id     = "logging"
 }
 ```
 
 **Shared Configuration** (DRY inside module):
+
 - CPU: 4 cores
 - Memory: 4096 MB
 - Disk: 200 GB (local-zfs, virtio, iothread=true)
@@ -191,6 +192,7 @@ module "splunk_idx1" {
 **Status**: Done
 
 Created `modules/firewall/` with:
+
 - `main.tf`: Proxmox firewall options and rules for VMs/containers
 - `variables.tf`: node_name, splunk_vm_ids, splunk_container_ids, networks
 - `outputs.tf`: Firewall enabled status
@@ -200,19 +202,22 @@ Integrated in `main.tf` after containers module.
 ### Phase 4: Terraform Configuration ⚠️ PARTIAL
 
 **Completed**:
+
 - ✅ Firewall variables added to `variables.tf`
 - ✅ Firewall module integrated in `main.tf`
 - ✅ Splunk management container added to `terraform.tfvars.example`
 
 **Pending Fixes**:
+
 - ❌ Remove duplicated splunk-idx1/idx2 blocks from `terraform.tfvars.example`
 - ❌ Update pool from "splunk" to "logging"
-- ❌ Update IP format from /24 to /32
+- ✅ Verified IP format uses /24 (correct for standard LAN)
 - ❌ Update example IPs from 10.0.1.x to 192.168.1.x
 
 ### Phase 5: Ansible Splunk Role ⚠️ PARTIAL
 
 **Completed**:
+
 - ✅ Role structure created (`ansible/roles/splunk/`)
 - ✅ Installation tasks (`tasks/install.yml`)
 - ✅ Configuration tasks (`tasks/configure.yml`)
@@ -220,6 +225,7 @@ Integrated in `main.tf` after containers module.
 - ✅ Handlers, meta, defaults
 
 **Pending Fixes**:
+
 - ❌ Update Splunk version from 9.4.0 to 10.0.2
 - ❌ Update build from 6b4ebe426ca6 to e2d18b4767e9
 - ❌ Create Molecule tests (`molecule/default/`)
@@ -228,6 +234,7 @@ Integrated in `main.tf` after containers module.
 ### Phase 6: Ansible Integration ❌ PENDING
 
 **Files to Update**:
+
 - `.github/workflows/ansible.yml`: Add "splunk" to matrix
 - `ansible/playbooks/site.yml`: Add splunk_indexers and splunk_management plays
 - `ansible/inventory/hosts.yml.example`: Add splunk groups
@@ -251,6 +258,7 @@ Integrated in `main.tf` after containers module.
 ## Validation Checklist
 
 ### Terraform
+
 - [x] `terraform init -upgrade` passes
 - [x] `terraform validate` passes
 - [ ] `terraform fmt -check` passes
@@ -258,6 +266,7 @@ Integrated in `main.tf` after containers module.
 - [ ] No DRY violations
 
 ### Ansible
+
 - [ ] `ansible-lint` passes (production profile)
 - [ ] `molecule test` passes for splunk role
 - [ ] Idempotency verified (run twice, no changes)
@@ -265,6 +274,7 @@ Integrated in `main.tf` after containers module.
 - [ ] iptables tasks tagged `molecule-notest`
 
 ### Integration
+
 - [ ] Firewall module resources created successfully
 - [ ] Splunk indexer modules create VMs correctly
 - [ ] Container firewall rules applied
@@ -279,6 +289,7 @@ Integrated in `main.tf` after containers module.
 **Proxmox Host**: Ryzen 7 1700 (8 cores), 16GB RAM
 
 **Memory Allocation**:
+
 - Original Plan: 2x 8GB indexers = 16GB (exceeds capacity)
 - **Decision**: Reduced to 2x 4GB indexers + 2GB management = 10GB total
 - Rationale: Leave 6GB for Proxmox host and other services
@@ -296,6 +307,7 @@ Integrated in `main.tf` after containers module.
 **Decision**: File-based secrets (not Vault, BWS, Doppler on Proxmox)
 
 **Rationale**:
+
 - Proxmox has no internet access (air-gapped)
 - Complexity of self-hosted Vault outweighs benefits for 3-node cluster
 - File-based secrets sufficient for homelab use case
@@ -307,6 +319,7 @@ Integrated in `main.tf` after containers module.
 **Decision**: Splunk-to-Splunk communication configured manually by user
 
 **Deferred to GitHub Issue**:
+
 - Cluster peer registration
 - Replication port configuration
 - Bucket policies
@@ -321,7 +334,7 @@ Integrated in `main.tf` after containers module.
 ### Already Staged ✅
 
 - Splunk Package: `/opt/splunk-packages/splunk-10.0.2-e2d18b4767e9-linux-amd64.deb` on pve
-- Network: Real config in `terraform.tfvars` (example: 192.168.1.x/32)
+- Network: Real config in `terraform.tfvars` (example: 192.168.1.x/24)
 - Pool: "logging" pool exists
 - Domain: `pve.example.com`
 
@@ -339,11 +352,13 @@ Integrated in `main.tf` after containers module.
 ### Unit Testing
 
 **Terraform**:
+
 - `terraform validate`: Syntax and provider constraints
 - `terraform fmt`: Code formatting
 - `terraform plan`: Resource generation without apply
 
 **Ansible**:
+
 - `ansible-lint`: YAML syntax, best practices (production profile)
 - `molecule test`: Docker-based role testing
   - Dependency resolution
@@ -355,16 +370,18 @@ Integrated in `main.tf` after containers module.
 ### Integration Testing
 
 **Manual Verification**:
+
 1. Run `terraform apply` in isolated environment
 2. Verify VMs created with correct specs
 3. Verify container created
 4. Verify Proxmox firewall rules applied
 5. Test SSH access to VMs
-6. Test Splunk Web UI access (http://192.168.1.205:8000)
+6. Test Splunk Web UI access (<http://192.168.1.205:8000>)
 7. Verify network isolation (no outbound internet)
 8. Verify cluster communication (8089, 9997, 8080, 9887 ports)
 
 **Performance Testing**:
+
 - Run `scripts/timing.sh` to measure terragrunt plan/apply times
 - Record baseline metrics for future optimization
 
@@ -375,12 +392,14 @@ Integrated in `main.tf` after containers module.
 ### If Deployment Fails
 
 **Terraform**:
+
 1. Run `terraform destroy` to remove resources
 2. Review error logs
 3. Fix configuration issues
 4. Re-run `terraform plan` and `terraform apply`
 
 **Ansible**:
+
 1. SSH into VMs manually
 2. Stop Splunk service: `systemctl stop Splunkd`
 3. Remove Splunk: `apt remove splunk` or `rm -rf /opt/splunk`
@@ -388,6 +407,7 @@ Integrated in `main.tf` after containers module.
 5. Re-run Ansible playbook
 
 **Proxmox Firewall**:
+
 1. Disable firewall in Proxmox UI: Datacenter > Firewall > Options > Firewall: No
 2. Remove firewall rules manually if needed
 
@@ -451,10 +471,10 @@ Integrated in `main.tf` after containers module.
 
 ### Documentation
 
-- **Splunk Docs**: https://docs.splunk.com/
-- **Proxmox VE**: https://pve.proxmox.com/wiki/
-- **Terraform Proxmox Provider**: https://registry.terraform.io/providers/bpg/proxmox/
-- **Ansible Best Practices**: https://docs.ansible.com/ansible/latest/user_guide/playbooks_best_practices.html
+- **Splunk Docs**: <https://docs.splunk.com/>
+- **Proxmox VE**: <https://pve.proxmox.com/wiki/>
+- **Terraform Proxmox Provider**: <https://registry.terraform.io/providers/bpg/proxmox/>
+- **Ansible Best Practices**: <https://docs.ansible.com/ansible/latest/user_guide/playbooks_best_practices.html>
 
 ### Internal
 
@@ -468,7 +488,7 @@ Integrated in `main.tf` after containers module.
 
 ### v1.0.0 (2025-12-25)
 
-**Initial specification created**
+Initial specification created:
 
 - Defined architecture (2 indexers + 1 management container)
 - Documented network security (defense-in-depth firewall)

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -40,11 +40,10 @@ These issues were identified during WIP commit review. Fix before proceeding wit
 
 ### 1.2 Fix IP Subnet in terraform.tfvars.example
 
-- [x] **Update IP format from /24 to /32 for Splunk nodes**
+- [x] **Verify IP format uses /24 for standard LAN**
   - File: `terraform.tfvars.example`
-  - Line 104: Change `10.0.1.100/24` to `192.168.1.100/32`
-  - Line 149: Change `10.0.1.101/24` to `192.168.1.101/32`
-  - Line 193: Change `10.0.1.205/24` to `192.168.1.205/32`
+  - All host IPs use /24 CIDR notation (e.g., `192.168.1.100/24`)
+  - /24 is correct for hosts on a standard LAN network
 
 ### 1.3 Fix Example IPs (10.0.1.x to 192.168.1.x)
 
@@ -231,7 +230,7 @@ Group 4 (Scripts) ----> Group 5 (Documentation)
 | Splunk Version | 10.0.2 |
 | Splunk Build | e2d18b4767e9 |
 | Example Network | 192.168.1.0/24 |
-| IP Format | /32 per host |
+| IP Format | /24 per host |
 | Pool Name | logging |
 | Management IP | 192.168.1.205 |
 | Indexer 1 IP | 192.168.1.100 |
@@ -240,7 +239,7 @@ Group 4 (Scripts) ----> Group 5 (Documentation)
 ### Constraints
 
 - Real `terraform.tfvars` is never committed (in .gitignore)
-- Example values use 192.168.1.x/32 network
+- Example values use 192.168.1.x/24 network
 - All real infrastructure details sanitized from committed files
 - Related Ansible automation in separate `feat/initial-splunk-ansible` branch
 

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -55,7 +55,7 @@ pools = {
 # Splunk VM Module Configuration - Single All-in-One (200+)
 splunk_vm_id         = 200
 splunk_vm_name       = "splunk-vm"
-splunk_vm_ip_address = "192.168.1.200/32"
+splunk_vm_ip_address = "192.168.1.200/24"
 splunk_vm_pool_id    = "logging"
 template_id          = 9200  # Packer-built Splunk template
 
@@ -94,7 +94,7 @@ containers = {
     }]
 
     ip_config = {
-      ipv4_address = "192.168.1.100/32"
+      ipv4_address = "192.168.1.100/24"
       ipv4_gateway = "192.168.1.1"
     }
   }
@@ -121,7 +121,7 @@ containers = {
     }]
 
     ip_config = {
-      ipv4_address = "192.168.1.101/32"
+      ipv4_address = "192.168.1.101/24"
       ipv4_gateway = "192.168.1.1"
     }
   }
@@ -151,7 +151,7 @@ containers = {
     }]
 
     ip_config = {
-      ipv4_address = "192.168.1.110/32"
+      ipv4_address = "192.168.1.110/24"
       ipv4_gateway = "192.168.1.1"
     }
   }
@@ -179,7 +179,7 @@ containers = {
     }]
 
     ip_config = {
-      ipv4_address = "192.168.1.150/32"
+      ipv4_address = "192.168.1.150/24"
       ipv4_gateway = "192.168.1.1"
     }
   }
@@ -206,7 +206,7 @@ containers = {
     }]
 
     ip_config = {
-      ipv4_address = "192.168.1.151/32"
+      ipv4_address = "192.168.1.151/24"
       ipv4_gateway = "192.168.1.1"
     }
   }
@@ -233,7 +233,7 @@ containers = {
     }]
 
     ip_config = {
-      ipv4_address = "192.168.1.161/32"
+      ipv4_address = "192.168.1.161/24"
       ipv4_gateway = "192.168.1.1"
     }
   }
@@ -260,7 +260,7 @@ containers = {
     }]
 
     ip_config = {
-      ipv4_address = "192.168.1.162/32"
+      ipv4_address = "192.168.1.162/24"
       ipv4_gateway = "192.168.1.1"
     }
   }
@@ -288,7 +288,7 @@ containers = {
     }]
 
     ip_config = {
-      ipv4_address = "192.168.1.171/32"
+      ipv4_address = "192.168.1.171/24"
       ipv4_gateway = "192.168.1.1"
     }
   }
@@ -315,7 +315,7 @@ containers = {
     }]
 
     ip_config = {
-      ipv4_address = "192.168.1.172/32"
+      ipv4_address = "192.168.1.172/24"
       ipv4_gateway = "192.168.1.1"
     }
   }
@@ -343,7 +343,7 @@ containers = {
     }]
 
     ip_config = {
-      ipv4_address = "192.168.1.181/32"
+      ipv4_address = "192.168.1.181/24"
       ipv4_gateway = "192.168.1.1"
     }
   }
@@ -370,7 +370,7 @@ containers = {
     }]
 
     ip_config = {
-      ipv4_address = "192.168.1.182/32"
+      ipv4_address = "192.168.1.182/24"
       ipv4_gateway = "192.168.1.1"
     }
   }
@@ -398,7 +398,7 @@ containers = {
     }]
 
     ip_config = {
-      ipv4_address = "192.168.1.199/32"
+      ipv4_address = "192.168.1.199/24"
       ipv4_gateway = "192.168.1.1"
     }
   }


### PR DESCRIPTION
## Summary

- Corrects CIDR notation from /32 to /24 across all documentation and examples
- /24 is the correct notation for hosts on a standard LAN network
- /32 is only for point-to-point links (single host, no gateway routing)

## Research

Confirmed via Proxmox Cloud-Init docs and forums:
- `ip=10.0.10.123/24,gw=10.0.10.1` is the documented pattern
- /32 with gateway causes network issues in Debian 12/netplan

## Changes

- `terraform.tfvars.example`: All container IPs use /24
- `docs/INFRASTRUCTURE_NUMBERING.md`: Fixed IP examples and description
- `docs/MANAGING_REAL_VALUES.md`: Fixed IP format guidance
- `docs/TEMPLATE_CREATION.md`: Fixed qm set and HCL examples
- `docs/splunk-cluster-spec.md`: Fixed IP format references
- `docs/tasks.md`: Corrected task description

## Test plan

- [x] Verify all /32 references replaced with /24
- [x] Verify internal terraform.tfvars already uses /24 (confirmed)
- [x] Markdown linting passes on all modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Corrects CIDR notation from /32 to /24 for standard LAN hosts across documentation and examples.
> 
>   - **Behavior**:
>     - Corrects CIDR notation from /32 to /24 for standard LAN hosts in all documentation and examples.
>     - Ensures all IP addresses use /24 notation, which is correct for standard LAN networks.
>   - **Files Affected**:
>     - `terraform.tfvars.example`: Updates all container IPs to use /24.
>     - `docs/INFRASTRUCTURE_NUMBERING.md`, `docs/MANAGING_REAL_VALUES.md`, `docs/TEMPLATE_CREATION.md`: Fixes IP examples and descriptions.
>     - `docs/splunk-cluster-spec.md`, `docs/tasks.md`: Corrects IP format references.
>   - **Test Plan**:
>     - Verified all /32 references replaced with /24.
>     - Confirmed internal `terraform.tfvars` already uses /24.
>     - Markdown linting passes on all modified files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fterraform-proxmox&utm_source=github&utm_medium=referral)<sup> for 8da9f0484fb4ca841a4e6820a14d741946fcc7ad. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->