### PR TITLE
security: add fork guard to ci-fix workflow

### DIFF
--- a/.github/workflows/ci-fix-claude.yml
+++ b/.github/workflows/ci-fix-claude.yml
@@ -24,7 +24,8 @@ jobs:
     name: Check if fix needed
     if: >-
       github.event.workflow_run.conclusion == 'failure' &&
-      github.event.workflow_run.head_branch != 'main'
+      github.event.workflow_run.head_branch != 'main' &&
+      github.event.workflow_run.head_repository.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read


### PR DESCRIPTION
## Summary
- Adds fork guard (`github.event.workflow_run.head_repository.full_name == github.repository`) to the `fix` job in `ci-fix-claude.yml`
- Prevents untrusted code checkout in the privileged `workflow_run` context
- Resolves CodeQL `actions/untrusted-checkout/high` alert

## Context
The `workflow_run` trigger gives the fix job write permissions to contents and pull-requests. Without a fork guard, a malicious fork PR could trigger the workflow and execute arbitrary code with those elevated permissions. The guard ensures only branches from the same repository are checked out.

## Test plan
- [ ] Verify CodeQL alert is dismissed after merge
- [ ] CI fix workflow still triggers correctly for same-repo PR branches

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a fork guard to the `fix` job in `ci-fix-claude.yml` to prevent untrusted code execution from forks, resolving a CodeQL alert.
> 
>   - **Security**:
>     - Adds fork guard to `fix` job in `ci-fix-claude.yml` to prevent untrusted code checkout.
>     - Uses condition `github.event.workflow_run.head_repository.full_name == github.repository` to ensure only same-repo branches are processed.
>     - Resolves CodeQL `actions/untrusted-checkout/high` alert.
>   - **Behavior**:
>     - Ensures `fix` job only runs for branches from the same repository, not forks.
>     - Protects against arbitrary code execution with elevated permissions in `workflow_run` context.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fterraform-proxmox&utm_source=github&utm_medium=referral)<sup> for a73b403b551dd7b03f638d8945cd43823acf8117. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->