### PR TITLE
🤖 Fix #64: Add ACME certificate management documentation

### DIFF
--- a/ACME_CERTIFICATE_MANAGEMENT.md
+++ b/ACME_CERTIFICATE_MANAGEMENT.md
@@ -10,7 +10,7 @@ For module-level reference (variables, outputs, usage examples), see
 
 ## Architecture Overview
 
-```
+```text
 Terraform (local) ──► BPG Proxmox Provider ──► Proxmox VE API
                                                      │
                               Route53 DNS-01 ◄────── pve-daily-update.service
@@ -21,7 +21,7 @@ Terraform (local) ──► BPG Proxmox Provider ──► Proxmox VE API
 ### Components
 
 | Component | Role |
-|---|---|
+| --- | --- |
 | `modules/acme-certificate/` | Terraform module managing accounts, DNS plugins, certificates |
 | BPG Proxmox provider | Translates Terraform HCL into Proxmox API calls |
 | AWS Route53 | DNS-01 challenge: creates `_acme-challenge` TXT records |
@@ -52,7 +52,7 @@ Terraform (local) ──► BPG Proxmox Provider ──► Proxmox VE API
 Before applying, configure the following secrets in Doppler:
 
 | Secret | Description |
-|---|---|
+| --- | --- |
 | `ROUTE53_ACCESS_KEY` | AWS IAM access key with Route53 permissions |
 | `ROUTE53_SECRET_KEY` | AWS IAM secret key |
 | `ROUTE53_ZONE_ID` | Route53 hosted zone ID for the target domain |
@@ -88,6 +88,14 @@ Minimum required IAM policy for Route53:
 
 ### Terraform Variables (`terraform.tfvars`)
 
+The Doppler secrets named `ROUTE53_ACCESS_KEY` / `ROUTE53_SECRET_KEY` are mapped to
+the standard `AWS_*` keys that the BPG Proxmox provider expects via the
+[Doppler config name-transformer](https://docs.doppler.com/docs/cli-name-transformers)
+configured for this project. The Terraform variable `dns_plugins` then references
+those (now-canonically-named) secrets via the `TF_VAR_dns_plugins` env var that
+`doppler run -- terragrunt apply` injects — `terraform.tfvars` itself does not
+read environment variables.
+
 ```hcl
 acme_accounts = {
   "letsencrypt" = {
@@ -97,16 +105,19 @@ acme_accounts = {
   }
 }
 
-dns_plugins = {
-  "myroute53" = {
-    plugin_type = "route53"
-    data = {
-      "AWS_ACCESS_KEY_ID"     = "<injected by Doppler>"
-      "AWS_SECRET_ACCESS_KEY" = "<injected by Doppler>"
-      "AWS_DEFAULT_REGION"    = "us-east-1"
-    }
-  }
-}
+# dns_plugins is provided by Doppler as TF_VAR_dns_plugins (JSON), NOT in terraform.tfvars.
+# Example shape (do not commit literal credentials):
+#
+# dns_plugins = {
+#   "myroute53" = {
+#     plugin_type = "route53"
+#     data = {
+#       "AWS_ACCESS_KEY_ID"     = "<from doppler ROUTE53_ACCESS_KEY>"
+#       "AWS_SECRET_ACCESS_KEY" = "<from doppler ROUTE53_SECRET_KEY>"
+#       "AWS_DEFAULT_REGION"    = "us-east-1"
+#     }
+#   }
+# }
 
 acme_certificates = {
   "pve-cert" = {
@@ -168,14 +179,21 @@ pvenode acme cert order
 If Route53 IAM credentials are rotated:
 
 1. Update secrets in Doppler
+
 2. Re-apply Terraform to push new credentials to Proxmox:
+
    ```bash
    aws-vault exec tf-proxmox -- doppler run -- terragrunt apply
    ```
+
 3. Verify Proxmox has the updated credentials:
+
    ```bash
-   # Proxmox stores credentials in encrypted cluster storage
+   # Confirm the node references the right ACME account + domains
    pvesh get /nodes/pve/config --output-format=json | jq '.acme'
+
+   # Verify the DNS plugin (cluster-wide resource — credentials are masked)
+   pvesh get /cluster/acme/plugins/myroute53 --output-format=json
    ```
 
 ---
@@ -185,19 +203,22 @@ If Route53 IAM credentials are rotated:
 If ACME resources were created manually in Proxmox before Terraform management was added:
 
 ```bash
+# Note: the `acme_certificates` module is declared with `count = length(...) > 0 ? 1 : 0`,
+# so the resource addresses include the `[0]` index.
+
 # Import ACME account
-terraform import \
-  'module.acme_certificates.proxmox_virtual_environment_acme_account.accounts["letsencrypt"]' \
+terragrunt run -- terraform import \
+  'module.acme_certificates[0].proxmox_virtual_environment_acme_account.accounts["letsencrypt"]' \
   'letsencrypt'
 
 # Import DNS plugin
-terraform import \
-  'module.acme_certificates.proxmox_virtual_environment_acme_dns_plugin.dns_plugins["myroute53"]' \
+terragrunt run -- terraform import \
+  'module.acme_certificates[0].proxmox_virtual_environment_acme_dns_plugin.dns_plugins["myroute53"]' \
   'myroute53'
 
 # Import certificate (node name as the ID)
-terraform import \
-  'module.acme_certificates.proxmox_virtual_environment_acme_certificate.certificates["pve-cert"]' \
+terragrunt run -- terraform import \
+  'module.acme_certificates[0].proxmox_virtual_environment_acme_certificate.certificates["pve-cert"]' \
   'pve'
 ```
 
@@ -217,11 +238,15 @@ it cannot find the `_acme-challenge` TXT record.
 
 1. Verify Route53 IAM credentials in Doppler are valid
 2. Confirm IAM policy includes `route53:ChangeResourceRecordSets` and `route53:GetChange`
+
 3. Check DNS propagation:
+
    ```bash
    dig -t TXT _acme-challenge.pve.example.com @8.8.8.8
    ```
+
 4. Review Proxmox certificate logs:
+
    ```bash
    journalctl -u pve-daily-update.service -n 50
    ```
@@ -233,15 +258,20 @@ it cannot find the `_acme-challenge` TXT record.
 **Checks:**
 
 1. Check if Proxmox can reach Let's Encrypt:
+
    ```bash
    curl -I https://acme-v02.api.letsencrypt.org/directory
    ```
+
 2. Verify Route53 credentials have not expired:
+
    ```bash
    # Re-apply Terraform to refresh credentials
    aws-vault exec tf-proxmox -- doppler run -- terragrunt apply
    ```
+
 3. Confirm `pveproxy` is running:
+
    ```bash
    systemctl status pveproxy
    ```
@@ -253,10 +283,12 @@ it cannot find the `_acme-challenge` TXT record.
 **Checks:**
 
 1. Inspect imported state:
+
    ```bash
-   terraform state show \
-     'module.acme_certificates.proxmox_virtual_environment_acme_account.accounts["letsencrypt"]'
+   terragrunt run -- terraform state show \
+     'module.acme_certificates[0].proxmox_virtual_environment_acme_account.accounts["letsencrypt"]'
    ```
+
 2. Compare `email` and `directory` values against `terraform.tfvars`
 3. Update `terraform.tfvars` to match current Proxmox state, then re-plan
 

--- a/ACME_CERTIFICATE_MANAGEMENT.md
+++ b/ACME_CERTIFICATE_MANAGEMENT.md
@@ -1,0 +1,288 @@
+# ACME Certificate Management
+
+Operational guide for managing Let's Encrypt TLS certificates on Proxmox VE using
+Terraform and AWS Route53 DNS-01 challenge validation.
+
+For module-level reference (variables, outputs, usage examples), see
+[`modules/acme-certificate/README.md`](modules/acme-certificate/README.md).
+
+---
+
+## Architecture Overview
+
+```
+Terraform (local) ──► BPG Proxmox Provider ──► Proxmox VE API
+                                                     │
+                              Route53 DNS-01 ◄────── pve-daily-update.service
+                                    │                     (auto-renewal)
+                              Let's Encrypt
+```
+
+### Components
+
+| Component | Role |
+|---|---|
+| `modules/acme-certificate/` | Terraform module managing accounts, DNS plugins, certificates |
+| BPG Proxmox provider | Translates Terraform HCL into Proxmox API calls |
+| AWS Route53 | DNS-01 challenge: creates `_acme-challenge` TXT records |
+| `pve-daily-update.service` | Proxmox systemd service that renews certificates 30 days before expiry |
+| Doppler | Injects Route53 IAM credentials at deploy time and stores them in Proxmox |
+
+### Secret Flow
+
+**Initial provisioning (Terraform apply):**
+
+1. Run: `aws-vault exec tf-proxmox -- doppler run -- terragrunt apply`
+2. Doppler injects `ROUTE53_ACCESS_KEY`, `ROUTE53_SECRET_KEY`, `ROUTE53_ZONE_ID`, `ACME_EMAIL`, `ACME_DOMAIN`
+3. Terraform configures the BPG Proxmox DNS plugin via API
+4. Proxmox stores credentials in `/etc/pve/priv/acme/plugins.cfg` (encrypted cluster filesystem)
+
+**Automatic renewal (no Doppler required):**
+
+1. `pve-daily-update.service` runs daily
+2. Proxmox reads credentials from `/etc/pve/priv/acme/plugins.cfg`
+3. Creates DNS TXT record in Route53, validates with Let's Encrypt, installs renewed certificate
+
+---
+
+## Configuration Guide
+
+### Doppler Secrets
+
+Before applying, configure the following secrets in Doppler:
+
+| Secret | Description |
+|---|---|
+| `ROUTE53_ACCESS_KEY` | AWS IAM access key with Route53 permissions |
+| `ROUTE53_SECRET_KEY` | AWS IAM secret key |
+| `ROUTE53_ZONE_ID` | Route53 hosted zone ID for the target domain |
+| `ACME_EMAIL` | Email address for Let's Encrypt account notifications |
+| `ACME_DOMAIN` | FQDN for the certificate (e.g., `pve.example.com`) |
+
+Minimum required IAM policy for Route53:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "route53:GetChange",
+        "route53:ChangeResourceRecordSets",
+        "route53:ListResourceRecordSets"
+      ],
+      "Resource": [
+        "arn:aws:route53:::hostedzone/<ZONE_ID>",
+        "arn:aws:route53:::change/*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": "route53:ListHostedZones",
+      "Resource": "*"
+    }
+  ]
+}
+```
+
+### Terraform Variables (`terraform.tfvars`)
+
+```hcl
+acme_accounts = {
+  "letsencrypt" = {
+    email     = "admin@example.com"
+    directory = "https://acme-v02.api.letsencrypt.org/directory"
+    tos       = "https://letsencrypt.org/documents/LE-SA-v1.4-April-3-2024.pdf"
+  }
+}
+
+dns_plugins = {
+  "myroute53" = {
+    plugin_type = "route53"
+    data = {
+      "AWS_ACCESS_KEY_ID"     = "<injected by Doppler>"
+      "AWS_SECRET_ACCESS_KEY" = "<injected by Doppler>"
+      "AWS_DEFAULT_REGION"    = "us-east-1"
+    }
+  }
+}
+
+acme_certificates = {
+  "pve-cert" = {
+    node_name     = "pve"
+    domain        = "pve.example.com"
+    account_id    = "letsencrypt"
+    dns_plugin_id = "myroute53"
+  }
+}
+```
+
+Use the Let's Encrypt staging directory (`https://acme-staging-v02.api.letsencrypt.org/directory`) for
+testing to avoid production rate limits.
+
+### Applying
+
+```bash
+aws-vault exec tf-proxmox -- doppler run -- terragrunt apply
+```
+
+---
+
+## Renewal Procedures
+
+### Automatic Renewal
+
+Proxmox renews certificates automatically 30 days before expiry via `pve-daily-update.service`.
+No manual action is required as long as:
+
+- Proxmox can reach Let's Encrypt and AWS Route53
+- Credentials in `/etc/pve/priv/acme/plugins.cfg` are valid
+
+Monitor the renewal timer:
+
+```bash
+# Check timer status
+systemctl status pve-daily-update.timer
+
+# Review recent renewal attempts
+journalctl -u pve-daily-update.service --since "7 days ago"
+
+# Check certificate expiry
+pvenode acme cert list
+```
+
+### Manual Renewal
+
+Force certificate renewal outside the automatic schedule:
+
+```bash
+# Renew via Proxmox CLI
+pvenode acme cert order
+
+# Or via Proxmox web UI: Datacenter → node → Certificates → Order Certificate
+```
+
+### Rotation After Credential Change
+
+If Route53 IAM credentials are rotated:
+
+1. Update secrets in Doppler
+2. Re-apply Terraform to push new credentials to Proxmox:
+   ```bash
+   aws-vault exec tf-proxmox -- doppler run -- terragrunt apply
+   ```
+3. Verify Proxmox has the updated credentials:
+   ```bash
+   # Proxmox stores credentials in encrypted cluster storage
+   pvesh get /nodes/pve/config --output-format=json | jq '.acme'
+   ```
+
+---
+
+## Importing Existing Certificates
+
+If ACME resources were created manually in Proxmox before Terraform management was added:
+
+```bash
+# Import ACME account
+terraform import \
+  'module.acme_certificates.proxmox_virtual_environment_acme_account.accounts["letsencrypt"]' \
+  'letsencrypt'
+
+# Import DNS plugin
+terraform import \
+  'module.acme_certificates.proxmox_virtual_environment_acme_dns_plugin.dns_plugins["myroute53"]' \
+  'myroute53'
+
+# Import certificate (node name as the ID)
+terraform import \
+  'module.acme_certificates.proxmox_virtual_environment_acme_certificate.certificates["pve-cert"]' \
+  'pve'
+```
+
+After import, run `terraform plan` and verify zero drift. If the plan shows changes, align
+`terraform.tfvars` values to match what Proxmox reports.
+
+---
+
+## Troubleshooting
+
+### DNS validation fails during certificate order
+
+**Symptoms:** `terraform apply` fails with ACME DNS-01 challenge error; Let's Encrypt reports
+it cannot find the `_acme-challenge` TXT record.
+
+**Checks:**
+
+1. Verify Route53 IAM credentials in Doppler are valid
+2. Confirm IAM policy includes `route53:ChangeResourceRecordSets` and `route53:GetChange`
+3. Check DNS propagation:
+   ```bash
+   dig -t TXT _acme-challenge.pve.example.com @8.8.8.8
+   ```
+4. Review Proxmox certificate logs:
+   ```bash
+   journalctl -u pve-daily-update.service -n 50
+   ```
+
+### Certificate renewal fails silently
+
+**Symptoms:** Certificate approaches expiry; no renewal in logs; `pve-daily-update.service` shows errors.
+
+**Checks:**
+
+1. Check if Proxmox can reach Let's Encrypt:
+   ```bash
+   curl -I https://acme-v02.api.letsencrypt.org/directory
+   ```
+2. Verify Route53 credentials have not expired:
+   ```bash
+   # Re-apply Terraform to refresh credentials
+   aws-vault exec tf-proxmox -- doppler run -- terragrunt apply
+   ```
+3. Confirm `pveproxy` is running:
+   ```bash
+   systemctl status pveproxy
+   ```
+
+### `terraform plan` shows unexpected drift after import
+
+**Symptoms:** After `terraform import`, plan shows changes to imported resources.
+
+**Checks:**
+
+1. Inspect imported state:
+   ```bash
+   terraform state show \
+     'module.acme_certificates.proxmox_virtual_environment_acme_account.accounts["letsencrypt"]'
+   ```
+2. Compare `email` and `directory` values against `terraform.tfvars`
+3. Update `terraform.tfvars` to match current Proxmox state, then re-plan
+
+### Rate limit errors from Let's Encrypt
+
+**Symptoms:** Certificate order fails with "too many certificates already issued".
+
+**Resolution:** Use the staging directory for testing:
+
+```hcl
+acme_accounts = {
+  "letsencrypt-staging" = {
+    directory = "https://acme-staging-v02.api.letsencrypt.org/directory"
+    ...
+  }
+}
+```
+
+Switch back to production once testing is complete.
+
+---
+
+## References
+
+- [`modules/acme-certificate/README.md`](modules/acme-certificate/README.md) — module variables, outputs, and usage examples
+- [BPG Proxmox Provider — ACME resources](https://registry.terraform.io/providers/bpg/proxmox/latest/docs)
+- [Proxmox Certificate Management](https://pve.proxmox.com/wiki/Certificate_Management)
+- [Let's Encrypt Rate Limits](https://letsencrypt.org/docs/rate-limits/)
+- [Route53 DNS-01 Challenge](https://letsencrypt.org/docs/challenge-types/#dns-01-challenge)


### PR DESCRIPTION
Closes #64

## Problem

`ACME_CERTIFICATE_MANAGEMENT.md` does not exist in the repository root. Operators have no single reference for the Let's Encrypt certificate architecture, Doppler secret setup, renewal procedures, or troubleshooting steps.

## Approach

Create `ACME_CERTIFICATE_MANAGEMENT.md` at the repo root covering:
- Architecture diagram and component roles (BPG provider, Route53 DNS-01, Proxmox auto-renewal, Doppler secret flow)
- Doppler secret requirements and minimum IAM policy for Route53
- `terraform.tfvars` example with staging vs production ACME directory guidance
- Automatic and manual renewal procedures with monitoring commands
- Import commands for pre-existing Proxmox certificates
- Troubleshooting for DNS validation failures, silent renewal failures, Terraform drift, and rate limits

The existing `modules/acme-certificate/README.md` (already complete) is referenced for module-specific variable/output details.

## Files changed

- `ACME_CERTIFICATE_MANAGEMENT.md` — new operational guide for ACME certificate management

## CI status

passed — all checks green (Markdown Lint, File Size, CodeQL, Merge Gate)

## Self-review

This PR was drafted by Issue Solver and is opened as a DRAFT for human review before merge. The Hard Rules in the prompt enforce: signed commits via Contents API, no dependency changes, no infra/workflow edits, secret-pattern pre-flight scan.

---

Generated by Issue Solver — prompt source: <https://github.com/JacobPEvans/claude-code-routines/blob/main/routines/issue-solver.prompt.md>