### PR TITLE
🤖 Fix #126: re-enable checkov security scanning in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,19 +40,13 @@ repos:
           - --args=--only=terraform_required_providers
           - --args=--only=terraform_standard_module_structure
 
-  # Checkov and Terrascan temporarily disabled - require environment fixes
-  # TODO: Re-enable after fixing rustworkx Rust compiler requirement
-  # - repo: https://github.com/bridgecrewio/checkov.git
-  #   rev: 3.2.255
-  #   hooks:
-  #     - id: checkov
-  #       args: ['-d', '.', '--framework', 'terraform']
-  #
-  # - repo: https://github.com/tenable/terrascan
-  #   rev: v1.19.9
-  #   hooks:
-  #     - id: terraform-pre-commit
-  #       args: ['scan', '-i', 'terraform', '-t', 'all']
+  # Checkov - Terraform IaC security scanner
+  - repo: https://github.com/bridgecrewio/checkov.git
+    rev: 3.2.526
+    hooks:
+      - id: checkov
+        args: ['-d', '.', '--framework', 'terraform', '--quiet']
+        pass_filenames: false
 
   # Local hooks using nix+doppler toolchain
   - repo: local


### PR DESCRIPTION
Closes #126

## Problem

`.pre-commit-config.yaml` had both Checkov and Terrascan commented out with a TODO noting they were disabled due to a `rustworkx` Rust compiler requirement. The pinned version (`3.2.255`) was old and the Rust build issue was addressed in later releases. Modern Checkov ships pre-built `rustworkx` wheels, so no Rust toolchain is needed.

## Approach

Re-enable the Checkov hook with the latest version (`3.2.526`) and add `--quiet` to reduce noise. Terrascan is dropped in favour of Checkov alone (per issue option 3 — simplest, no added maintenance burden).

## Files changed

- `.pre-commit-config.yaml` — uncomment Checkov hook, bump rev from `3.2.255` → `3.2.526`, add `--quiet` flag; drop Terrascan block

## CI status

pending — checks URL: https://github.com/JacobPEvans/terraform-proxmox/commit/dc9d505772b6fe15fc743207058fea0f729c0a87

## Self-review

This PR was drafted by Issue Solver and is opened as a DRAFT for human review before merge. The Hard Rules in the prompt enforce: signed commits via Contents API, no dependency changes, no infra/workflow edits, secret-pattern pre-flight scan.

---

Generated by Issue Solver — prompt source: <https://github.com/JacobPEvans/claude-code-routines/blob/main/routines/issue-solver.prompt.md>
