### PR TITLE
🤖 Fix #283: ungate pre-commit hooks; remove aws-vault from scripts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,23 +9,18 @@ repos:
       - id: check-yaml
       - id: check-added-large-files
 
-  # Terraform hooks - require terraform/tflint installed locally
-  # These run in CI via GitHub Actions instead
+  # Terraform hooks - run on every commit (no credentials required)
   - repo: https://github.com/antonbabenko/pre-commit-terraform
     rev: v1.92.0
     hooks:
       - id: terraform_fmt
-        stages: [manual]  # Run manually or in CI, not on every commit
       - id: terraform_validate
-        stages: [manual]
       - id: terraform_docs
-        stages: [manual]
         args:
           - --hook-config=--path-to-file=README.md
           - --hook-config=--add-to-existing-file=true
           - --hook-config=--create-file-if-not-exist=true
       - id: terraform_tflint
-        stages: [manual]
         args:
           - --args=--only=terraform_deprecated_interpolation
           - --args=--only=terraform_deprecated_index
@@ -48,28 +43,12 @@ repos:
         args: ['-d', '.', '--framework', 'terraform', '--quiet']
         pass_filenames: false
 
-  # Local hooks using nix+doppler toolchain
+  # Local hooks using nix toolchain (no credentials required)
   - repo: local
     hooks:
       - id: tofu-test
         name: tofu test (mock providers)
-        entry: bash -c 'nix develop "github:JacobPEvans/nix-devenv?dir=shells/terraform" --command bash -c "tofu init -backend=false -no-color >/dev/null 2>&1 && tofu test -no-color"'
+        entry: bash -c 'tofu init -backend=false -no-color >/dev/null && tofu test -no-color'
         language: system
         files: '\.(tf|hcl)$'
         pass_filenames: false
-
-      - id: terragrunt-validate
-        name: terragrunt validate
-        entry: bash -c 'nix develop "github:JacobPEvans/nix-devenv?dir=shells/terraform" --command bash -c "aws-vault exec tf-proxmox -- doppler run -- terragrunt validate"'
-        language: system
-        files: '\.(tf|hcl)$'
-        pass_filenames: false
-        stages: [pre-push]  # Requires aws-vault tf-proxmox profile + Doppler
-
-      - id: terragrunt-plan
-        name: terragrunt plan
-        entry: bash -c 'nix develop "github:JacobPEvans/nix-devenv?dir=shells/terraform" --command bash -c "aws-vault exec tf-proxmox -- doppler run -- terragrunt plan -detailed-exitcode"; rc=$?; if [ $rc -eq 0 ] || [ $rc -eq 2 ]; then exit 0; else exit 1; fi'
-        language: system
-        files: '\.(tf|hcl)$'
-        pass_filenames: false
-        stages: [pre-push]

--- a/scripts/cleanup-orphaned-vms.sh
+++ b/scripts/cleanup-orphaned-vms.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Cleanup VMs in pool that aren't defined in Terraform
-# Usage: ./scripts/cleanup-orphaned-vms.sh <pool-name>
+# Run as: av tf-proxmox -- doppler run -- ./scripts/cleanup-orphaned-vms.sh <pool-name>
 
 set -euo pipefail
 
@@ -24,7 +24,7 @@ cd "$(dirname "$0")/.."
 
 run_terragrunt() {
     nix develop "github:JacobPEvans/nix-devenv?dir=shells/terraform" --command bash -c \
-        "aws-vault exec tf-proxmox -- doppler run -- terragrunt $*"
+        "doppler run -- terragrunt $*"
 }
 
 # Get VM IDs from state


### PR DESCRIPTION
Partial fix for #283

> **Note:** This PR addresses the pre-commit ungating and aws-vault script cleanup. The `.github/workflows/` CI gate additions are excluded — the agent cannot modify workflow files without an explicit `cicd` label on the issue.

## Problem

Per the `agentsmd/rules/terraform-checks-placement` policy:
- `terraform_fmt`, `terraform_validate`, `terraform_docs`, and `terraform_tflint` were gated behind `stages: [manual]` — they never ran on a normal commit.
- The `terragrunt-validate` and `terragrunt-plan` local hooks embedded `aws-vault exec tf-proxmox --` inside the hook entry, requiring AWS credentials in the pre-commit environment.
- `cleanup-orphaned-vms.sh` embedded `aws-vault exec tf-proxmox --` in its `run_terragrunt` helper, coupling the script to the caller's vault profile rather than expecting credentials from the environment.

## Approach

1. **`.pre-commit-config.yaml`**: Remove `stages: [manual]` from all four terraform hooks. Delete the `terragrunt-validate` and `terragrunt-plan` local hooks (credentials belong in CI, not pre-commit). Replace the `nix develop` wrapper in `tofu-test` with a direct `tofu init ... && tofu test` call.
2. **`scripts/cleanup-orphaned-vms.sh`**: Remove `aws-vault exec tf-proxmox --` from the `run_terragrunt` helper. Update the header comment to document that credentials must be passed externally: `av tf-proxmox -- doppler run -- ./scripts/cleanup-orphaned-vms.sh`.

## Files changed

- `.pre-commit-config.yaml` — ungate static hooks; remove credentialed local hooks; simplify tofu-test
- `scripts/cleanup-orphaned-vms.sh` — remove aws-vault from run_terragrunt; update usage comment

## CI status

none — no check-runs triggered on this branch yet

## Self-review

This PR was drafted by Issue Solver and is opened as a DRAFT for human review before merge. The Hard Rules in the prompt enforce: signed commits via Contents API, no dependency changes, no infra/workflow edits, secret-pattern pre-flight scan.

---

Generated by Issue Solver — prompt source: <https://github.com/JacobPEvans/claude-code-routines/blob/main/routines/issue-solver.prompt.md>
