### PR TITLE
fix(ci): remove deprecated app-id secret passthrough

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,5 +13,4 @@ jobs:
       pull-requests: write
     uses: JacobPEvans/.github/.github/workflows/_release-please.yml@main
     secrets:
-      GH_ACTION_JACOBPEVANS_APP_ID: ${{ secrets.GH_ACTION_JACOBPEVANS_APP_ID }}
       GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}

--- a/.github/workflows/retrigger-pr-checks.yml
+++ b/.github/workflows/retrigger-pr-checks.yml
@@ -19,5 +19,4 @@ jobs:
   retrigger:
     uses: JacobPEvans/.github/.github/workflows/_retrigger-pr-checks.yml@main
     secrets:
-      GH_ACTION_JACOBPEVANS_APP_ID: ${{ secrets.GH_ACTION_JACOBPEVANS_APP_ID }}
       GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary
- Removes `GH_ACTION_JACOBPEVANS_APP_ID` from the `secrets:` block in reusable workflow callers
- The central reusable workflows now read the GitHub App Client ID from `vars.GH_APP_CLIENT_ID` (distributed by secrets-sync)

**Depends on:** JacobPEvans/secrets-sync#74 → JacobPEvans/.github#268 → this PR

## Changes
- Removed deprecated `GH_ACTION_JACOBPEVANS_APP_ID` secret passthrough from `.github/workflows/release-please.yml` and `.github/workflows/retrigger-pr-checks.yml`

## Test Plan
- [x] No functional change until secrets-sync#74 and .github#268 merge in order

🤖 Generated with [Claude Code](https://claude.com/claude-code)