### PR TITLE
feat: auto-merge all PRs on open

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,23 @@
+name: Auto Merge
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    name: Enable auto-merge
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - run: gh pr merge "$PR_NUMBER" --auto --squash --repo "$GITHUB_REPOSITORY"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
Automatically enables squash auto-merge on every non-draft PR when it is opened or marked ready for review. No more manually running `gh pr merge --auto --squash`.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a GitHub Actions workflow to auto-enable squash auto-merge for non-draft PRs on open or ready for review.
> 
>   - **Behavior**:
>     - Adds `.github/workflows/auto-merge.yml` to automatically enable squash auto-merge on non-draft PRs when opened or marked ready for review.
>     - Uses `gh pr merge --auto --squash` command to perform the merge.
>   - **Conditions**:
>     - Triggers on `pull_request` events of types `opened` and `ready_for_review`.
>     - Executes only if the PR is not a draft (`github.event.pull_request.draft == false`).
>   - **Permissions**:
>     - Requires `contents: write` and `pull-requests: write` permissions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fterraform-proxmox&utm_source=github&utm_medium=referral)<sup> for eb6e1e386f5e4e53f9f4fc9a035fb50f79372b8f. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->