### PR TITLE
fix: add bot PR CI retrigger workflow

### DIFF
--- a/.github/workflows/retrigger-pr-checks.yml
+++ b/.github/workflows/retrigger-pr-checks.yml
@@ -1,0 +1,24 @@
+---
+name: Retrigger PR Checks
+
+# Ensures bot-created PRs (GITHUB_TOKEN) get the Merge Gate check.
+# Calls shared logic from JacobPEvans/.github.
+# See: .github/workflows/_retrigger-pr-checks.yml in JacobPEvans/.github
+
+on:
+  schedule:
+    - cron: "0 10 * * *"  # 6 AM ET (UTC-4)
+    - cron: "0 20 * * *"  # 4 PM ET (UTC-4)
+    - cron: "0 0 * * *"   # 8 PM ET (UTC-4)
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  retrigger:
+    uses: JacobPEvans/.github/.github/workflows/_retrigger-pr-checks.yml@main
+    secrets:
+      GH_ACTION_JACOBPEVANS_APP_ID: ${{ secrets.GH_ACTION_JACOBPEVANS_APP_ID }}
+      GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}

--- a/.github/workflows/retrigger-pr-checks.yml
+++ b/.github/workflows/retrigger-pr-checks.yml
@@ -1,4 +1,3 @@
----
 name: Retrigger PR Checks
 
 # Ensures bot-created PRs (GITHUB_TOKEN) get the Merge Gate check.
@@ -7,9 +6,9 @@ name: Retrigger PR Checks
 
 on:
   schedule:
-    - cron: "0 10 * * *"  # 6 AM ET (UTC-4)
-    - cron: "0 20 * * *"  # 4 PM ET (UTC-4)
-    - cron: "0 0 * * *"   # 8 PM ET (UTC-4)
+    - cron: "0 10 * * *"  # 6 AM EDT
+    - cron: "0 20 * * *"  # 4 PM EDT
+    - cron: "0 0 * * *"   # 8 PM EDT
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

Bot-created PRs (Copilot agentic workflows, Claude actions) use `GITHUB_TOKEN` → no `pull_request` event → `ci-gate.yml` never runs → **Merge Gate** missing → PR blocked.

Adds `retrigger-pr-checks.yml` — thin caller to shared `JacobPEvans/.github` reusable workflow. Runs 3×/day (6 AM, 4 PM, 8 PM ET) to find bot PRs missing CI Gate runs and close/reopen them, triggering `ci-gate.yml` via `pull_request: reopened`.

## Dependencies

Requires JacobPEvans/.github#207 merged first.

## Test plan

- [ ] Merge JacobPEvans/.github#207 first
- [ ] Merge this PR
- [ ] Run `gh workflow run retrigger-pr-checks.yml --repo JacobPEvans/terraform-proxmox`
- [ ] Verify any bot PRs get Merge Gate check

🤖 Generated with [Claude Code](https://claude.com/claude-code)