### PR TITLE
feat: add ansible_inventory output for dynamic Ansible integration

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -75,10 +75,10 @@ output "ansible_inventory" {
   value = {
     # LXC Containers - using proxmox_pct_remote connection
     containers = {
-      for k, v in(length(var.containers) > 0 ? module.containers[0].container_details : {}) : k => {
+      for k, v in (length(var.containers) > 0 ? module.containers[0].container_details : {}) : k => {
         vmid     = v.id
-        hostname = k
-        ip       = local.derive_ip[v.id] # IP derived from vm_id: network_prefix.vm_id/mask
+        hostname = var.containers[k].hostname
+        ip       = split("/", local.derive_ip[v.id])[0] # IP derived from vm_id: network_prefix.vm_id/mask; strip CIDR for Ansible
         node     = v.node_name
         # Connection settings for proxmox_pct_remote (community.general)
         ansible_connection = "community.general.proxmox_pct_remote"
@@ -107,7 +107,7 @@ output "ansible_inventory" {
       splunk = {
         vmid     = module.splunk_vm.vm_id
         hostname = module.splunk_vm.name
-        ip       = module.splunk_vm.ip_address
+        ip       = module.splunk_vm.ip_address != null ? split("/", module.splunk_vm.ip_address)[0] : null
         node     = var.proxmox_node
         ansible_connection = "ssh"
       }


### PR DESCRIPTION
## Summary

This PR introduces a new Terraform output (`ansible_inventory`) that structures all infrastructure data (VMs, containers, and Splunk infrastructure) for consumption by Ansible.

### Changes

- Added `ansible_inventory` output to `outputs.tf` that combines:
  - LXC containers with proxmox_pct_remote connection settings
  - Regular VMs with SSH connection configuration
  - Splunk VM with dedicated Docker host settings

### How It Works

The output structures infrastructure data dynamically from Terraform modules, including:
- VM IDs (vmid)
- IP addresses (derived from Terraform state)
- Hostname information
- Connection plugin settings
- Node assignments and pool IDs

### Integration

This output enables Ansible to load infrastructure data dynamically via:
```bash
terragrunt output -json ansible_inventory > inventory/terraform_inventory.json
```

Then Ansible can consume this via the `load_terraform.yml` pre-playbook (added in ansible-proxmox-apps PR).

### Eliminates Hardcoding

This resolves the DRY violation where Ansible had hardcoded VM IDs and IPs. Now Terraform is the single source of truth for all infrastructure.

### Testing

- ✓ Terraform validation passes
- ✓ Output structure validated with sample data
- ✓ Integration tested with ansible-proxmox-apps repo

## Related

- ansible-proxmox-apps PR: [Terraform inventory integration infrastructure](https://github.com/JacobPEvans/ansible-proxmox-apps/pull)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds `ansible_inventory` output in `outputs.tf` for dynamic Ansible inventory, eliminating hardcoded VM IDs and IPs.
> 
>   - **New Output**:
>     - Adds `ansible_inventory` output in `outputs.tf` for dynamic Ansible inventory generation.
>     - Structures data for LXC containers, regular VMs, and Splunk VM with specific connection settings.
>   - **Behavior**:
>     - Eliminates hardcoded VM IDs and IPs in Ansible configurations.
>     - Terraform becomes the single source of truth for infrastructure data.
>   - **Testing**:
>     - Validated output structure with sample data.
>     - Integration tested with `ansible-proxmox-apps` repository.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fterraform-proxmox&utm_source=github&utm_medium=referral)<sup> for 19cf1df1aa13779bc173530a619eeb3e82755fa1. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->