### PR TITLE
fix(pre-commit): use aws-vault as outer wrapper for terragrunt hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,15 +60,15 @@ repos:
 
       - id: terragrunt-validate
         name: terragrunt validate
-        entry: bash -c 'nix develop "github:JacobPEvans/nix-devenv?dir=shells/terraform" --command bash -c "doppler run -- terragrunt validate"'
+        entry: bash -c 'nix develop "github:JacobPEvans/nix-devenv?dir=shells/terraform" --command bash -c "aws-vault exec tf-proxmox -- doppler run -- terragrunt validate"'
         language: system
         files: '\.(tf|hcl)$'
         pass_filenames: false
-        stages: [pre-push]  # Requires AWS credentials in environment + Doppler
+        stages: [pre-push]  # Requires aws-vault tf-proxmox profile + Doppler
 
       - id: terragrunt-plan
         name: terragrunt plan
-        entry: bash -c 'nix develop "github:JacobPEvans/nix-devenv?dir=shells/terraform" --command bash -c "doppler run -- terragrunt plan -detailed-exitcode"; rc=$?; if [ $rc -eq 0 ] || [ $rc -eq 2 ]; then exit 0; else exit 1; fi'
+        entry: bash -c 'nix develop "github:JacobPEvans/nix-devenv?dir=shells/terraform" --command bash -c "aws-vault exec tf-proxmox -- doppler run -- terragrunt plan -detailed-exitcode"; rc=$?; if [ $rc -eq 0 ] || [ $rc -eq 2 ]; then exit 0; else exit 1; fi'
         language: system
         files: '\.(tf|hcl)$'
         pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,7 +60,7 @@ repos:
 
       - id: terragrunt-validate
         name: terragrunt validate
-        entry: bash -c 'nix develop "github:JacobPEvans/nix-devenv?dir=shells/terraform" --command bash -c "aws-vault exec tf-proxmox -- doppler run -- terragrunt validate"'
+        entry: bash -c 'aws-vault exec tf-proxmox -- nix develop "github:JacobPEvans/nix-devenv?dir=shells/terraform" --command doppler run -- terragrunt validate'
         language: system
         files: '\.(tf|hcl)$'
         pass_filenames: false
@@ -68,7 +68,7 @@ repos:
 
       - id: terragrunt-plan
         name: terragrunt plan
-        entry: bash -c 'nix develop "github:JacobPEvans/nix-devenv?dir=shells/terraform" --command bash -c "aws-vault exec tf-proxmox -- doppler run -- terragrunt plan -detailed-exitcode"; rc=$?; if [ $rc -eq 0 ] || [ $rc -eq 2 ]; then exit 0; else exit 1; fi'
+        entry: bash -c 'aws-vault exec tf-proxmox -- nix develop "github:JacobPEvans/nix-devenv?dir=shells/terraform" --command doppler run -- terragrunt plan -detailed-exitcode; rc=$?; [ $rc -eq 0 ] || [ $rc -eq 2 ]'
         language: system
         files: '\.(tf|hcl)$'
         pass_filenames: false

--- a/aws-infra/modules/route53-records/main.tf
+++ b/aws-infra/modules/route53-records/main.tf
@@ -13,6 +13,7 @@ terraform {
 # A Record for Proxmox VE UI
 # Points the Proxmox domain to the Proxmox host IP address
 resource "aws_route53_record" "proxmox" {
+  #checkov:skip=CKV2_AWS_23: Proxmox is on-premises infrastructure with a static IP; AWS alias resource is architecturally inapplicable
   zone_id = var.route53_zone_id
   name    = var.proxmox_domain
   type    = "A"


### PR DESCRIPTION
## Summary

- Invert command nesting in the `terragrunt-validate` and `terragrunt-plan` pre-push hooks: `aws-vault exec` now wraps `nix develop` (matching `docs/aws-vault-terraform.md`)
- Annotate the Route53 A record for Proxmox with `checkov:skip=CKV2_AWS_23` — Proxmox is on-premises with a static IP; an AWS alias is architecturally inapplicable

## Changes

- `.pre-commit-config.yaml`:
  - `terragrunt-validate`: `aws-vault exec tf-proxmox -- nix develop ... --command doppler run -- terragrunt validate`
  - `terragrunt-plan`: same pattern; simplified exit-code check to `rc=$?; [ $rc -eq 0 ] || [ $rc -eq 2 ]`
- `aws-infra/modules/route53-records/main.tf`: add `#checkov:skip=CKV2_AWS_23` inside `aws_route53_record.proxmox`

## Test Plan

- [x] Pre-commit hooks run without errors in the `fix/pre-commit-hooks-and-checkov` worktree
- [x] `terragrunt validate` passes via CI (Terraform check in CI Gate)
- [x] Checkov check passes (skip annotation resolves CKV2_AWS_23)