### PR TITLE
fix: detect aws-vault launcher in pre-push hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,7 +66,7 @@ repos:
 
       - id: terragrunt-validate
         name: terragrunt validate
-        entry: bash -c 'nix develop "github:JacobPEvans/nix-devenv?dir=shells/terraform" --command bash -c "if [ -n \"$AWS_SESSION_TOKEN\" ]; then doppler run -- terragrunt validate; else aws-vault exec tf-proxmox -- doppler run -- terragrunt validate; fi"'
+        entry: bash -c 'nix develop "github:JacobPEvans/nix-devenv?dir=shells/terraform" --command bash -c "if [ -n \"$AWS_VAULT\" ]; then doppler run -- terragrunt validate; else aws-vault exec tf-proxmox -- doppler run -- terragrunt validate; fi"'
         language: system
         always_run: true
         pass_filenames: false
@@ -74,7 +74,7 @@ repos:
 
       - id: terragrunt-plan
         name: terragrunt plan
-        entry: bash -c 'nix develop "github:JacobPEvans/nix-devenv?dir=shells/terraform" --command bash -c "if [ -n \"$AWS_SESSION_TOKEN\" ]; then doppler run -- terragrunt plan -detailed-exitcode; else aws-vault exec tf-proxmox -- doppler run -- terragrunt plan -detailed-exitcode; fi"; rc=$?; if [ $rc -eq 0 ] || [ $rc -eq 2 ]; then exit 0; else exit 1; fi'
+        entry: bash -c 'nix develop "github:JacobPEvans/nix-devenv?dir=shells/terraform" --command bash -c "if [ -n \"$AWS_VAULT\" ]; then doppler run -- terragrunt plan -detailed-exitcode; else aws-vault exec tf-proxmox -- doppler run -- terragrunt plan -detailed-exitcode; fi"; rc=$?; if [ $rc -eq 0 ] || [ $rc -eq 2 ]; then exit 0; else exit 1; fi'
         language: system
         files: '\.(tf|hcl)$'
         pass_filenames: false


### PR DESCRIPTION
## Summary
- detect Claude/aws-vault launched sessions via `AWS_VAULT`
- skip nested `aws-vault exec` in pre-push terragrunt hooks when credentials are already inherited
- preserve the existing fallback path for shells started outside aws-vault