### PR TITLE
feat(renovate): extend shared preset for org-wide auto-merge rules

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "local>JacobPEvans/.github:renovate-presets"
   ]
 }


### PR DESCRIPTION
## Summary

- Extends `local>JacobPEvans/.github:renovate-presets` to inherit org-wide auto-merge rules
- Trusted publishers (JacobPEvans/, actions/, googleapis/, anthropics/) and pre-commit hooks now auto-merge via shared preset

## Why

Centralizes Renovate auto-merge configuration in the `.github` repo preset, eliminating duplication across repos.

## Test plan

- [ ] Merge `.github` PR #69 first (preset must be on main before Renovate runs)
- [ ] Verify next Renovate PR gets auto-merge enabled at creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Extends `renovate.json` to include org-wide auto-merge rules via a shared preset, centralizing configuration.
> 
>   - **Configuration**:
>     - Extends `renovate.json` to include `local>JacobPEvans/.github:renovate-presets` for org-wide auto-merge rules.
>     - Trusted publishers (JacobPEvans/, actions/, googleapis/, anthropics/) and pre-commit hooks now auto-merge via shared preset.
>   - **Purpose**:
>     - Centralizes Renovate auto-merge configuration in the `.github` repo preset, eliminating duplication across repos.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fterraform-proxmox&utm_source=github&utm_medium=referral)<sup> for b4afc14e0003839e34cfb14c0f9b779028e3482c. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->