### PR TITLE
feat(containers): add OpenProject Community Edition LXC

### DIFF
--- a/deployment.json
+++ b/deployment.json
@@ -228,6 +228,21 @@
       ],
       "features": { "nesting": true, "keyctl": true, "fuse": true }
     },
+    "openproject": {
+      "vm_id": 140,
+      "hostname": "openproject",
+      "description": "OpenProject Community Edition - project management platform (Docker in LXC)",
+      "cpu_cores": 2,
+      "memory_dedicated": 4096,
+      "memory_swap": 4096,
+      "tags": ["terraform", "container", "openproject", "projects", "docker"],
+      "pool_id": "infrastructure",
+      "root_disk": { "size": 16 },
+      "mount_points": [
+        { "volume": "local-zfs", "size": "50G", "path": "/opt/openproject" }
+      ],
+      "features": { "nesting": true, "keyctl": true, "fuse": true }
+    },
     "claude-code-01": {
       "vm_id": 150,
       "hostname": "claude-code-01",

--- a/deployment.json
+++ b/deployment.json
@@ -234,9 +234,10 @@
       "description": "OpenProject Community Edition - project management platform (Docker in LXC)",
       "cpu_cores": 2,
       "memory_dedicated": 4096,
-      "memory_swap": 4096,
+      "memory_swap": 12288,
       "tags": ["terraform", "container", "openproject", "projects", "docker"],
       "pool_id": "infrastructure",
+      "unprivileged": true,
       "root_disk": { "size": 16 },
       "mount_points": [
         { "volume": "local-zfs", "size": "50G", "path": "/opt/openproject" }


### PR DESCRIPTION
## Summary

Adds a self-hosted OpenProject Community Edition LXC (vm_id `140`) to `deployment.json`, sized for the official all-in-one Docker image and following the existing Docker-in-LXC pattern.

- **IP**: auto-derived as `${network_prefix}.140/24` via `local.derive_ip`
- **Pool**: `infrastructure`
- **Resources**: 2 vCPU, 4 GB RAM (+ 12 GB swap, 3x — matches `homeassistant`, `claude-code-*`, `cribl-edge-*`, `splunk-mgmt`, `phpipam` ratio), 16 GB root disk, 50 GB persistent volume at `/opt/openproject`
- **Security**: `unprivileged: true` (kernel UID-namespace isolation)
- **Features**: `nesting + keyctl + fuse` for Docker-in-LXC
- **Tags**: `openproject`, `projects`, `docker` — the `openproject` tag will be the selector for the role added next in **ansible-proxmox-apps**

No changes needed to `main.tf`, `locals.tf`, `outputs.tf`, or the firewall module — the existing for-each in `main.tf` picks up the new container automatically, and untagged web apps inherit cluster-level ACCEPT (same as `homeassistant`, `phpipam`, `prometheus`, `nginx-proxy-manager`). The new container will be auto-synced into `ansible-proxmox-apps/inventory/terraform_inventory.json` via the existing Terragrunt `after_hook`.

> **Note for the Ansible role**: because the container is unprivileged, the `/opt/openproject` bind-mount UID/GID will be remapped (subuid/subgid). The future ansible-proxmox-apps role should account for this when setting ownership on `pgdata`/`assets`/`attachments` inside the volume.

## Test plan

- [ ] `aws-vault exec tf-proxmox -- doppler run -- terragrunt validate`
- [ ] `aws-vault exec tf-proxmox -- doppler run -- terragrunt plan` shows exactly one new LXC (vm 140) and no other diffs
- [ ] `aws-vault exec tf-proxmox -- doppler run -- terragrunt apply`
- [ ] `jq '.containers.openproject' ~/git/ansible-proxmox-apps/main/inventory/terraform_inventory.json` shows the expected vmid/ip/tags
- [ ] `ping ${network_prefix}.140` reachable from the LAN
- [ ] Follow-up role in **ansible-proxmox-apps** stands up the Docker Compose stack and serves the UI on `http://${network_prefix}.140/`