### PR TITLE
chore: bump ai-workflows to v0.7.0

### DIFF
--- a/.github/workflows/best-practices.yml
+++ b/.github/workflows/best-practices.yml
@@ -13,5 +13,5 @@ permissions:
 
 jobs:
   recommend:
-    uses: JacobPEvans/ai-workflows/.github/workflows/best-practices.yml@v0.6.1
+    uses: JacobPEvans/ai-workflows/.github/workflows/best-practices.yml@v0.7.0
     secrets: inherit

--- a/.github/workflows/ci-fail-issue.yml
+++ b/.github/workflows/ci-fail-issue.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   handle-failure:
     if: github.event.workflow_run.conclusion == 'failure'
-    uses: JacobPEvans/ai-workflows/.github/workflows/ci-fail-issue.yml@v0.6.1
+    uses: JacobPEvans/ai-workflows/.github/workflows/ci-fail-issue.yml@v0.7.0
     with:
       workflow_name: "Terraform CI"
     secrets: inherit

--- a/.github/workflows/ci-fix.yml
+++ b/.github/workflows/ci-fix.yml
@@ -21,7 +21,7 @@ jobs:
     if: >-
       github.event.workflow_run.conclusion == 'failure' &&
       github.event.workflow_run.head_branch != 'main'
-    uses: JacobPEvans/ai-workflows/.github/workflows/ci-fix.yml@v0.6.1
+    uses: JacobPEvans/ai-workflows/.github/workflows/ci-fix.yml@v0.7.0
     with:
       repo_context: "Terraform/OpenTofu project managing Proxmox VE infrastructure"
       ci_structure: "terraform.yml (tofu fmt/init/validate/test), markdown-lint.yml (markdownlint)"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   review:
-    uses: JacobPEvans/ai-workflows/.github/workflows/claude-review.yml@v0.6.1
+    uses: JacobPEvans/ai-workflows/.github/workflows/claude-review.yml@v0.7.0
     with:
       review_prompt: "Focus on Terraform best practices, security, SOPS/age patterns"
     secrets: inherit

--- a/.github/workflows/code-simplifier.yml
+++ b/.github/workflows/code-simplifier.yml
@@ -12,5 +12,5 @@ permissions:
 
 jobs:
   simplify:
-    uses: JacobPEvans/ai-workflows/.github/workflows/code-simplifier.yml@v0.6.1
+    uses: JacobPEvans/ai-workflows/.github/workflows/code-simplifier.yml@v0.7.0
     secrets: inherit

--- a/.github/workflows/final-pr-review.yml
+++ b/.github/workflows/final-pr-review.yml
@@ -19,5 +19,5 @@ concurrency:
 
 jobs:
   review:
-    uses: JacobPEvans/ai-workflows/.github/workflows/final-pr-review.yml@v0.6.1
+    uses: JacobPEvans/ai-workflows/.github/workflows/final-pr-review.yml@v0.7.0
     secrets: inherit

--- a/.github/workflows/issue-auto-resolve.yml
+++ b/.github/workflows/issue-auto-resolve.yml
@@ -64,7 +64,7 @@ jobs:
 
   run-triage:
     if: github.event_name == 'workflow_dispatch'
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-triage.yml@v0.6.1
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-triage.yml@v0.7.0
     secrets: inherit
     with:
       issue_number: ${{ inputs.issue_number }}
@@ -75,7 +75,7 @@ jobs:
       always() &&
       github.event_name == 'workflow_dispatch' &&
       (needs.run-triage.result == 'success' || needs.run-triage.result == 'skipped')
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-resolver.yml@v0.6.1
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-resolver.yml@v0.7.0
     secrets: inherit
     with:
       repo_context: "Terraform Proxmox VM/container provisioning"

--- a/.github/workflows/issue-hygiene.yml
+++ b/.github/workflows/issue-hygiene.yml
@@ -13,5 +13,5 @@ permissions:
 
 jobs:
   hygiene:
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-hygiene.yml@v0.6.1
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-hygiene.yml@v0.7.0
     secrets: inherit

--- a/.github/workflows/issue-sweeper.yml
+++ b/.github/workflows/issue-sweeper.yml
@@ -13,5 +13,5 @@ permissions:
 
 jobs:
   sweep:
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-sweeper.yml@v0.6.1
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-sweeper.yml@v0.7.0
     secrets: inherit

--- a/.github/workflows/next-steps.yml
+++ b/.github/workflows/next-steps.yml
@@ -13,5 +13,5 @@ permissions:
 
 jobs:
   analyze:
-    uses: JacobPEvans/ai-workflows/.github/workflows/next-steps.yml@v0.6.1
+    uses: JacobPEvans/ai-workflows/.github/workflows/next-steps.yml@v0.7.0
     secrets: inherit

--- a/.github/workflows/post-merge-docs-review.yml
+++ b/.github/workflows/post-merge-docs-review.yml
@@ -37,7 +37,7 @@ jobs:
 
   review:
     if: github.event_name == 'workflow_dispatch'
-    uses: JacobPEvans/ai-workflows/.github/workflows/post-merge-docs-review.yml@v0.6.1
+    uses: JacobPEvans/ai-workflows/.github/workflows/post-merge-docs-review.yml@v0.7.0
     with:
       commit_sha: ${{ inputs.commit_sha || github.sha }}
     secrets: inherit

--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -37,7 +37,7 @@ jobs:
 
   review:
     if: github.event_name == 'workflow_dispatch'
-    uses: JacobPEvans/ai-workflows/.github/workflows/post-merge-tests.yml@v0.6.1
+    uses: JacobPEvans/ai-workflows/.github/workflows/post-merge-tests.yml@v0.7.0
     with:
       commit_sha: ${{ inputs.commit_sha || github.sha }}
     secrets: inherit


### PR DESCRIPTION
Dependency bot workflows (renovate, dependabot) will now show as skipped instead of failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Bump `ai-workflows` to v0.7.0 in multiple GitHub Actions workflows to show dependency bot workflows as skipped instead of failed.
> 
>   - **Workflows Updated**:
>     - Bump `ai-workflows` version from `v0.6.1` to `v0.7.0` in `.github/workflows/best-practices.yml`, `.github/workflows/ci-fail-issue.yml`, and `.github/workflows/ci-fix.yml`.
>     - Update version in `.github/workflows/claude-review.yml`, `.github/workflows/code-simplifier.yml`, and `.github/workflows/final-pr-review.yml`.
>     - Version bump in `.github/workflows/issue-auto-resolve.yml`, `.github/workflows/issue-hygiene.yml`, and `.github/workflows/issue-sweeper.yml`.
>     - Change version in `.github/workflows/next-steps.yml`, `.github/workflows/post-merge-docs-review.yml`, and `.github/workflows/post-merge-tests.yml`.
>   - **Behavior**:
>     - Dependency bot workflows (renovate, dependabot) will now show as skipped instead of failed.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fterraform-proxmox&utm_source=github&utm_medium=referral)<sup> for 92c710559208e18729c6a4215112e95e36b2ee79. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->