### PR TITLE
feat: consolidate Splunk Docker deployment to ansible-splunk

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -3,7 +3,7 @@
 
 provider "registry.opentofu.org/bpg/proxmox" {
   version     = "0.93.0"
-  constraints = ">= 0.90.0, ~> 0.90"
+  constraints = "~> 0.93"
   hashes = [
     "h1:yYhnmVwP6UtwAYaPMUyGQiicg+adzLj3q3gsE3Ve8UE=",
     "zh:0e497d36981f5b70edc9ac23287222d17854781a911c4c44a058ca0ba7a7807f",
@@ -61,7 +61,7 @@ provider "registry.opentofu.org/hashicorp/null" {
 
 provider "registry.opentofu.org/hashicorp/random" {
   version     = "3.8.0"
-  constraints = "~> 3.7"
+  constraints = "~> 3.8"
   hashes = [
     "h1:aEaTEHutDdKNaztKFmInhfzmZK0/OaVL8uxmncM9YF8=",
     "zh:2d5e0bbfac7f15595739fe54a9ab8b8eea92fd6d879706139dad7ecaa5c01c19",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,9 +39,11 @@ configuration management.
 All commands require the complete toolchain wrapper:
 
 ```bash
-nix develop ~/git/nix-config/main/shells/terraform --command bash -c \
+nix develop <path-to-nix-config>/main/shells/terraform --command bash -c \
   "aws-vault exec terraform -- doppler run -- terragrunt <COMMAND>"
 ```
+
+Replace `<path-to-nix-config>` with the absolute path to your nix-config repository.
 
 Common operations:
 
@@ -53,7 +55,7 @@ Common operations:
 
 ```bash
 terragrunt output -json ansible_inventory > \
-  ~/git/ansible-splunk/inventory/terraform_inventory.json
+  <path-to-ansible-repo>/inventory/terraform_inventory.json
 ```
 
 ## Ansible Inventory Output

--- a/modules/splunk-vm/outputs.tf
+++ b/modules/splunk-vm/outputs.tf
@@ -12,7 +12,7 @@ output "ip_address" {
   description = "The IPv4 address of the Splunk VM (first non-loopback interface)"
   value = length(proxmox_virtual_environment_vm.splunk_vm.ipv4_addresses) > 1 ? (
     length(proxmox_virtual_environment_vm.splunk_vm.ipv4_addresses[1]) > 0 ?
-    proxmox_virtual_environment_vm.splunk_vm.ipv4_addresses[1][0] : null
+    split("/", proxmox_virtual_environment_vm.splunk_vm.ipv4_addresses[1][0])[0] : null
   ) : null
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -93,10 +93,7 @@ output "ansible_inventory" {
         vmid     = v.id
         hostname = v.name
         # Extract first IPv4 address from vm_network_interfaces (skip loopback at index 0)
-        ip = length(module.vms.vm_network_interfaces[k].ipv4_addresses) > 1 ? (
-          length(module.vms.vm_network_interfaces[k].ipv4_addresses[1]) > 0 ?
-          split("/", module.vms.vm_network_interfaces[k].ipv4_addresses[1][0])[0] : null
-        ) : null
+        ip = try(split("/", module.vms.vm_network_interfaces[k].ipv4_addresses[1][0])[0], null)
         node                = v.node_name
         ansible_connection  = "ssh"
         tags                = v.tags
@@ -108,7 +105,7 @@ output "ansible_inventory" {
       splunk = {
         vmid     = module.splunk_vm.vm_id
         hostname = module.splunk_vm.name
-        ip       = module.splunk_vm.ip_address
+        ip       = module.splunk_vm.ip_address # CIDR already stripped in module output
         node     = var.proxmox_node
         ansible_connection = "ssh"
       }


### PR DESCRIPTION
## Summary
- Migrate splunk_docker role from ansible-proxmox-apps to ansible-splunk
- Implement Terraform dynamic inventory integration
- Fix file ownership for Splunk apps (UID 41812)
- Add SSH configuration for Packer-based Debian VMs
- Create AGENTS.md documentation

## Test plan
- [x] Terraform inventory exports correctly
- [x] Splunk container starts and becomes healthy
- [x] Web UI accessible at http://10.0.1.200:8000/
- [x] HEC endpoint listening on port 8088

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Consolidate Splunk Docker deployment to `ansible-splunk` with Terraform dynamic inventory integration and documentation updates.
> 
>   - **Migration**:
>     - Move `splunk_docker` role from `ansible-proxmox-apps` to `ansible-splunk`.
>   - **Terraform Integration**:
>     - Implement dynamic inventory integration in `outputs.tf` and `modules/splunk-vm/outputs.tf`.
>     - Update `ansible_inventory` output to handle non-loopback IPs.
>   - **Configuration**:
>     - Fix file ownership for Splunk apps to UID 41812.
>     - Add SSH configuration for Packer-based Debian VMs.
>   - **Documentation**:
>     - Create `AGENTS.md` for Terraform Proxmox AI Agent documentation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fterraform-proxmox&utm_source=github&utm_medium=referral)<sup> for 10f9e281de4ad2697a625a6e5152a0cc10d71b51. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->