### PR TITLE
feat: add per-repo devShell

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.envrc.example
+++ b/.envrc.example
@@ -1,4 +1,0 @@
-# Copy to .envrc and run: direnv allow
-export NIX_CONFIG_PATH=${NIX_CONFIG_PATH:-$HOME/git/nix-config/main}
-export SOPS_AGE_KEY_FILE=${SOPS_AGE_KEY_FILE:-$HOME/.config/sops/age/keys.txt}
-use flake ${NIX_CONFIG_PATH}/shells/terraform

--- a/.gitignore
+++ b/.gitignore
@@ -49,7 +49,6 @@ aws-credentials
 .env
 .env.*
 !.env.example
-.envrc
 
 # Doppler configuration (contains project/config names)
 .doppler.yaml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ Doppler secrets use `PROXMOX_VE_*` naming to match the BPG Terraform provider:
 
 ### Config File Architecture
 
-```
+```text
 deployment.json          (committed, plaintext) — containers, VMs, pools, proxmox_node
 terraform.sops.json      (committed, encrypted) — network_prefix, vm_ssh_*_key_path
 Doppler env vars         (runtime only)         — PROXMOX_VE_*, SPLUNK_*, SSH key content
@@ -101,6 +101,17 @@ See [docs/SOPS_SETUP.md](./docs/SOPS_SETUP.md) for full setup and usage.
 - `.sops.yaml` - Age public key configuration (safe to commit)
 - `deployment.json` - Non-secret config (edit and commit directly)
 - `terraform.sops.json.example` - SOPS template with 3 values (copy, fill in, encrypt)
+
+## Dev Environment
+
+Uses [Nix flakes](https://wiki.nixos.org/wiki/Flakes) + [direnv](https://direnv.net/) for reproducible dev environment.
+
+```sh
+direnv allow    # one-time per worktree, then automatic on cd
+nix develop     # manual activation
+```
+
+**Tools**: terraform, terragrunt, opentofu, terraform-docs, tflint, tfsec, trivy, sops, age, awscli2
 
 ## Repository Context
 

--- a/README.md
+++ b/README.md
@@ -93,22 +93,30 @@ terraform-proxmox/
 
 #### Option A: Using Nix Shell (Recommended)
 
-All tools are provided via a pre-configured Nix development shell.
-The repository ships an `.envrc` file that auto-activates the shell
-via direnv when you enter the directory.
+All tools are provided via a self-contained `flake.nix` devShell.
+The repository ships a committed `.envrc` file that auto-activates
+the shell via direnv when you enter the directory.
 
 **Requirements:**
 
-- `nix-direnv` (not just plain direnv) - Install via: `nix profile install nixpkgs#nix-direnv`
-- Shell hook setup for direnv (see [direnv setup](https://direnv.net/docs/hook.html))
+- [Nix](https://nixos.org/download/) with flakes enabled
+- [direnv](https://direnv.net/docs/installation.html) with [nix-direnv](https://github.com/nix-community/nix-direnv)
 
 ```bash
 # Automatic activation (requires direnv + nix-direnv)
-direnv allow    # one-time setup
+direnv allow    # one-time per worktree, then automatic on cd
 
-# Manual fallback
-nix develop "${NIX_CONFIG_PATH:-$HOME/git/nix-config/main}/shells/terraform"
+# Manual activation
+nix develop
 ```
+
+**Tools provided:**
+
+- `terraform`, `terragrunt`, `opentofu`, `terraform-docs`, `tflint` -- IaC tooling
+- `tfsec`, `trivy` -- security scanning
+- `sops`, `age` -- secrets management
+- `awscli2` -- AWS CLI
+- `jq`, `yq` -- utilities
 
 See **[Nix Shell Setup Guide](./docs/nix-shell-setup.md)** for detailed instructions.
 
@@ -121,7 +129,7 @@ Install the following tools manually:
 - AWS CLI configured
 - Proxmox API token
 - SSH key pair
-- Security scanners (tfsec, checkov, trivy)
+- Security scanners (tfsec, trivy)
 - Ansible and molecule (for configuration management)
 
 ### Essential Commands

--- a/cspell.json
+++ b/cspell.json
@@ -56,7 +56,14 @@
     "qemu",
     "k3s",
     "OrbStack",
-    "orbstack"
+    "orbstack",
+    "worktree",
+    "worktrees",
+    "tokenid",
+    "tflint",
+    "awscli",
+    "FQCN",
+    "geerlingguy"
   ],
   "ignorePaths": [
     ".terraform/**",

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,104 @@
+# Terraform/Terragrunt Development Shell
+#
+# Complete IaC environment with Terraform, Terragrunt, security scanners,
+# secrets management, and AWS integration.
+#
+# Usage:
+#   nix develop
+#   # or with direnv: cd into repo → direnv allow (auto-activates)
+
+{
+  description = "Terraform/Terragrunt infrastructure development environment";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+  };
+
+  outputs =
+    { nixpkgs, ... }:
+    let
+      systems = [
+        "aarch64-darwin"
+        "x86_64-darwin"
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+      forAllSystems =
+        f:
+        nixpkgs.lib.genAttrs systems (
+          system:
+          f {
+            pkgs = import nixpkgs {
+              inherit system;
+              config.allowUnfree = true; # Terraform uses BSL license
+            };
+          }
+        );
+    in
+    {
+      devShells = forAllSystems (
+        { pkgs }:
+        {
+          default = pkgs.mkShell {
+            buildInputs = with pkgs; [
+              # === Infrastructure as Code ===
+              terraform
+              terragrunt
+              opentofu
+              terraform-docs
+              tflint
+
+              # === Security & Compliance ===
+              # checkov and terrascan removed: checkov is broken in nixpkgs-unstable
+              # (pycep-parser fails to build with uv_build backend). Both hooks are
+              # also disabled in .pre-commit-config.yaml. Re-add when upstream fixes.
+              tfsec
+              trivy
+
+              # === Secrets Management ===
+              sops
+              age
+
+              # === Cloud & Development ===
+              awscli2
+              git
+              python3
+
+              # === Utilities ===
+              jq
+              yq
+            ];
+
+            shellHook = ''
+              if [ -z "''${DIRENV_IN_ENVRC:-}" ]; then
+                echo "═══════════════════════════════════════════════════════════════"
+                echo "Terraform/Terragrunt Infrastructure as Code Environment"
+                echo "═══════════════════════════════════════════════════════════════"
+                echo ""
+                echo "Infrastructure as Code:"
+                echo "  - terraform: $(terraform version -json 2>/dev/null | jq -r '.terraform_version' 2>/dev/null || terraform version | head -1)"
+                echo "  - terragrunt: $(terragrunt --version 2>/dev/null | cut -d' ' -f3)"
+                echo "  - opentofu: $(tofu version 2>/dev/null | head -1)"
+                echo ""
+                echo "Security & Compliance:"
+                echo "  - tfsec: $(tfsec --version 2>/dev/null)"
+                echo ""
+                echo "Secrets Management:"
+                echo "  - sops: $(sops --version 2>/dev/null)"
+                echo "  - age: $(age --version 2>/dev/null)"
+                echo ""
+                echo "Cloud:"
+                echo "  - aws-cli: $(aws --version 2>/dev/null)"
+                echo ""
+                echo "Getting Started:"
+                echo "  1. Configure AWS credentials: aws configure or aws-vault"
+                echo "  2. Initialize: terragrunt init"
+                echo "  3. Setup pre-commit: pre-commit install"
+                echo ""
+              fi
+            '';
+          };
+        }
+      );
+    };
+}


### PR DESCRIPTION
## Summary

- Adds self-contained `flake.nix` with Terraform devShell (terraform, terragrunt, opentofu, tfsec, trivy, sops, age, awscli2)
- Commits `.envrc` with `use flake` for automatic direnv activation
- Removes `.envrc.example` (superseded by committed `.envrc`)
- Removes `.envrc` from `.gitignore` (now committed)
- Adds `.direnv/` to `.gitignore` (already present)
- Updates CLAUDE.md and README.md with dev environment documentation
- Fixes pre-existing markdownlint MD040 violation in CLAUDE.md
- Adds missing cspell dictionary words

## Test plan
- [ ] `nix develop` activates shell with expected tools
- [ ] `direnv allow` auto-activates on `cd`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `flake.nix` for Terraform devShell, updates `.envrc` for direnv, and revises documentation for new setup.
> 
>   - **Environment Setup**:
>     - Adds `flake.nix` for a self-contained Terraform devShell with tools like `terraform`, `terragrunt`, `tfsec`, `trivy`, `sops`, `age`, `awscli2`.
>     - Commits `.envrc` with `use flake` for automatic direnv activation.
>     - Removes `.envrc.example` and updates `.gitignore` to include `.direnv/`.
>   - **Documentation**:
>     - Updates `CLAUDE.md` and `README.md` with new dev environment setup instructions.
>     - Fixes markdownlint MD040 violation in `CLAUDE.md`.
>   - **Misc**:
>     - Adds missing words to `cspell.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fterraform-proxmox&utm_source=github&utm_medium=referral)<sup> for 797eaff7c9685a13da8a67906e689a913246e0c7. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->