### PR TITLE
chore: bump ai-workflows to v0.5.1

### DIFF
--- a/.github/workflows/best-practices.yml
+++ b/.github/workflows/best-practices.yml
@@ -13,5 +13,5 @@ permissions:
 
 jobs:
   recommend:
-    uses: JacobPEvans/ai-workflows/.github/workflows/best-practices.yml@v0.5.0
+    uses: JacobPEvans/ai-workflows/.github/workflows/best-practices.yml@v0.5.1
     secrets: inherit

--- a/.github/workflows/ci-fix.yml
+++ b/.github/workflows/ci-fix.yml
@@ -21,7 +21,7 @@ jobs:
     if: >-
       github.event.workflow_run.conclusion == 'failure' &&
       github.event.workflow_run.head_branch != 'main'
-    uses: JacobPEvans/ai-workflows/.github/workflows/ci-fix.yml@v0.5.0
+    uses: JacobPEvans/ai-workflows/.github/workflows/ci-fix.yml@v0.5.1
     with:
       repo_context: "Terraform/OpenTofu project managing Proxmox VE infrastructure"
       ci_structure: "terraform.yml (tofu fmt/init/validate/test), markdown-lint.yml (markdownlint)"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   review:
-    uses: JacobPEvans/ai-workflows/.github/workflows/claude-review.yml@v0.5.0
+    uses: JacobPEvans/ai-workflows/.github/workflows/claude-review.yml@v0.5.1
     with:
       review_prompt: "Focus on Terraform best practices, security, SOPS/age patterns"
     secrets: inherit

--- a/.github/workflows/code-simplifier.yml
+++ b/.github/workflows/code-simplifier.yml
@@ -12,5 +12,5 @@ permissions:
 
 jobs:
   simplify:
-    uses: JacobPEvans/ai-workflows/.github/workflows/code-simplifier.yml@v0.5.0
+    uses: JacobPEvans/ai-workflows/.github/workflows/code-simplifier.yml@v0.5.1
     secrets: inherit

--- a/.github/workflows/final-pr-review.yml
+++ b/.github/workflows/final-pr-review.yml
@@ -19,5 +19,5 @@ concurrency:
 
 jobs:
   review:
-    uses: JacobPEvans/ai-workflows/.github/workflows/final-pr-review.yml@v0.5.0
+    uses: JacobPEvans/ai-workflows/.github/workflows/final-pr-review.yml@v0.5.1
     secrets: inherit

--- a/.github/workflows/issue-auto-resolve.yml
+++ b/.github/workflows/issue-auto-resolve.yml
@@ -54,7 +54,7 @@ jobs:
     if: >-
       github.event_name == 'workflow_dispatch' &&
       inputs.skip_triage != 'true'
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-triage.yml@v0.5.0
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-triage.yml@v0.5.1
     secrets: inherit
     with:
       issue_number: ${{ inputs.issue_number }}
@@ -65,7 +65,7 @@ jobs:
       always() &&
       github.event_name == 'workflow_dispatch' &&
       (needs.run-triage.result == 'success' || needs.run-triage.result == 'skipped')
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-resolver.yml@v0.5.0
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-resolver.yml@v0.5.1
     secrets: inherit
     with:
       repo_context: "Terraform/OpenTofu managing Proxmox VE infrastructure"

--- a/.github/workflows/issue-hygiene.yml
+++ b/.github/workflows/issue-hygiene.yml
@@ -13,5 +13,5 @@ permissions:
 
 jobs:
   hygiene:
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-hygiene.yml@v0.5.0
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-hygiene.yml@v0.5.1
     secrets: inherit

--- a/.github/workflows/issue-pipeline.yml
+++ b/.github/workflows/issue-pipeline.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   resolve-issue:
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-resolver.yml@v0.5.0
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-resolver.yml@v0.5.1
     secrets: inherit
     with:
       repo_context: "Terraform/OpenTofu managing Proxmox VE infrastructure"

--- a/.github/workflows/issue-sweeper.yml
+++ b/.github/workflows/issue-sweeper.yml
@@ -13,5 +13,5 @@ permissions:
 
 jobs:
   sweep:
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-sweeper.yml@v0.5.0
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-sweeper.yml@v0.5.1
     secrets: inherit

--- a/.github/workflows/next-steps.yml
+++ b/.github/workflows/next-steps.yml
@@ -13,5 +13,5 @@ permissions:
 
 jobs:
   analyze:
-    uses: JacobPEvans/ai-workflows/.github/workflows/next-steps.yml@v0.5.0
+    uses: JacobPEvans/ai-workflows/.github/workflows/next-steps.yml@v0.5.1
     secrets: inherit

--- a/.github/workflows/post-merge-docs-review.yml
+++ b/.github/workflows/post-merge-docs-review.yml
@@ -37,7 +37,7 @@ jobs:
 
   review:
     if: github.event_name == 'workflow_dispatch'
-    uses: JacobPEvans/ai-workflows/.github/workflows/post-merge-docs-review.yml@v0.5.0
+    uses: JacobPEvans/ai-workflows/.github/workflows/post-merge-docs-review.yml@v0.5.1
     with:
       commit_sha: ${{ inputs.commit_sha || github.sha }}
     secrets: inherit

--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -37,7 +37,7 @@ jobs:
 
   review:
     if: github.event_name == 'workflow_dispatch'
-    uses: JacobPEvans/ai-workflows/.github/workflows/post-merge-tests.yml@v0.5.0
+    uses: JacobPEvans/ai-workflows/.github/workflows/post-merge-tests.yml@v0.5.1
     with:
       commit_sha: ${{ inputs.commit_sha || github.sha }}
     secrets: inherit


### PR DESCRIPTION
Bump all ai-workflows reusable workflow references from @v0.5.0 to @v0.5.1.

## Changes in v0.5.1
- Fix claude-review self-cancellation loop (concurrency group collision between `pull_request` and `issue_comment` events)
- Add `max_reviews` input to prevent re-reviewing on subsequent pushes
- Add `model` input for token efficiency control

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Bump ai-workflows to v0.5.1 across multiple GitHub Actions workflows, incorporating fixes and new inputs for improved functionality.
> 
>   - **Version Update**:
>     - Bump `ai-workflows` from `v0.5.0` to `v0.5.1` in `.github/workflows/best-practices.yml`, `.github/workflows/ci-fix.yml`, and `.github/workflows/claude-review.yml`.
>     - Update also applied to `.github/workflows/code-simplifier.yml`, `.github/workflows/final-pr-review.yml`, and `.github/workflows/issue-auto-resolve.yml`.
>     - Changes extend to `.github/workflows/issue-hygiene.yml`, `.github/workflows/issue-pipeline.yml`, and `.github/workflows/issue-sweeper.yml`.
>     - Further updates in `.github/workflows/next-steps.yml`, `.github/workflows/post-merge-docs-review.yml`, and `.github/workflows/post-merge-tests.yml`.
>   - **Improvements in v0.5.1**:
>     - Fixes self-cancellation loop in `claude-review`.
>     - Adds `max_reviews` input to prevent re-reviewing.
>     - Introduces `model` input for token efficiency control.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fterraform-proxmox&utm_source=github&utm_medium=referral)<sup> for 65fd0a18f8cea361e3cf0e6fa1c012c487900661. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->