### PR TITLE
feat: declare Samba NAS inventory contract

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,24 +142,27 @@ These are exposed via `ansible_inventory.constants` in `outputs.tf` for downstre
 
 | Repo | Consumes | Purpose |
 | --- | --- | --- |
-| ansible-proxmox | N/A | Proxmox host config (kernel, ZFS, monitoring) |
+| ansible-proxmox | `ansible_inventory.host_services` | Proxmox host config (kernel, ZFS, monitoring, NAS/Samba) |
 | ansible-proxmox-apps | `ansible_inventory` (containers, docker_vms, constants) | Cribl, HAProxy, DNS |
 | ansible-splunk | `ansible_inventory` (splunk_vm) | Splunk Enterprise (Docker) |
 
 ### Inventory Sync (Automatic)
 
 Inventory sync to downstream repos is **automatic** via a Terragrunt `after_hook` in `terragrunt.hcl`.
-After every `terragrunt apply`, `terraform_inventory.json` is written to both
-`ansible-proxmox-apps` and `ansible-splunk` if they are cloned at `~/git/<repo>/main/`.
+After every `terragrunt apply`, `terraform_inventory.json` is written to
+`ansible-proxmox`, `ansible-proxmox-apps`, and `ansible-splunk` if they are cloned
+at `~/git/<repo>/main/`.
 Repos not present are skipped with a stderr warning.
 
 To sync manually (e.g., after importing state without apply):
 
 ```bash
-aws-vault exec tf-proxmox -- doppler run -- \
-  terragrunt output -json ansible_inventory \
-  | tee ~/git/ansible-proxmox-apps/main/inventory/terraform_inventory.json \
-  > ~/git/ansible-splunk/main/inventory/terraform_inventory.json
+aws-vault exec tf-proxmox -- doppler run -- bash -c '
+  INV=$(terragrunt output -json ansible_inventory)
+  for repo in ansible-proxmox ansible-proxmox-apps ansible-splunk; do
+    printf "%s\n" "$INV" > "$HOME/git/$repo/main/inventory/terraform_inventory.json"
+  done
+'
 ```
 
 ## Development Workflow

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,7 +160,12 @@ To sync manually (e.g., after importing state without apply):
 aws-vault exec tf-proxmox -- doppler run -- bash -c '
   INV=$(terragrunt output -json ansible_inventory)
   for repo in ansible-proxmox ansible-proxmox-apps ansible-splunk; do
-    printf "%s\n" "$INV" > "$HOME/git/$repo/main/inventory/terraform_inventory.json"
+    TARGET="$HOME/git/$repo/main/inventory/terraform_inventory.json"
+    if [ -d "$(dirname "$TARGET")" ]; then
+      printf "%s\n" "$INV" > "$TARGET"
+    else
+      printf "Skipped %s (not cloned at ~/git/%s/main)\n" "$repo" "$repo" >&2
+    fi
   done
 '
 ```

--- a/deployment.json
+++ b/deployment.json
@@ -29,6 +29,51 @@
       "mount_point": "/mnt/nas",
       "smb_share_name": "nas",
       "directories": ["huggingface/hub", "ollama/models", "media", "backups"],
+      "group_name": "nas",
+      "managed_users": [
+        {
+          "name": "homeassistant",
+          "unix_groups": ["nas"],
+          "shell": "/usr/sbin/nologin",
+          "create_home": false,
+          "password_secret_env": "NAS_HOMEASSISTANT_SMB_PASSWORD"
+        }
+      ],
+      "shares": [
+        {
+          "name": "nas",
+          "path": "/mnt/nas",
+          "valid_users": "@nas",
+          "browsable": true,
+          "read_only": false,
+          "force_group": "nas",
+          "create_mask": "0664",
+          "directory_mask": "0775",
+          "comment": "Primary NAS root share"
+        },
+        {
+          "name": "ha-backups",
+          "path": "/mnt/nas/backups",
+          "valid_users": "homeassistant",
+          "browsable": true,
+          "read_only": false,
+          "force_group": "nas",
+          "create_mask": "0664",
+          "directory_mask": "0775",
+          "comment": "Home Assistant backup storage"
+        },
+        {
+          "name": "ha-media",
+          "path": "/mnt/nas/media",
+          "valid_users": "homeassistant",
+          "browsable": true,
+          "read_only": false,
+          "force_group": "nas",
+          "create_mask": "0664",
+          "directory_mask": "0775",
+          "comment": "Home Assistant media storage"
+        }
+      ],
       "description": "Host-level NAS: ZFS dataset on local-zfs served via Samba. Managed by ansible-proxmox."
     }
   },

--- a/terragrunt.hcl
+++ b/terragrunt.hcl
@@ -43,7 +43,7 @@ terraform {
   # Writes terraform_inventory.json to ansible-proxmox, ansible-proxmox-apps, and ansible-splunk.
   after_hook "sync_inventory" {
     commands     = ["apply"]
-    execute      = ["bash", "-c", "INV=$(tofu output -json ansible_inventory) && for repo in ansible-proxmox ansible-proxmox-apps ansible-splunk; do TARGET=\"$HOME/git/$repo/main/inventory/terraform_inventory.json\"; if [ -d \"$(dirname \"$TARGET\")\" ]; then echo \"$INV\" > \"$TARGET\" && echo \"Synced inventory -> $repo\" >&2; else echo \"Skipped $repo (not cloned at ~/git/$repo/main)\" >&2; fi; done"]
+    execute      = ["bash", "-c", "INV=$(tofu output -json ansible_inventory) && for repo in ansible-proxmox ansible-proxmox-apps ansible-splunk; do TARGET=\"$HOME/git/$repo/main/inventory/terraform_inventory.json\"; if [ -d \"$(dirname \"$TARGET\")\" ]; then printf \"%s\\n\" \"$INV\" > \"$TARGET\" && echo \"Synced inventory -> $repo\" >&2; else echo \"Skipped $repo (not cloned at ~/git/$repo/main)\" >&2; fi; done"]
     run_on_error = false
   }
 }

--- a/terragrunt.hcl
+++ b/terragrunt.hcl
@@ -40,10 +40,10 @@ terraform {
   source = "."
 
   # Automatically sync ansible_inventory to downstream Ansible repos after every apply.
-  # Writes terraform_inventory.json to ansible-proxmox-apps and ansible-splunk.
+  # Writes terraform_inventory.json to ansible-proxmox, ansible-proxmox-apps, and ansible-splunk.
   after_hook "sync_inventory" {
     commands     = ["apply"]
-    execute      = ["bash", "-c", "INV=$(tofu output -json ansible_inventory) && for repo in ansible-proxmox-apps ansible-splunk; do TARGET=\"$HOME/git/$repo/main/inventory/terraform_inventory.json\"; if [ -d \"$(dirname \"$TARGET\")\" ]; then echo \"$INV\" > \"$TARGET\" && echo \"Synced inventory -> $repo\" >&2; else echo \"Skipped $repo (not cloned at ~/git/$repo/main)\" >&2; fi; done"]
+    execute      = ["bash", "-c", "INV=$(tofu output -json ansible_inventory) && for repo in ansible-proxmox ansible-proxmox-apps ansible-splunk; do TARGET=\"$HOME/git/$repo/main/inventory/terraform_inventory.json\"; if [ -d \"$(dirname \"$TARGET\")\" ]; then echo \"$INV\" > \"$TARGET\" && echo \"Synced inventory -> $repo\" >&2; else echo \"Skipped $repo (not cloned at ~/git/$repo/main)\" >&2; fi; done"]
     run_on_error = false
   }
 }

--- a/tests/ansible_inventory_contract.tftest.hcl
+++ b/tests/ansible_inventory_contract.tftest.hcl
@@ -250,6 +250,40 @@ run "ansible_inventory_host_services_nas_propagated" {
         mount_point    = "/mnt/nas"
         smb_share_name = "nas"
         directories    = ["huggingface/hub", "ollama/models", "media", "backups"]
+        group_name     = "nas"
+        managed_users = [
+          {
+            name                = "homeassistant"
+            unix_groups         = ["nas"]
+            shell               = "/usr/sbin/nologin"
+            create_home         = false
+            password_secret_env = "NAS_HOMEASSISTANT_SMB_PASSWORD"
+          }
+        ]
+        shares = [
+          {
+            name           = "nas"
+            path           = "/mnt/nas"
+            valid_users    = "@nas"
+            browsable      = true
+            read_only      = false
+            force_group    = "nas"
+            create_mask    = "0664"
+            directory_mask = "0775"
+            comment        = "Primary NAS root share"
+          },
+          {
+            name           = "ha-backups"
+            path           = "/mnt/nas/backups"
+            valid_users    = "homeassistant"
+            browsable      = true
+            read_only      = false
+            force_group    = "nas"
+            create_mask    = "0664"
+            directory_mask = "0775"
+            comment        = "Home Assistant backup storage"
+          }
+        ]
       }
     }
   }
@@ -262,5 +296,20 @@ run "ansible_inventory_host_services_nas_propagated" {
   assert {
     condition     = output.ansible_inventory.host_services.nas.mount_point == "/mnt/nas"
     error_message = "host_services.nas.mount_point must propagate to ansible_inventory output"
+  }
+
+  assert {
+    condition     = output.ansible_inventory.host_services.nas.group_name == "nas"
+    error_message = "host_services.nas.group_name must propagate to ansible_inventory output"
+  }
+
+  assert {
+    condition     = output.ansible_inventory.host_services.nas.managed_users[0].password_secret_env == "NAS_HOMEASSISTANT_SMB_PASSWORD"
+    error_message = "host_services.nas.managed_users must propagate to ansible_inventory output"
+  }
+
+  assert {
+    condition     = output.ansible_inventory.host_services.nas.shares[1].name == "ha-backups"
+    error_message = "host_services.nas.shares must propagate to ansible_inventory output"
   }
 }

--- a/variables-storage.tf
+++ b/variables-storage.tf
@@ -72,7 +72,26 @@ variable "host_services" {
       mount_point    = string
       smb_share_name = string
       directories    = list(string)
-      description    = optional(string)
+      group_name     = optional(string)
+      managed_users = optional(list(object({
+        name                = string
+        unix_groups         = optional(list(string))
+        shell               = optional(string)
+        create_home         = optional(bool)
+        password_secret_env = string
+      })))
+      shares = optional(list(object({
+        name           = string
+        path           = string
+        valid_users    = string
+        browsable      = optional(bool)
+        read_only      = optional(bool)
+        force_group    = optional(string)
+        create_mask    = optional(string)
+        directory_mask = optional(string)
+        comment        = optional(string)
+      })))
+      description = optional(string)
     }))
   })
   default = {}


### PR DESCRIPTION
# NAS Infrastructure Contract

## Summary

Extends the NAS infrastructure contract in Terraform to include Samba group, user, and share
management. Adds concrete Home Assistant-oriented NAS users and shares to `deployment.json` and
hardens inventory sync reliability across downstream Ansible repos.

## Changes

- **Schema extension**: `host_services.nas` now declares Samba groups, managed users, and shares in `variables-storage.tf`
- **Deployment config**: Added Home Assistant-oriented NAS users and shares in `deployment.json`
- **Contract validation**: Expanded `tests/ansible_inventory_contract.tftest.hcl` with assertions for new NAS fields
- **Inventory sync hardening**: `terragrunt.hcl` after_hook now uses `printf` instead of `echo` and checks for directory existence before writing
- **Manual sync documentation**: Updated `CLAUDE.md` sync snippet with matching directory existence guard

## Test Plan

- ✅ `tofu test -no-color` passed (Terraform test suite)
- ✅ Pre-commit hooks passed (mock providers)
- ✅ All CI checks passing
- ✅ Review threads resolved
