### PR TITLE
fix: correct Cribl Stream API port to 9000

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -84,7 +84,7 @@ locals {
       splunk_hec       = 8088
       splunk_mgmt      = 8089
       cribl_edge_api   = 9420
-      cribl_stream_api = 9100
+      cribl_stream_api = 9000
       apt_cacher_ng    = 3142
       minio_api        = 9000
       minio_console    = 9001

--- a/modules/firewall/container_rules.tf
+++ b/modules/firewall/container_rules.tf
@@ -127,7 +127,7 @@ resource "proxmox_virtual_environment_firewall_rules" "cribl_stream_container" {
 
   rule {
     security_group = proxmox_virtual_environment_cluster_firewall_security_group.cribl_stream_services.name
-    comment        = "Cribl Stream API (9100)"
+    comment        = "Cribl Stream API (9000)"
   }
 
   rule {

--- a/modules/firewall/locals.tf
+++ b/modules/firewall/locals.tf
@@ -63,7 +63,7 @@ locals {
   ]
 
   cribl_stream_services_rules = [
-    { proto = "tcp", dport = "9100", source = local.internal_src, comment = "Cribl Stream API from internal" },
+    { proto = "tcp", dport = "9000", source = local.internal_src, comment = "Cribl Stream API TCP/9000 from internal" },
   ]
 
   minio_services_rules = [

--- a/modules/firewall/security_groups.tf
+++ b/modules/firewall/security_groups.tf
@@ -201,7 +201,7 @@ resource "proxmox_virtual_environment_cluster_firewall_security_group" "vectordb
 
 resource "proxmox_virtual_environment_cluster_firewall_security_group" "cribl_stream_services" {
   name    = "cribl-stream-svc"
-  comment = "Cribl Stream API (9100) from internal networks"
+  comment = "Cribl Stream API (9000) from internal networks"
 
   dynamic "rule" {
     for_each = local.cribl_stream_services_rules

--- a/modules/firewall/tests/rule_generation.tftest.hcl
+++ b/modules/firewall/tests/rule_generation.tftest.hcl
@@ -106,7 +106,7 @@ run "cribl_stream_rules_always_one" {
 
   assert {
     condition     = length(local.cribl_stream_services_rules) == 1
-    error_message = "cribl_stream_services_rules must be exactly 1 (TCP 9100), got ${length(local.cribl_stream_services_rules)}"
+    error_message = "cribl_stream_services_rules must be exactly 1 (TCP 9000), got ${length(local.cribl_stream_services_rules)}"
   }
 }
 

--- a/tests/locals.tftest.hcl
+++ b/tests/locals.tftest.hcl
@@ -286,8 +286,8 @@ run "pipeline_constants_cribl_ports" {
   }
 
   assert {
-    condition     = local.pipeline_constants.service_ports.cribl_stream_api == 9100
-    error_message = "cribl_stream_api port should be 9100"
+    condition     = local.pipeline_constants.service_ports.cribl_stream_api == 9000
+    error_message = "cribl_stream_api port should be 9000"
   }
 }
 


### PR DESCRIPTION
## Summary

- Cribl Stream default API port is 9000, not 9100
- Updated `pipeline_constants.service_ports.cribl_stream_api` from 9100 to 9000
- Fixed hardcoded firewall rule `dport` and all related comments/tests

Same pattern as #223 (cribl_edge_api 9000->9420).

## Test Plan

- [x] `terragrunt validate` passes
- [x] `terragrunt test` passes (57/57 relevant tests; 2 pre-existing failures in inventory contract)
- [x] `terragrunt plan` passes (via pre-push hook)
- [x] Verified Cribl Stream actually listens on port 9000 on CT 182

Generated with [Claude Code](https://claude.com/claude-code)