### PR TITLE
fix: assume credentials in environment for pre-push hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,15 +66,15 @@ repos:
 
       - id: terragrunt-validate
         name: terragrunt validate
-        entry: bash -c 'nix develop "github:JacobPEvans/nix-devenv?dir=shells/terraform" --command bash -c "if [ -n \"$AWS_SESSION_TOKEN\" ]; then doppler run -- terragrunt validate; else aws-vault exec tf-proxmox -- doppler run -- terragrunt validate; fi"'
+        entry: bash -c 'nix develop "github:JacobPEvans/nix-devenv?dir=shells/terraform" --command bash -c "doppler run -- terragrunt validate"'
         language: system
         always_run: true
         pass_filenames: false
-        stages: [pre-push]  # Requires AWS credentials (aws-vault or assumed-role env vars) + Doppler
+        stages: [pre-push]  # Requires AWS credentials in environment + Doppler
 
       - id: terragrunt-plan
         name: terragrunt plan
-        entry: bash -c 'nix develop "github:JacobPEvans/nix-devenv?dir=shells/terraform" --command bash -c "if [ -n \"$AWS_SESSION_TOKEN\" ]; then doppler run -- terragrunt plan -detailed-exitcode; else aws-vault exec tf-proxmox -- doppler run -- terragrunt plan -detailed-exitcode; fi"; rc=$?; if [ $rc -eq 0 ] || [ $rc -eq 2 ]; then exit 0; else exit 1; fi'
+        entry: bash -c 'nix develop "github:JacobPEvans/nix-devenv?dir=shells/terraform" --command bash -c "doppler run -- terragrunt plan -detailed-exitcode"; rc=$?; if [ $rc -eq 0 ] || [ $rc -eq 2 ]; then exit 0; else exit 1; fi'
         language: system
         files: '\.(tf|hcl)$'
         pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,7 +54,7 @@ repos:
   #     - id: terraform-pre-commit
   #       args: ['scan', '-i', 'terraform', '-t', 'all']
 
-  # Local hooks using the full nix+aws-vault+doppler toolchain
+  # Local hooks using nix+doppler toolchain
   - repo: local
     hooks:
       - id: tofu-test

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,7 +68,7 @@ repos:
         name: terragrunt validate
         entry: bash -c 'nix develop "github:JacobPEvans/nix-devenv?dir=shells/terraform" --command bash -c "doppler run -- terragrunt validate"'
         language: system
-        always_run: true
+        files: '\.(tf|hcl)$'
         pass_filenames: false
         stages: [pre-push]  # Requires AWS credentials in environment + Doppler
 


### PR DESCRIPTION
## Summary

Strips the `aws-vault exec` wrappers and `AWS_SESSION_TOKEN` conditionals from both `terragrunt-validate` and `terragrunt-plan` pre-push hooks.

**Before**: hooks detected whether creds existed and fell back to `aws-vault exec` (interactive, causes password prompts)

**After**: hooks assume AWS credentials are already in the environment. No auth management — fail fast with a clear AWS error if creds are absent.

## Why

Sessions that invoke these hooks are expected to have credentials pre-injected (forwarded into Claude sessions, or via `aws-vault exec` before starting work). Pre-commit hooks shouldn't be authentication managers.

Closes #247 (which attempted to fix this with a conditional swap but used the wrong env var and kept the complexity).

## Note on `always_run: true`

The `terragrunt-validate` hook runs on every push regardless of changed files. With credentials required in the environment, this means all pushes to this repo require AWS creds — even non-Terraform changes. Consider removing `always_run: true` if that becomes painful.