### PR TITLE
chore: gitignore .mcp.json to prevent accidental commit of MCP config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,10 @@ scripts/timing-results.txt
 
 # ai-workflows runtime checkout (checked out by CI into .ai-workflows/ at runtime)
 .ai-workflows/
+
+# Claude Code repo-scoped MCP server config. NOT committed because it
+# auto-executes on agent load — committing would silently spawn the listed
+# MCP servers (terraform-mcp-server, bunx-fetched AWS tools, etc.) for every
+# contributor without review or version pinning. Contributors who want MCP
+# tooling in this repo should create their own .mcp.json locally.
+.mcp.json


### PR DESCRIPTION
## Summary

Adds `.mcp.json` to `.gitignore`. This prevents the Claude Code repo-scoped MCP server config from showing up as untracked noise in `git status` on contributor workstations that have a local `.mcp.json`, and — more importantly — prevents future contributors from accidentally committing a file that auto-executes tools on agent load.

## Why not commit it instead?

`.mcp.json` is executable config: any MCP server listed in it is spawned the moment an AI agent opens the repo. Committing a repo-scoped config has several sharp edges:

- **Unpinned supply chain**: `bunx <npm-package>` fetches from npm at invocation time. No version lock, no integrity hash. Every clone/CI run could pull a different version of a tool that then runs against this repo.
- **Unreviewed tool exposure**: `terraform-mcp-server` typically exposes `plan`, `show`, and state operations. Plan output contains resource IDs, IPs, and occasionally unmarked-sensitive values that would land inside model prompts.
- **Ambient credential pickup**: MCP servers run as the contributor's user — they inherit ambient AWS creds, Doppler sessions, SSH agents, etc. Committing a config that auto-loads AWS tools into a Proxmox repo silently encourages every contributor to query AWS with their own identity.
- **Domain mismatch**: the specific config that prompted this PR auto-loads an AWS KB retrieval tool alongside `terraform-mcp-server`. AWS KB has zero domain relevance to a Proxmox repo; it has no place in auto-loaded config here.

Contributors who want MCP tooling in this repo should create their own `.mcp.json` locally after reviewing what each listed server actually does. The tradeoff: no shared MCP config, but also no accidental supply chain or credential exposure.

## Changes

- `.gitignore` — added `.mcp.json` with an explanatory comment block

## Test plan

- [x] Confirmed `.gitignore` pattern matches by running `git check-ignore -v .mcp.json` on a local workstation that has the file
- [x] Confirmed no existing `.mcp.json` in repo history (`git log --all -- .mcp.json` returns empty)
- [x] No functional change — pure ignore rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)