### PR TITLE
chore: bump ai-workflows callers to v0.5.0

### DIFF
--- a/.github/workflows/best-practices.yml
+++ b/.github/workflows/best-practices.yml
@@ -13,5 +13,5 @@ permissions:
 
 jobs:
   recommend:
-    uses: JacobPEvans/ai-workflows/.github/workflows/best-practices.yml@v0.4.0
+    uses: JacobPEvans/ai-workflows/.github/workflows/best-practices.yml@v0.5.0
     secrets: inherit

--- a/.github/workflows/ci-fix.yml
+++ b/.github/workflows/ci-fix.yml
@@ -21,7 +21,7 @@ jobs:
     if: >-
       github.event.workflow_run.conclusion == 'failure' &&
       github.event.workflow_run.head_branch != 'main'
-    uses: JacobPEvans/ai-workflows/.github/workflows/ci-fix.yml@v0.4.0
+    uses: JacobPEvans/ai-workflows/.github/workflows/ci-fix.yml@v0.5.0
     with:
       repo_context: "Terraform/OpenTofu project managing Proxmox VE infrastructure"
       ci_structure: "terraform.yml (tofu fmt/init/validate/test), markdown-lint.yml (markdownlint)"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   review:
-    uses: JacobPEvans/ai-workflows/.github/workflows/claude-review.yml@v0.4.0
+    uses: JacobPEvans/ai-workflows/.github/workflows/claude-review.yml@v0.5.0
     with:
       review_prompt: "Focus on Terraform best practices, security, SOPS/age patterns"
     secrets: inherit

--- a/.github/workflows/code-simplifier.yml
+++ b/.github/workflows/code-simplifier.yml
@@ -12,5 +12,5 @@ permissions:
 
 jobs:
   simplify:
-    uses: JacobPEvans/ai-workflows/.github/workflows/code-simplifier.yml@v0.4.0
+    uses: JacobPEvans/ai-workflows/.github/workflows/code-simplifier.yml@v0.5.0
     secrets: inherit

--- a/.github/workflows/final-pr-review.yml
+++ b/.github/workflows/final-pr-review.yml
@@ -19,5 +19,5 @@ concurrency:
 
 jobs:
   review:
-    uses: JacobPEvans/ai-workflows/.github/workflows/final-pr-review.yml@v0.4.0
+    uses: JacobPEvans/ai-workflows/.github/workflows/final-pr-review.yml@v0.5.0
     secrets: inherit

--- a/.github/workflows/issue-auto-resolve.yml
+++ b/.github/workflows/issue-auto-resolve.yml
@@ -54,7 +54,7 @@ jobs:
     if: >-
       github.event_name == 'workflow_dispatch' &&
       inputs.skip_triage != 'true'
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-triage.yml@v0.4.0
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-triage.yml@v0.5.0
     secrets: inherit
     with:
       issue_number: ${{ inputs.issue_number }}
@@ -65,7 +65,7 @@ jobs:
       always() &&
       github.event_name == 'workflow_dispatch' &&
       (needs.run-triage.result == 'success' || needs.run-triage.result == 'skipped')
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-resolver.yml@v0.4.0
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-resolver.yml@v0.5.0
     secrets: inherit
     with:
       repo_context: "Terraform/OpenTofu managing Proxmox VE infrastructure"

--- a/.github/workflows/issue-hygiene.yml
+++ b/.github/workflows/issue-hygiene.yml
@@ -13,5 +13,5 @@ permissions:
 
 jobs:
   hygiene:
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-hygiene.yml@v0.4.0
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-hygiene.yml@v0.5.0
     secrets: inherit

--- a/.github/workflows/issue-pipeline.yml
+++ b/.github/workflows/issue-pipeline.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   resolve-issue:
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-resolver.yml@v0.4.0
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-resolver.yml@v0.5.0
     secrets: inherit
     with:
       repo_context: "Terraform/OpenTofu managing Proxmox VE infrastructure"

--- a/.github/workflows/issue-sweeper.yml
+++ b/.github/workflows/issue-sweeper.yml
@@ -13,5 +13,5 @@ permissions:
 
 jobs:
   sweep:
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-sweeper.yml@v0.4.0
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-sweeper.yml@v0.5.0
     secrets: inherit

--- a/.github/workflows/next-steps.yml
+++ b/.github/workflows/next-steps.yml
@@ -13,5 +13,5 @@ permissions:
 
 jobs:
   analyze:
-    uses: JacobPEvans/ai-workflows/.github/workflows/next-steps.yml@v0.4.0
+    uses: JacobPEvans/ai-workflows/.github/workflows/next-steps.yml@v0.5.0
     secrets: inherit

--- a/.github/workflows/post-merge-docs-review.yml
+++ b/.github/workflows/post-merge-docs-review.yml
@@ -37,7 +37,7 @@ jobs:
 
   review:
     if: github.event_name == 'workflow_dispatch'
-    uses: JacobPEvans/ai-workflows/.github/workflows/post-merge-docs-review.yml@v0.4.0
+    uses: JacobPEvans/ai-workflows/.github/workflows/post-merge-docs-review.yml@v0.5.0
     with:
       commit_sha: ${{ inputs.commit_sha || github.sha }}
     secrets: inherit

--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -37,7 +37,7 @@ jobs:
 
   review:
     if: github.event_name == 'workflow_dispatch'
-    uses: JacobPEvans/ai-workflows/.github/workflows/post-merge-tests.yml@v0.4.0
+    uses: JacobPEvans/ai-workflows/.github/workflows/post-merge-tests.yml@v0.5.0
     with:
       commit_sha: ${{ inputs.commit_sha || github.sha }}
     secrets: inherit


### PR DESCRIPTION
## Summary
- Bumps all `ai-workflows` caller workflows from `@v0.4.0` → `@v0.5.0`
- v0.5.0 switches write workflows to API commit signing (`use_commit_signing: "true"`)
- Removes dependency on SSH signing key secrets for Claude-authored commits
- Draft PR mode removed from all prompts

## Test plan
- [ ] Verify workflows continue to trigger and succeed normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Bumps ai-workflows to v0.5.0, enabling API commit signing and removing SSH key dependency.
> 
>   - **Workflows Update**:
>     - Bumps `ai-workflows` version from `v0.4.0` to `v0.5.0` in `best-practices.yml`, `ci-fix.yml`, and `claude-review.yml`.
>     - Updates `code-simplifier.yml`, `final-pr-review.yml`, and `issue-auto-resolve.yml` to use `v0.5.0`.
>     - Changes in `issue-hygiene.yml`, `issue-pipeline.yml`, and `issue-sweeper.yml` to `v0.5.0`.
>     - Modifies `next-steps.yml`, `post-merge-docs-review.yml`, and `post-merge-tests.yml` to `v0.5.0`.
>   - **Behavior Changes**:
>     - `v0.5.0` uses API commit signing (`use_commit_signing: "true"`).
>     - Removes dependency on SSH signing key secrets for Claude-authored commits.
>     - Draft PR mode removed from all prompts.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fterraform-proxmox&utm_source=github&utm_medium=referral)<sup> for bf92dd06575cbb309f3a0adf42ad4d4c71f19c81. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->