### PR TITLE
docs: update nix-config references to per-repo devshell pattern

### DIFF
--- a/SECRETS_SETUP.md.example
+++ b/SECRETS_SETUP.md.example
@@ -27,8 +27,12 @@ AWS_VAULT_PROFILE="your-profile-name"
 ## Complete Command Pattern
 
 ```bash
-# Full command with all credentials
-nix develop ~/git/nix-config/main/shells/terraform --command bash -c "aws-vault exec YOUR_PROFILE -- doppler run --name-transformer tf-var -- terragrunt <COMMAND>"
+# Full command with all credentials (direnv activates the nix shell automatically)
+# cd into repo, then:
+aws-vault exec YOUR_PROFILE -- doppler run --name-transformer tf-var -- terragrunt <COMMAND>
+
+# Or manually enter the nix shell first, then run:
+nix develop ~/git/terraform-proxmox/main --command bash -c "aws-vault exec YOUR_PROFILE -- doppler run --name-transformer tf-var -- terragrunt <COMMAND>"
 ```
 
 ## Quick Reference

--- a/cspell.json
+++ b/cspell.json
@@ -63,7 +63,20 @@
     "tflint",
     "awscli",
     "FQCN",
-    "geerlingguy"
+    "geerlingguy",
+    "terrascan",
+    "nixos",
+    "NixOS",
+    "infracost",
+    "subshell",
+    "jevans",
+    "cachix",
+    "creds",
+    "mgmt",
+    "Palo",
+    "IPFIX",
+    "Technitium",
+    "keyctl"
   ],
   "ignorePaths": [
     ".terraform/**",

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -21,7 +21,6 @@ graph TD
     end
 
     subgraph "Development & Applications"
-        NC[nix-config]
         CR[cribl]
         SP[splunk]
     end
@@ -41,8 +40,6 @@ graph TD
     DOP -->|env vars| APA
     AV -->|AWS creds for S3 backend| TP
     AV -->|AWS creds| TA
-    NC -->|nix develop shells| TP
-    NC -->|nix develop shells| TA
     CR -->|packs & configs| APA
     SP -->|add-ons| AS
     SOPS_AGE -.->|planned| TP

--- a/docs/DEPLOYMENT_GUIDE.md
+++ b/docs/DEPLOYMENT_GUIDE.md
@@ -59,8 +59,9 @@ These are created via Proxmox UI and **not** managed by Terraform:
 ### 1. Validate Configuration
 
 ```bash
-# Enter Nix shell with tools
-nix develop ~/git/nix-config/main/shells/terraform
+# Enter Nix shell (direnv handles this automatically if .envrc is allowed)
+# Or enter manually:
+nix develop ~/git/terraform-proxmox/main
 
 # Validate Terraform syntax
 terragrunt validate

--- a/docs/nix-shell-setup.md
+++ b/docs/nix-shell-setup.md
@@ -5,9 +5,9 @@ to use Nix shells for local Terraform/Terragrunt development and testing.
 
 ## Overview
 
-This repository leverages a pre-configured Nix development shell located at
-`~/git/nix-config/main/shells/terraform` that provides all necessary tools
-for infrastructure-as-code development, including:
+This repository includes a pre-configured Nix development shell at its root
+`flake.nix` that provides all necessary tools for infrastructure-as-code
+development, including:
 
 - **Infrastructure Tools**: Terraform, Terragrunt, OpenTofu
 - **Security Scanners**: checkov, terrascan, tfsec, trivy
@@ -58,8 +58,8 @@ direnv allow
 #### Manual Activation
 
 ```bash
-# Enter the Nix shell manually
-nix develop ~/git/nix-config/main/shells/terraform
+# Enter the Nix shell manually (from the repo root)
+nix develop ~/git/terraform-proxmox/main
 
 # You'll see a welcome message showing all available tools
 ```
@@ -367,11 +367,11 @@ If direnv is not available, use the manual nix develop wrapper:
 ```bash
 # General pattern
 aws-vault exec PROFILE_NAME -- \
-  nix develop ~/git/nix-config/main/shells/terraform --command COMMAND
+  nix develop ~/git/terraform-proxmox/main --command COMMAND
 
 # Common examples
 aws-vault exec PROFILE_NAME -- \
-  nix develop ~/git/nix-config/main/shells/terraform --command terragrunt plan
+  nix develop ~/git/terraform-proxmox/main --command terragrunt plan
 ```
 
 ### Finding Your AWS Profile Name
@@ -454,11 +454,11 @@ nix develop ~/path/to/shell --command \
 **Solution**:
 
 ```bash
-# Update nix flake inputs
-nix flake update ~/git/nix-config/main/shells/terraform
+# Update nix flake inputs (run from repo root)
+nix flake update ~/git/terraform-proxmox/main
 
 # Rebuild the shell
-nix develop ~/git/nix-config/main/shells/terraform --rebuild
+nix develop ~/git/terraform-proxmox/main --rebuild
 ```
 
 ### Issue: Docker not available in Nix shell
@@ -543,37 +543,27 @@ cd ~/git/terraform-proxmox/main
 
 ### Customizing the Shell
 
-Create a local `flake.nix` override:
+The repo's `flake.nix` defines `devShells.default`. To add local customizations
+without modifying the committed flake, set extra environment variables in your
+`.envrc` after `use flake`:
 
-```nix
-{
-  description = "Custom Terraform shell for this project";
-
-  inputs = {
-    terraform-shell.url = "path:/Users/jevans/git/nix-config/main/shells/terraform";
-  };
-
-  outputs = { terraform-shell, ... }: {
-    devShells = terraform-shell.devShells // {
-      default = terraform-shell.devShells.default.overrideAttrs (old: {
-        shellHook = old.shellHook + ''
-          echo "Custom setup for Splunk cluster development"
-          export TF_LOG=DEBUG
-        '';
-      });
-    };
-  };
-}
+```bash
+# .envrc (local only, gitignored for personal overrides)
+use flake
+export TF_LOG=DEBUG
+echo "Custom setup for Splunk cluster development"
 ```
+
+Alternatively, extend the shell by editing `flake.nix` in your feature branch.
 
 ### Running Commands Outside the Shell
 
 ```bash
-# Execute a single command in the Nix shell environment
-nix develop ~/git/nix-config/main/shells/terraform --command terragrunt plan
+# Execute a single command in the Nix shell environment (from repo root)
+nix develop ~/git/terraform-proxmox/main --command terragrunt plan
 
 # Run a script in the Nix shell
-nix develop ~/git/nix-config/main/shells/terraform --command bash ./scripts/deploy.sh
+nix develop ~/git/terraform-proxmox/main --command bash ./scripts/deploy.sh
 ```
 
 ## Integration with CI/CD
@@ -598,7 +588,7 @@ jobs:
 
       - name: Enter Nix shell and validate
         run: |
-          nix develop ~/git/nix-config/main/shells/terraform --command bash -c "
+          nix develop . --command bash -c "
             terragrunt init
             terragrunt validate
             tflint
@@ -608,7 +598,7 @@ jobs:
 
 ## Additional Resources
 
-- **Nix Shell Documentation**: `~/git/nix-config/main/shells/terraform/flake.nix`
+- **Nix Shell Definition**: `~/git/terraform-proxmox/main/flake.nix`
 - **Terraform Documentation**:
   [developer.hashicorp.com/terraform](https://developer.hashicorp.com/terraform/docs)
 - **Terragrunt Documentation**:

--- a/scripts/cleanup-orphaned-vms.sh
+++ b/scripts/cleanup-orphaned-vms.sh
@@ -23,7 +23,7 @@ echo "Fetching VMs from Terraform state..."
 cd "$(dirname "$0")/.."
 
 run_terragrunt() {
-    nix develop ~/git/nix-config/main/shells/terraform --command bash -c \
+    nix develop ~/git/terraform-proxmox/main --command bash -c \
         "aws-vault exec terraform -- doppler run --name-transformer tf-var -- terragrunt $*"
 }
 


### PR DESCRIPTION
## Summary

- Replace all 13 references to the old central `~/git/nix-config/main/shells/terraform` shell with the per-repo `flake.nix` devshell that now lives in this repository
- Remove stale `NC[nix-config]` node and its edges from the dependency graph in `ARCHITECTURE.md` — each repo now owns its own devshell, so nix-config is no longer a runtime dependency
- Add pre-existing cspell unknown words (`terrascan`, `nixos`, `infracost`, `subshell`, `jevans`, `cachix`, `creds`, `mgmt`, `Palo`, `IPFIX`, `Technitium`, `keyctl`) to `cspell.json` so validation passes cleanly

## Files changed

| File | Changes |
|------|---------|
| `docs/nix-shell-setup.md` | 11 references updated; customizing-shell section rewritten; CI/CD example updated |
| `docs/DEPLOYMENT_GUIDE.md` | 1 reference updated |
| `docs/ARCHITECTURE.md` | `NC[nix-config]` node and 2 edges removed |
| `SECRETS_SETUP.md.example` | 1 reference updated |
| `scripts/cleanup-orphaned-vms.sh` | 1 reference updated |
| `cspell.json` | 12 pre-existing unknown words added |

## Test plan

- [ ] Confirm `nix develop ~/git/terraform-proxmox/main` enters the shell correctly
- [ ] Confirm direnv auto-activates on `cd ~/git/terraform-proxmox/main` (`.envrc` with `use flake`)
- [ ] Confirm `scripts/cleanup-orphaned-vms.sh` runs without path errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update documentation and scripts to use per-repo Nix devshell and remove outdated references.
> 
>   - **Documentation**:
>     - Update 13 references from `~/git/nix-config/main/shells/terraform` to `flake.nix` devshell in `docs/nix-shell-setup.md`, `docs/DEPLOYMENT_GUIDE.md`, `SECRETS_SETUP.md.example`, and `scripts/cleanup-orphaned-vms.sh`.
>     - Remove `NC[nix-config]` node and 2 edges from `ARCHITECTURE.md` dependency graph.
>   - **Spell Check**:
>     - Add 12 words to `cspell.json` to pass validation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fterraform-proxmox&utm_source=github&utm_medium=referral)<sup> for 2fcccee889c7b11e6aa9dc0781fa7b02273d5e4d. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->