### PR TITLE
feat: disable automatic triggers on Claude-executing workflows

### DIFF
--- a/.github/workflows/best-practices.yml
+++ b/.github/workflows/best-practices.yml
@@ -1,9 +1,11 @@
 name: Best Practices Recommender
 
 on:
-  schedule:
-    - cron: "0 3 * * 2,5"
   workflow_dispatch:
+  # --- DISABLED AUTOMATIC TRIGGERS (restore by uncommenting) ---
+  # schedule:
+  #   - cron: "0 3 * * 2,5"
+  # --- END DISABLED ---
 
 permissions:
   contents: read

--- a/.github/workflows/ci-fix.yml
+++ b/.github/workflows/ci-fix.yml
@@ -1,9 +1,12 @@
 name: CI Fix (Claude)
 
 on:
-  workflow_run:
-    workflows: ["Terraform CI", "Markdown Lint"]
-    types: [completed]
+  workflow_dispatch:
+  # --- DISABLED AUTOMATIC TRIGGERS (restore by uncommenting) ---
+  # workflow_run:
+  #   workflows: ["Terraform CI", "Markdown Lint"]
+  #   types: [completed]
+  # --- END DISABLED ---
 
 permissions:
   actions: read
@@ -12,15 +15,19 @@ permissions:
   issues: write
   pull-requests: write
 
-concurrency:
-  group: ci-fix-${{ github.event.workflow_run.head_branch }}
-  cancel-in-progress: true
+# --- DISABLED AUTOMATIC TRIGGERS (restore by uncommenting) ---
+# concurrency:
+#   group: ci-fix-${{ github.event.workflow_run.head_branch }}
+#   cancel-in-progress: true
+# --- END DISABLED ---
 
 jobs:
   fix:
-    if: >-
-      github.event.workflow_run.conclusion == 'failure' &&
-      github.event.workflow_run.head_branch != 'main'
+    # --- DISABLED AUTOMATIC TRIGGERS (restore by uncommenting) ---
+    # if: >-
+    #   github.event.workflow_run.conclusion == 'failure' &&
+    #   github.event.workflow_run.head_branch != 'main'
+    # --- END DISABLED ---
     uses: JacobPEvans/ai-workflows/.github/workflows/ci-fix.yml@v0.9.4
     with:
       repo_context: "Terraform/OpenTofu project managing Proxmox VE infrastructure"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,10 +1,13 @@
 name: Claude Code Review
 
 on:
-  pull_request:
-    types: [opened, synchronize]
-  issue_comment:
-    types: [created]
+  workflow_dispatch:
+  # --- DISABLED AUTOMATIC TRIGGERS (restore by uncommenting) ---
+  # pull_request:
+  #   types: [opened, synchronize]
+  # issue_comment:
+  #   types: [created]
+  # --- END DISABLED ---
 
 permissions:
   actions: read

--- a/.github/workflows/code-simplifier.yml
+++ b/.github/workflows/code-simplifier.yml
@@ -1,9 +1,11 @@
 name: Code Simplifier
 
 on:
-  schedule:
-    - cron: "0 4 * * 0,3,6"
   workflow_dispatch:
+  # --- DISABLED AUTOMATIC TRIGGERS (restore by uncommenting) ---
+  # schedule:
+  #   - cron: "0 4 * * 0,3,6"
+  # --- END DISABLED ---
 
 permissions:
   contents: write

--- a/.github/workflows/final-pr-review.yml
+++ b/.github/workflows/final-pr-review.yml
@@ -1,10 +1,13 @@
 name: Final PR Review
 
 on:
-  pull_request_review:
-    types: [submitted]
-  check_suite:
-    types: [completed]
+  workflow_dispatch:
+  # --- DISABLED AUTOMATIC TRIGGERS (restore by uncommenting) ---
+  # pull_request_review:
+  #   types: [submitted]
+  # check_suite:
+  #   types: [completed]
+  # --- END DISABLED ---
 
 permissions:
   checks: read

--- a/.github/workflows/issue-auto-resolve.yml
+++ b/.github/workflows/issue-auto-resolve.yml
@@ -1,14 +1,16 @@
 name: Issue Auto-Resolve
 
 on:
-  issues:
-    types: [opened, labeled]
   workflow_dispatch:
     inputs:
       issue_number:
         description: "Issue number to resolve"
         required: true
         type: string
+  # --- DISABLED AUTOMATIC TRIGGERS (restore by uncommenting) ---
+  # issues:
+  #   types: [opened, labeled]
+  # --- END DISABLED ---
 
 permissions:
   actions: write
@@ -18,49 +20,51 @@ permissions:
   pull-requests: write
 
 jobs:
-  dispatch:
-    if: github.event_name == 'issues'
-    runs-on: ubuntu-latest
-    permissions:
-      actions: write
-      issues: write
-    steps:
-      - name: Dispatch as workflow_dispatch
-        env:
-          GH_TOKEN: ${{ github.token }}
-          WORKFLOW_NAME: ${{ github.workflow }}
-          REPO: ${{ github.repository }}
-          ISSUE_NUM: ${{ github.event.issue.number }}
-          EVENT_ACTION: ${{ github.event.action }}
-          LABEL_NAME: ${{ github.event.label.name }}
-        run: |
-          # Filter labeled events to only ai:ready
-          if [[ "$EVENT_ACTION" == "labeled" && "$LABEL_NAME" != "ai:ready" ]]; then
-            echo "Label '$LABEL_NAME' is not ai:ready — skipping"
-            exit 0
-          fi
-
-          # Daily dispatch limit (cost control safety valve)
-          TODAY=$(date -u +%Y-%m-%d)
-          COUNT=$(gh run list \
-            --workflow "$WORKFLOW_NAME" \
-            --repo "$REPO" \
-            --event workflow_dispatch \
-            --created ">=$TODAY" \
-            --json databaseId --jq 'length')
-          if [[ "$COUNT" -ge 5 ]]; then
-            echo "Daily dispatch limit reached ($COUNT/5) — skipping"
-            exit 0
-          fi
-
-          # Remove ai:ready label so it can be re-applied to re-trigger
-          if [[ "$EVENT_ACTION" == "labeled" && "$LABEL_NAME" == "ai:ready" ]]; then
-            gh issue edit "$ISSUE_NUM" --repo "$REPO" --remove-label "ai:ready" || true
-          fi
-
-          gh workflow run "$WORKFLOW_NAME" \
-            --repo "$REPO" \
-            -f issue_number="$ISSUE_NUM"
+  # --- DISABLED AUTOMATIC TRIGGERS (restore by uncommenting) ---
+  # dispatch:
+  #   if: github.event_name == 'issues'
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     actions: write
+  #     issues: write
+  #   steps:
+  #     - name: Dispatch as workflow_dispatch
+  #       env:
+  #         GH_TOKEN: ${{ github.token }}
+  #         WORKFLOW_NAME: ${{ github.workflow }}
+  #         REPO: ${{ github.repository }}
+  #         ISSUE_NUM: ${{ github.event.issue.number }}
+  #         EVENT_ACTION: ${{ github.event.action }}
+  #         LABEL_NAME: ${{ github.event.label.name }}
+  #       run: |
+  #         # Filter labeled events to only ai:ready
+  #         if [[ "$EVENT_ACTION" == "labeled" && "$LABEL_NAME" != "ai:ready" ]]; then
+  #           echo "Label '$LABEL_NAME' is not ai:ready — skipping"
+  #           exit 0
+  #         fi
+  #
+  #         # Daily dispatch limit (cost control safety valve)
+  #         TODAY=$(date -u +%Y-%m-%d)
+  #         COUNT=$(gh run list \
+  #           --workflow "$WORKFLOW_NAME" \
+  #           --repo "$REPO" \
+  #           --event workflow_dispatch \
+  #           --created ">=$TODAY" \
+  #           --json databaseId --jq 'length')
+  #         if [[ "$COUNT" -ge 5 ]]; then
+  #           echo "Daily dispatch limit reached ($COUNT/5) — skipping"
+  #           exit 0
+  #         fi
+  #
+  #         # Remove ai:ready label so it can be re-applied to re-trigger
+  #         if [[ "$EVENT_ACTION" == "labeled" && "$LABEL_NAME" == "ai:ready" ]]; then
+  #           gh issue edit "$ISSUE_NUM" --repo "$REPO" --remove-label "ai:ready" || true
+  #         fi
+  #
+  #         gh workflow run "$WORKFLOW_NAME" \
+  #           --repo "$REPO" \
+  #           -f issue_number="$ISSUE_NUM"
+  # --- END DISABLED ---
 
   run-triage:
     if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/issue-hygiene.yml
+++ b/.github/workflows/issue-hygiene.yml
@@ -1,9 +1,11 @@
 name: Issue Hygiene
 
 on:
-  schedule:
-    - cron: "0 7 * * 1"
   workflow_dispatch:
+  # --- DISABLED AUTOMATIC TRIGGERS (restore by uncommenting) ---
+  # schedule:
+  #   - cron: "0 7 * * 1"
+  # --- END DISABLED ---
 
 permissions:
   contents: read

--- a/.github/workflows/issue-sweeper.yml
+++ b/.github/workflows/issue-sweeper.yml
@@ -1,9 +1,11 @@
 name: Issue Sweeper
 
 on:
-  schedule:
-    - cron: "0 6 * * 1"
   workflow_dispatch:
+  # --- DISABLED AUTOMATIC TRIGGERS (restore by uncommenting) ---
+  # schedule:
+  #   - cron: "0 6 * * 1"
+  # --- END DISABLED ---
 
 permissions:
   contents: read

--- a/.github/workflows/next-steps.yml
+++ b/.github/workflows/next-steps.yml
@@ -1,9 +1,11 @@
 name: Next Steps
 
 on:
-  schedule:
-    - cron: "0 5 * * 1,4"
   workflow_dispatch:
+  # --- DISABLED AUTOMATIC TRIGGERS (restore by uncommenting) ---
+  # schedule:
+  #   - cron: "0 5 * * 1,4"
+  # --- END DISABLED ---
 
 permissions:
   contents: write

--- a/.github/workflows/post-merge-docs-review.yml
+++ b/.github/workflows/post-merge-docs-review.yml
@@ -1,14 +1,16 @@
 name: Post-Merge Docs Review
 
 on:
-  push:
-    branches: [main]
   workflow_dispatch:
     inputs:
       commit_sha:
         description: 'Commit SHA to review'
         required: false
         type: string
+  # --- DISABLED AUTOMATIC TRIGGERS (restore by uncommenting) ---
+  # push:
+  #   branches: [main]
+  # --- END DISABLED ---
 
 # Workflow-level: union of all job permissions (required for job-level to be effective).
 # Each job below restricts further to only what it needs.
@@ -19,21 +21,23 @@ permissions:
   pull-requests: write
 
 jobs:
-  dispatch:
-    if: github.event_name == 'push'
-    runs-on: ubuntu-latest
-    permissions:
-      actions: write
-    steps:
-      - name: Re-trigger as workflow_dispatch
-        env:
-          WORKFLOW_NAME: ${{ github.workflow }}
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh workflow run "$WORKFLOW_NAME" \
-            --repo "${{ github.repository }}" \
-            --ref main \
-            -f commit_sha="${{ github.sha }}"
+  # --- DISABLED AUTOMATIC TRIGGERS (restore by uncommenting) ---
+  # dispatch:
+  #   if: github.event_name == 'push'
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     actions: write
+  #   steps:
+  #     - name: Re-trigger as workflow_dispatch
+  #       env:
+  #         WORKFLOW_NAME: ${{ github.workflow }}
+  #         GH_TOKEN: ${{ github.token }}
+  #       run: |
+  #         gh workflow run "$WORKFLOW_NAME" \
+  #           --repo "${{ github.repository }}" \
+  #           --ref main \
+  #           -f commit_sha="${{ github.sha }}"
+  # --- END DISABLED ---
 
   review:
     if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -1,14 +1,16 @@
 name: Post-Merge Test Review
 
 on:
-  push:
-    branches: [main]
   workflow_dispatch:
     inputs:
       commit_sha:
         description: 'Commit SHA to review'
         required: false
         type: string
+  # --- DISABLED AUTOMATIC TRIGGERS (restore by uncommenting) ---
+  # push:
+  #   branches: [main]
+  # --- END DISABLED ---
 
 # Workflow-level: union of all job permissions (required for job-level to be effective).
 # Each job below restricts further to only what it needs.
@@ -19,21 +21,23 @@ permissions:
   pull-requests: write
 
 jobs:
-  dispatch:
-    if: github.event_name == 'push'
-    runs-on: ubuntu-latest
-    permissions:
-      actions: write
-    steps:
-      - name: Re-trigger as workflow_dispatch
-        env:
-          WORKFLOW_NAME: ${{ github.workflow }}
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh workflow run "$WORKFLOW_NAME" \
-            --repo "${{ github.repository }}" \
-            --ref main \
-            -f commit_sha="${{ github.sha }}"
+  # --- DISABLED AUTOMATIC TRIGGERS (restore by uncommenting) ---
+  # dispatch:
+  #   if: github.event_name == 'push'
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     actions: write
+  #   steps:
+  #     - name: Re-trigger as workflow_dispatch
+  #       env:
+  #         WORKFLOW_NAME: ${{ github.workflow }}
+  #         GH_TOKEN: ${{ github.token }}
+  #       run: |
+  #         gh workflow run "$WORKFLOW_NAME" \
+  #           --repo "${{ github.repository }}" \
+  #           --ref main \
+  #           -f commit_sha="${{ github.sha }}"
+  # --- END DISABLED ---
 
   review:
     if: github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
## Summary
- Converts all 11 Claude-executing workflows from automatic triggers (pull_request, schedule, push, issues, workflow_run, etc.) to `workflow_dispatch` only
- Comments out all automatic triggers with `DISABLED AUTOMATIC TRIGGERS` markers for easy restoration
- Also comments out dead-code dispatch jobs and conditions that depended on the removed triggers (ci-fix concurrency/if, post-merge dispatch jobs, issue-auto-resolve dispatch job)

## Test plan
- [ ] Verify no Claude workflows fire automatically on PR open, push to main, schedule, or issue creation
- [ ] Verify each workflow can still be triggered manually via Actions > Run workflow
- [ ] Confirm non-Claude workflows (CI, release-please, renovate, label-sync) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR performs a surgical, fully-reversible "kill switch" on all 11 Claude-executing GitHub Actions workflows, converting every automatic trigger (`pull_request`, `schedule`, `push`, `issues`, `workflow_run`, `pull_request_review`, `check_suite`) to `workflow_dispatch`-only. All disabled triggers are commented out with clearly marked `DISABLED AUTOMATIC TRIGGERS` / `END DISABLED` fences, making restoration as simple as uncommenting. Dependent code (relay `dispatch` jobs in `post-merge-docs-review.yml`, `post-merge-tests.yml`, `issue-auto-resolve.yml`, and the concurrency/`if` condition in `ci-fix.yml`) is also commented out consistently.

**Key observations:**

- `ci-fix.yml` — The `fix` job's `if` guard tied to `workflow_run` context is correctly commented out since it would always evaluate to `false` under `workflow_dispatch`. The job now runs unconditionally on manual dispatch, which is the right behaviour.
- `concurrency` blocks in `claude-review.yml` and `final-pr-review.yml` retain expressions referencing `github.event.pull_request.number` and similar fields that are now null under `workflow_dispatch`, falling back safely to `github.ref` / `github.run_id`. These fall-throughs are harmless and don't affect workflow execution.
- Non-Claude workflows (CI, release-please, renovate, label-sync) are untouched. ✅

<h3>Confidence Score: 5/5</h3>

- Safe to merge — all changes are additive comment-outs with no logic alterations to any active code paths.
- Every modification is either commenting out a trigger or commenting out code that exclusively served that trigger. No runtime logic changes, no new failure modes introduced. The `workflow_dispatch` path in all 11 workflows was already present and tested before this PR. Concurrency group expressions still work correctly despite stale event context references.
- No files require special attention

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[GitHub Event] -->|~~pull_request~~<br/>~~schedule~~<br/>~~push~~<br/>~~issues~~<br/>~~workflow_run~~<br/>~~pull_request_review~~<br/>~~check_suite~~| B["❌ DISABLED"]
    A -->|workflow_dispatch<br/>Manual only| C{"Which Workflow?"}

    C --> D[claude-review]
    C --> E[ci-fix]
    C --> F[best-practices]
    C --> G[code-simplifier]
    C --> H[final-pr-review]
    C --> I["issue-auto-resolve<br/>requires issue_number input"]
    C --> J[issue-hygiene]
    C --> K[issue-sweeper]
    C --> L[next-steps]
    C --> M["post-merge-docs-review<br/>optional commit_sha input"]
    C --> N["post-merge-tests<br/>optional commit_sha input"]

    D --> O["ai-workflows<br/>reusable workflow"]
    E --> O
    F --> O
    G --> O
    H --> O
    I --> O
    J --> O
    K --> O
    L --> O
    M --> O
    N --> O
```

<sub>Last reviewed commit: 2396d67</sub>

<!-- /greptile_comment -->