### PR TITLE
feat: create ansible inventory export script

### DIFF
--- a/scripts/ansible-inventory.jq
+++ b/scripts/ansible-inventory.jq
@@ -1,0 +1,56 @@
+# Transform Terraform ansible_inventory to Ansible inventory YAML format
+# Build groups from resource types
+#
+# Note: The `add` function merges an array of objects into a single object.
+# We use `add // {}` to handle empty input: if there are no resources in a
+# category (e.g., no containers), `to_entries` returns an empty array, `map`
+# produces an empty array, and `add` returns null. The `// {}` coalesces
+# null to an empty object for graceful handling of missing resource types.
+
+{
+  "all": {
+    "children": {
+      "lxc_containers": {
+        "hosts": (
+          .containers // {} | to_entries | map({
+            (.key): {
+              "ansible_host": .value.ip,
+              "ansible_connection": .value.ansible_connection,
+              "ansible_pct_vmid": .value.ansible_pct_vmid,
+              "vmid": .value.vmid,
+              "proxmox_node": .value.node,
+              "tags": .value.tags,
+              "pool_id": .value.pool_id
+            }
+          }) | add // {}
+        )
+      },
+      "vms": {
+        "hosts": (
+          .vms // {} | to_entries | map({
+            (.key): {
+              "ansible_host": .value.ip,
+              "ansible_connection": .value.ansible_connection,
+              "vmid": .value.vmid,
+              "proxmox_node": .value.node,
+              "tags": .value.tags,
+              "pool_id": .value.pool_id
+            }
+          }) | add // {}
+        )
+      },
+      "splunk_vms": {
+        "hosts": (
+          .splunk_vm // {} | to_entries | map({
+            (.key): {
+              "ansible_host": .value.ip,
+              "ansible_connection": .value.ansible_connection,
+              "vmid": .value.vmid,
+              "proxmox_node": .value.node
+            }
+          }) | add // {}
+        )
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add `scripts/export-ansible-inventory.sh` to export Terraform's ansible_inventory output
- Support three output formats: json, yaml, ansible inventory YAML
- Enable integration with ansible-proxmox-apps repository

## Test plan
- [ ] Run `doppler run -- ./scripts/export-ansible-inventory.sh` for JSON output
- [ ] Run `doppler run -- ./scripts/export-ansible-inventory.sh yaml` for YAML output
- [ ] Run `doppler run -- ./scripts/export-ansible-inventory.sh ansible hosts.yml` for Ansible format
- [ ] Validate JSON output: `./scripts/export-ansible-inventory.sh | jq .`

Closes #86

Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add script to export Terraform ansible_inventory output in JSON, YAML, or Ansible inventory YAML format.
> 
>   - **Scripts**:
>     - Add `export-ansible-inventory.sh` to export Terraform's ansible_inventory output in JSON, YAML, or Ansible inventory YAML format.
>     - Add `ansible-inventory.jq` to transform JSON to Ansible inventory YAML format.
>   - **Functionality**:
>     - Supports JSON, YAML, and Ansible inventory formats.
>     - Validates required tools: `jq`, `terragrunt`, and `yq` (for YAML/Ansible formats).
>     - Outputs to specified file or stdout.
>   - **Usage**:
>     - Requires environment variables via Doppler: `PROXMOX_VE_ENDPOINT`, `PROXMOX_VE_API_TOKEN`, AWS credentials.
>     - Provides usage instructions and error handling for missing tools or invalid formats.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fterraform-proxmox&utm_source=github&utm_medium=referral)<sup> for 0a32a8d1679b572ae25958c8731cbc775c474444. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->