### PR TITLE
fix(ci): use GitHub App token for release-please to trigger CI Gate

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,8 +9,7 @@ permissions: {}
 jobs:
   release-please:
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     uses: JacobPEvans/.github/.github/workflows/_release-please.yml@main
     secrets:
       GH_ACTION_JACOBPEVANS_APP_ID: ${{ secrets.GH_ACTION_JACOBPEVANS_APP_ID }}


### PR DESCRIPTION
## Summary

- Pass GitHub App credentials explicitly to the release-please reusable workflow
- Tighten workflow-level permissions to `{}`; move to job-level

## Root Cause

Release-please used `GITHUB_TOKEN` to create PRs. GitHub does not trigger `pull_request` events for `GITHUB_TOKEN`-created PRs, so `ci-gate.yml` (Merge Gate) never ran — blocking PR #182 indefinitely.

## Dependency

Requires JacobPEvans/.github#87 to be merged first.

## Test plan

- [ ] Merge JacobPEvans/.github#87 first
- [ ] Merge this PR
- [ ] Confirm the next release-please PR triggers Merge Gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the `release-please` workflow so that PRs it creates actually trigger the CI gate (`ci-gate.yml` / Merge Gate). The root cause was a well-known GitHub platform constraint: PRs opened by `GITHUB_TOKEN` do **not** fire `pull_request` events, so the merge gate never ran — blocking PR #182 indefinitely. The fix swaps `GITHUB_TOKEN` for a GitHub App identity by forwarding `GH_ACTION_JACOBPEVANS_APP_ID` and `GH_APP_PRIVATE_KEY` to the reusable workflow, where a real installation token is generated. As a bonus, permissions are tightened from workflow-level to job-level, following the principle of least privilege.

**Key changes:**
- `permissions: {}` set at the workflow level — deny-by-default 🔒
- `contents: write` + `pull-requests: write` moved to job scope (correct for reusable-workflow calls)
- GitHub App credentials (`GH_ACTION_JACOBPEVANS_APP_ID`, `GH_APP_PRIVATE_KEY`) forwarded explicitly — better than `secrets: inherit`

**Noteworthy:** This PR has a hard dependency on `JacobPEvans/.github#87` being merged first, as the reusable workflow must be updated to accept and use these new secrets before this can work end-to-end.

<h3>Confidence Score: 4/5</h3>

- Safe to merge after confirming JacobPEvans/.github#87 is merged and both secrets are present in the repository settings.
- The code change itself is minimal, correct, and follows security best practices (job-scoped permissions, explicit secret forwarding). Score is 4 rather than 5 because correctness depends on an external prerequisite (JacobPEvans/.github#87) and the repository secrets must be pre-configured — neither of which can be verified from the code alone.
- No files require special attention — the single changed file is clean and well-structured.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/release-please.yml | Scopes workflow-level permissions to `{}` (deny-by-default) and moves `contents: write` + `pull-requests: write` to the job level; adds explicit GitHub App secret forwarding to the reusable workflow so release-please PRs are created under a GitHub App identity rather than GITHUB_TOKEN, enabling `pull_request` events to fire and unblocking the CI gate. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Push as Push to main
    participant RP as release-please.yml
    participant Reusable as _release-please.yml@main<br/>(JacobPEvans/.github)
    participant GHA as GitHub App Token
    participant GH as GitHub API
    participant CI as ci-gate.yml<br/>(Merge Gate)

    Push->>RP: triggers on push to main
    RP->>Reusable: uses: (with GH_ACTION_JACOBPEVANS_APP_ID + GH_APP_PRIVATE_KEY)
    Reusable->>GHA: exchange App ID + private key
    GHA-->>Reusable: installation access token
    Reusable->>GH: create/update release-please PR<br/>(authenticated as GitHub App)
    GH-->>CI: ✅ pull_request event fires!
    Note over CI: Before this fix: GITHUB_TOKEN<br/>created the PR, pull_request events<br/>were suppressed — CI gate never ran
```

<sub>Last reviewed commit: aa3ec40</sub>

<!-- /greptile_comment -->