### PR TITLE
fix: bump ai-workflows callers to v0.2.9 and add OIDC permissions

### DIFF
--- a/.github/workflows/best-practices.yml
+++ b/.github/workflows/best-practices.yml
@@ -12,5 +12,5 @@ permissions:
 
 jobs:
   recommend:
-    uses: JacobPEvans/ai-workflows/.github/workflows/best-practices.yml@v0.2.6
+    uses: JacobPEvans/ai-workflows/.github/workflows/best-practices.yml@v0.2.9
     secrets: inherit

--- a/.github/workflows/ci-fix.yml
+++ b/.github/workflows/ci-fix.yml
@@ -21,7 +21,7 @@ jobs:
     if: >-
       github.event.workflow_run.conclusion == 'failure' &&
       github.event.workflow_run.head_branch != 'main'
-    uses: JacobPEvans/ai-workflows/.github/workflows/ci-fix.yml@v0.2.6
+    uses: JacobPEvans/ai-workflows/.github/workflows/ci-fix.yml@v0.2.9
     with:
       repo_context: "Terraform/OpenTofu project managing Proxmox VE infrastructure"
       ci_structure: "terraform.yml (tofu fmt/init/validate/test), markdown-lint.yml (markdownlint)"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   review:
-    uses: JacobPEvans/ai-workflows/.github/workflows/claude-review.yml@v0.2.6
+    uses: JacobPEvans/ai-workflows/.github/workflows/claude-review.yml@v0.2.9
     with:
       review_prompt: "Focus on Terraform best practices, security, SOPS/age patterns"
     secrets: inherit

--- a/.github/workflows/code-simplifier.yml
+++ b/.github/workflows/code-simplifier.yml
@@ -11,5 +11,5 @@ permissions:
 
 jobs:
   simplify:
-    uses: JacobPEvans/ai-workflows/.github/workflows/code-simplifier.yml@v0.2.6
+    uses: JacobPEvans/ai-workflows/.github/workflows/code-simplifier.yml@v0.2.9
     secrets: inherit

--- a/.github/workflows/final-pr-review.yml
+++ b/.github/workflows/final-pr-review.yml
@@ -19,5 +19,5 @@ concurrency:
 
 jobs:
   review:
-    uses: JacobPEvans/ai-workflows/.github/workflows/final-pr-review.yml@v0.2.6
+    uses: JacobPEvans/ai-workflows/.github/workflows/final-pr-review.yml@v0.2.9
     secrets: inherit

--- a/.github/workflows/issue-hygiene.yml
+++ b/.github/workflows/issue-hygiene.yml
@@ -12,5 +12,5 @@ permissions:
 
 jobs:
   hygiene:
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-hygiene.yml@v0.2.6
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-hygiene.yml@v0.2.9
     secrets: inherit

--- a/.github/workflows/issue-sweeper.yml
+++ b/.github/workflows/issue-sweeper.yml
@@ -12,5 +12,5 @@ permissions:
 
 jobs:
   sweep:
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-sweeper.yml@v0.2.6
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-sweeper.yml@v0.2.9
     secrets: inherit

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -6,9 +6,10 @@ on:
 
 permissions:
   contents: read
+  id-token: write
   issues: write
 
 jobs:
   triage:
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-triage.yml@v0.2.6
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-triage.yml@v0.2.9
     secrets: inherit

--- a/.github/workflows/next-steps.yml
+++ b/.github/workflows/next-steps.yml
@@ -11,5 +11,5 @@ permissions:
 
 jobs:
   analyze:
-    uses: JacobPEvans/ai-workflows/.github/workflows/next-steps.yml@v0.2.6
+    uses: JacobPEvans/ai-workflows/.github/workflows/next-steps.yml@v0.2.9
     secrets: inherit

--- a/.github/workflows/post-merge-docs-review.yml
+++ b/.github/workflows/post-merge-docs-review.yml
@@ -10,5 +10,5 @@ permissions:
 
 jobs:
   review:
-    uses: JacobPEvans/ai-workflows/.github/workflows/post-merge-docs-review.yml@v0.2.6
+    uses: JacobPEvans/ai-workflows/.github/workflows/post-merge-docs-review.yml@v0.2.9
     secrets: inherit

--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -10,5 +10,5 @@ permissions:
 
 jobs:
   review:
-    uses: JacobPEvans/ai-workflows/.github/workflows/post-merge-tests.yml@v0.2.6
+    uses: JacobPEvans/ai-workflows/.github/workflows/post-merge-tests.yml@v0.2.9
     secrets: inherit


### PR DESCRIPTION
## Summary
- Bump all 11 ai-workflows reusable workflow callers from `@v0.2.6` to `@v0.2.9`
- Add missing `id-token: write` permission to `issue-triage.yml` for OIDC token exchange

## Files changed
- `ci-fix.yml` - version bump
- `claude-review.yml` - version bump
- `final-pr-review.yml` - version bump
- `issue-triage.yml` - version bump + `id-token: write` added
- `best-practices.yml` - version bump
- `code-simplifier.yml` - version bump
- `issue-hygiene.yml` - version bump
- `issue-sweeper.yml` - version bump
- `next-steps.yml` - version bump
- `post-merge-docs-review.yml` - version bump
- `post-merge-tests.yml` - version bump

## Test plan
- [ ] CI passes (Terraform CI + Markdown Lint)
- [ ] Workflow syntax is valid (checked by pre-commit yaml hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Bump ai-workflows callers to v0.2.9 and add OIDC permissions in `issue-triage.yml`.
> 
>   - **Version Bump**:
>     - Update ai-workflows callers from `@v0.2.6` to `@v0.2.9` in 11 workflow files including `ci-fix.yml`, `claude-review.yml`, and `final-pr-review.yml`.
>   - **Permissions**:
>     - Add `id-token: write` permission to `issue-triage.yml` for OIDC token exchange.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fterraform-proxmox&utm_source=github&utm_medium=referral)<sup> for 9f248ec4201e60da773347bc0067b8620486a7dc. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->