### PR TITLE
fix: address devShell review feedback

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,21 +57,21 @@ repos:
     hooks:
       - id: tofu-test
         name: tofu test (mock providers)
-        entry: bash -c 'nix develop ~/git/nix-config/main/shells/terraform --command bash -c "tofu init -backend=false -no-color >/dev/null 2>&1 && tofu test -no-color"'
+        entry: bash -c 'nix develop --command bash -c "tofu init -backend=false -no-color >/dev/null 2>&1 && tofu test -no-color"'
         language: system
         files: '\.(tf|hcl)$'
         pass_filenames: false
 
       - id: terragrunt-validate
         name: terragrunt validate
-        entry: bash -c 'nix develop ~/git/nix-config/main/shells/terraform --command bash -c "aws-vault exec terraform -- doppler run -- terragrunt validate"'
+        entry: bash -c 'nix develop --command bash -c "aws-vault exec terraform -- doppler run -- terragrunt validate"'
         language: system
         files: '\.(tf|hcl)$'
         pass_filenames: false
 
       - id: terragrunt-plan
         name: terragrunt plan
-        entry: bash -c 'nix develop ~/git/nix-config/main/shells/terraform --command bash -c "aws-vault exec terraform -- doppler run -- terragrunt plan -detailed-exitcode"; rc=$?; if [ $rc -eq 0 ] || [ $rc -eq 2 ]; then exit 0; else exit 1; fi'
+        entry: bash -c 'nix develop --command bash -c "aws-vault exec terraform -- doppler run -- terragrunt plan -detailed-exitcode"; rc=$?; if [ $rc -eq 0 ] || [ $rc -eq 2 ]; then exit 0; else exit 1; fi'
         language: system
         files: '\.(tf|hcl)$'
         pass_filenames: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,7 +111,7 @@ direnv allow    # one-time per worktree, then automatic on cd
 nix develop     # manual activation
 ```
 
-**Tools**: terraform, terragrunt, opentofu, terraform-docs, tflint, tfsec, trivy, sops, age, awscli2
+**Tools**: terragrunt, opentofu, terraform-docs, tflint, tfsec, trivy, sops, age, awscli2, git, python3, jq, yq, pre-commit
 
 ## Repository Context
 

--- a/README.md
+++ b/README.md
@@ -112,13 +112,14 @@ nix develop
 
 **Tools provided:**
 
-- `terraform`, `terragrunt`, `opentofu`, `terraform-docs`, `tflint` -- IaC tooling
+- `terragrunt`, `opentofu`, `terraform-docs`, `tflint` -- IaC tooling
 - `tfsec`, `trivy` -- security scanning
 - `sops`, `age` -- secrets management
-- `awscli2` -- AWS CLI
+- `awscli2`, `git`, `python3` -- cloud and development
 - `jq`, `yq` -- utilities
+- `pre-commit` -- git hook management
 
-See **[Nix Shell Setup Guide](./docs/nix-shell-setup.md)** for detailed instructions.
+See **[`flake.nix`](./flake.nix)** for the complete dev environment definition.
 
 #### Option B: Manual Installation
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1772173633,
+        "narHash": "sha256-MOH58F4AIbCkh6qlQcwMycyk5SWvsqnS/TCfnqDlpj4=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "c0f3d81a7ddbc2b1332be0d8481a672b4f6004d6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
-# Terraform/Terragrunt Development Shell
+# Terragrunt/OpenTofu Development Shell
 #
-# Complete IaC environment with Terraform, Terragrunt, security scanners,
+# Complete IaC environment with Terragrunt, OpenTofu, security scanners,
 # secrets management, and AWS integration.
 #
 # Usage:
@@ -8,7 +8,7 @@
 #   # or with direnv: cd into repo → direnv allow (auto-activates)
 
 {
-  description = "Terraform/Terragrunt infrastructure development environment";
+  description = "Terragrunt/OpenTofu infrastructure development environment";
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
@@ -30,7 +30,6 @@
           f {
             pkgs = import nixpkgs {
               inherit system;
-              config.allowUnfree = true; # Terraform uses BSL license
             };
           }
         );
@@ -42,7 +41,7 @@
           default = pkgs.mkShell {
             buildInputs = with pkgs; [
               # === Infrastructure as Code ===
-              terraform
+              # terraform omitted: this repo uses OpenTofu (tofu), not Terraform
               terragrunt
               opentofu
               terraform-docs
@@ -67,16 +66,18 @@
               # === Utilities ===
               jq
               yq
+
+              # === Dev Tooling ===
+              pre-commit
             ];
 
             shellHook = ''
               if [ -z "''${DIRENV_IN_ENVRC:-}" ]; then
                 echo "═══════════════════════════════════════════════════════════════"
-                echo "Terraform/Terragrunt Infrastructure as Code Environment"
+                echo "Terragrunt/OpenTofu Infrastructure as Code Environment"
                 echo "═══════════════════════════════════════════════════════════════"
                 echo ""
                 echo "Infrastructure as Code:"
-                echo "  - terraform: $(terraform version -json 2>/dev/null | jq -r '.terraform_version' 2>/dev/null || terraform version | head -1)"
                 echo "  - terragrunt: $(terragrunt --version 2>/dev/null | cut -d' ' -f3)"
                 echo "  - opentofu: $(tofu version 2>/dev/null | head -1)"
                 echo ""


### PR DESCRIPTION
## Summary
- Remove terraform from buildInputs (repo uses OpenTofu per convention), remove `config.allowUnfree`
- Add pre-commit to buildInputs, generate and commit flake.lock
- Update README and CLAUDE.md tools lists to reflect actual dependencies
- Update .pre-commit-config.yaml hooks to use per-repo `nix develop`

## Test plan
- [ ] `nix flake check` passes
- [ ] `nix develop` provides expected tools (opentofu, pre-commit, git, python3, jq, yq)
- [ ] Pre-commit hooks run correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove Terraform, add pre-commit, and update documentation for devShell setup.
> 
>   - **Build Inputs**:
>     - Remove `terraform` from `buildInputs` in `flake.nix`.
>     - Add `pre-commit` to `buildInputs` in `flake.nix`.
>     - Remove `config.allowUnfree` from `flake.nix`.
>   - **Documentation**:
>     - Update tools list in `README.md` and `CLAUDE.md` to reflect current dependencies.
>     - Update `.pre-commit-config.yaml` to use `nix develop` without specifying a path.
>   - **Misc**:
>     - Generate and commit `flake.lock` file.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fterraform-proxmox&utm_source=github&utm_medium=referral)<sup> for 0ffd43ffe872e717c1705844fac2e407e027411c. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->