### PR TITLE
chore(ci): terraform-proxmox workflow refs @v0.9.4 to @main

### DIFF
--- a/.github/workflows/best-practices.yml
+++ b/.github/workflows/best-practices.yml
@@ -15,5 +15,5 @@ permissions:
 
 jobs:
   recommend:
-    uses: JacobPEvans/ai-workflows/.github/workflows/best-practices.yml@v0.9.4
+    uses: JacobPEvans/ai-workflows/.github/workflows/best-practices.yml@main
     secrets: inherit

--- a/.github/workflows/ci-fail-issue.yml
+++ b/.github/workflows/ci-fail-issue.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   handle-failure:
     if: github.event.workflow_run.conclusion == 'failure'
-    uses: JacobPEvans/ai-workflows/.github/workflows/ci-fail-issue.yml@v0.9.4
+    uses: JacobPEvans/ai-workflows/.github/workflows/ci-fail-issue.yml@main
     with:
       workflow_name: "Terraform CI"
     secrets: inherit

--- a/.github/workflows/ci-fix.yml
+++ b/.github/workflows/ci-fix.yml
@@ -28,7 +28,7 @@ jobs:
     #   github.event.workflow_run.conclusion == 'failure' &&
     #   github.event.workflow_run.head_branch != 'main'
     # --- END DISABLED ---
-    uses: JacobPEvans/ai-workflows/.github/workflows/ci-fix.yml@v0.9.4
+    uses: JacobPEvans/ai-workflows/.github/workflows/ci-fix.yml@main
     with:
       repo_context: "Terraform/OpenTofu project managing Proxmox VE infrastructure"
       ci_structure: "terraform.yml (tofu fmt/init/validate/test), markdown-lint.yml (markdownlint)"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   review:
-    uses: JacobPEvans/ai-workflows/.github/workflows/claude-review.yml@v0.9.4
+    uses: JacobPEvans/ai-workflows/.github/workflows/claude-review.yml@main
     with:
       review_prompt: "Focus on Terraform best practices, security, SOPS/age patterns"
     secrets: inherit

--- a/.github/workflows/code-simplifier.yml
+++ b/.github/workflows/code-simplifier.yml
@@ -14,5 +14,5 @@ permissions:
 
 jobs:
   simplify:
-    uses: JacobPEvans/ai-workflows/.github/workflows/code-simplifier.yml@v0.9.4
+    uses: JacobPEvans/ai-workflows/.github/workflows/code-simplifier.yml@main
     secrets: inherit

--- a/.github/workflows/final-pr-review.yml
+++ b/.github/workflows/final-pr-review.yml
@@ -22,5 +22,5 @@ concurrency:
 
 jobs:
   review:
-    uses: JacobPEvans/ai-workflows/.github/workflows/final-pr-review.yml@v0.9.4
+    uses: JacobPEvans/ai-workflows/.github/workflows/final-pr-review.yml@main
     secrets: inherit

--- a/.github/workflows/issue-auto-resolve.yml
+++ b/.github/workflows/issue-auto-resolve.yml
@@ -68,7 +68,7 @@ jobs:
 
   run-triage:
     if: github.event_name == 'workflow_dispatch'
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-triage.yml@v0.9.4
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-triage.yml@main
     secrets: inherit
     with:
       issue_number: ${{ inputs.issue_number }}
@@ -79,7 +79,7 @@ jobs:
       always() &&
       github.event_name == 'workflow_dispatch' &&
       (needs.run-triage.result == 'success' || needs.run-triage.result == 'skipped')
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-resolver.yml@v0.9.4
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-resolver.yml@main
     secrets: inherit
     with:
       repo_context: "Terraform Proxmox VM/container provisioning"

--- a/.github/workflows/issue-hygiene.yml
+++ b/.github/workflows/issue-hygiene.yml
@@ -15,5 +15,5 @@ permissions:
 
 jobs:
   hygiene:
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-hygiene.yml@v0.9.4
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-hygiene.yml@main
     secrets: inherit

--- a/.github/workflows/issue-sweeper.yml
+++ b/.github/workflows/issue-sweeper.yml
@@ -15,5 +15,5 @@ permissions:
 
 jobs:
   sweep:
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-sweeper.yml@v0.9.4
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-sweeper.yml@main
     secrets: inherit

--- a/.github/workflows/next-steps.yml
+++ b/.github/workflows/next-steps.yml
@@ -15,5 +15,5 @@ permissions:
 
 jobs:
   analyze:
-    uses: JacobPEvans/ai-workflows/.github/workflows/next-steps.yml@v0.9.4
+    uses: JacobPEvans/ai-workflows/.github/workflows/next-steps.yml@main
     secrets: inherit

--- a/.github/workflows/post-merge-docs-review.yml
+++ b/.github/workflows/post-merge-docs-review.yml
@@ -41,7 +41,7 @@ jobs:
 
   review:
     if: github.event_name == 'workflow_dispatch'
-    uses: JacobPEvans/ai-workflows/.github/workflows/post-merge-docs-review.yml@v0.9.4
+    uses: JacobPEvans/ai-workflows/.github/workflows/post-merge-docs-review.yml@main
     with:
       commit_sha: ${{ inputs.commit_sha || github.sha }}
     secrets: inherit

--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -41,7 +41,7 @@ jobs:
 
   review:
     if: github.event_name == 'workflow_dispatch'
-    uses: JacobPEvans/ai-workflows/.github/workflows/post-merge-tests.yml@v0.9.4
+    uses: JacobPEvans/ai-workflows/.github/workflows/post-merge-tests.yml@main
     with:
       commit_sha: ${{ inputs.commit_sha || github.sha }}
     secrets: inherit


### PR DESCRIPTION
# chore(ci): standardize ai-workflows refs to @main

## Summary

- Replace all `@v0.9.4` pinned refs with `@main` for `JacobPEvans/ai-workflows`
  reusable workflows across 12 workflow files (13 total refs)
- This is an owner-controlled first-party repo — tracking `@main` is deliberate
  policy so all downstream consumer repos stay in sync without per-repo version bump PRs

## Changes

| File | Change |
|---|---|
| `.github/workflows/best-practices.yml` | `@v0.9.4` → `@main` |
| `.github/workflows/ci-fail-issue.yml` | `@v0.9.4` → `@main` |
| `.github/workflows/ci-fix.yml` | `@v0.9.4` → `@main` |
| `.github/workflows/claude-review.yml` | `@v0.9.4` → `@main` |
| `.github/workflows/code-simplifier.yml` | `@v0.9.4` → `@main` |
| `.github/workflows/final-pr-review.yml` | `@v0.9.4` → `@main` |
| `.github/workflows/issue-auto-resolve.yml` | `@v0.9.4` → `@main` (2 refs) |
| `.github/workflows/issue-hygiene.yml` | `@v0.9.4` → `@main` |
| `.github/workflows/issue-sweeper.yml` | `@v0.9.4` → `@main` |
| `.github/workflows/next-steps.yml` | `@v0.9.4` → `@main` |
| `.github/workflows/post-merge-docs-review.yml` | `@v0.9.4` → `@main` |
| `.github/workflows/post-merge-tests.yml` | `@v0.9.4` → `@main` |

## Test plan

- [x] No `@v0.9.4` refs remain in any workflow file
- [x] All CI checks pass (CodeQL, Merge Gate, Detect Changes, Analyze)
- [x] All 13 Copilot review threads addressed and resolved
  (`@main` is intentional — owner-controlled first-party workflow repo)
- [x] PR is `MERGEABLE` with no blocking threads
