### PR TITLE
feat(firewall): add idrac-kvm VM 251 with tag-driven internal firewall

### DIFF
--- a/deployment.json
+++ b/deployment.json
@@ -101,6 +101,7 @@
       "tags": ["terraform", "docker", "idrac", "oob", "management"],
       "pool_id": "infrastructure",
       "boot_disk": { "datastore_id": "local-zfs", "size": 16 },
+      "network_interfaces": [{ "bridge": "vmbr0", "firewall": true }],
       "clone_template": { "template_id": 9000 },
       "user_account": { "username": "debian", "password": "", "keys": [] }
     }

--- a/deployment.json
+++ b/deployment.json
@@ -91,6 +91,18 @@
       "additional_disks": [{ "datastore_id": "local-zfs", "interface": "scsi1", "size": 100 }],
       "clone_template": { "template_id": 9000 },
       "user_account": { "username": "debian", "password": "", "keys": [] }
+    },
+    "idrac-kvm": {
+      "vm_id": 251,
+      "name": "idrac-kvm",
+      "description": "Vendor domistyle/idrac6 containers (R410 + R710). HTML5 iDRAC KVM. Vendor Docker image only.",
+      "cpu_cores": 1,
+      "memory_dedicated": 2048,
+      "tags": ["terraform", "docker", "idrac", "oob", "management"],
+      "pool_id": "infrastructure",
+      "boot_disk": { "datastore_id": "local-zfs", "size": 16 },
+      "clone_template": { "template_id": 9000 },
+      "user_account": { "username": "debian", "password": "", "keys": [] }
     }
   },
 

--- a/locals.tf
+++ b/locals.tf
@@ -72,6 +72,12 @@ locals {
     for k, v in var.containers : k => v.vm_id
     if contains(coalesce(try(v.tags, null), []), "cribl") && contains(coalesce(try(v.tags, null), []), "stream")
   }
+
+  # iDRAC KVM VMs: tagged "idrac" (domistyle/idrac6 containers on dedicated Docker VM)
+  idrac_kvm_vm_ids = {
+    for k, v in var.vms : k => v.vm_id
+    if contains(coalesce(try(v.tags, null), []), "idrac")
+  }
 }
 
 # Pipeline constants - single source of truth for service, syslog, NetFlow, notification, and vector DB ports

--- a/main.tf
+++ b/main.tf
@@ -191,6 +191,9 @@ module "firewall" {
   # MinIO object storage containers (minio tag)
   minio_container_ids = local.minio_container_ids
 
+  # iDRAC KVM VMs: tagged "idrac" (domistyle/idrac6 containers on dedicated Docker VM)
+  idrac_kvm_vm_ids = local.idrac_kvm_vm_ids
+
   management_network = local.management_network
   splunk_network     = join(",", local.splunk_network_ips)
   internal_networks  = var.internal_networks

--- a/modules/firewall/locals.tf
+++ b/modules/firewall/locals.tf
@@ -81,4 +81,10 @@ locals {
     { proto = "udp", dest = local.internal_src, comment = "Outbound UDP to internal" },
     { proto = "icmp", dest = local.internal_src, comment = "Outbound ICMP to internal" },
   ]
+
+  # iDRAC KVM: inbound noVNC HTTP ports from internal; egress reuses outbound_internal
+  idrac_kvm_services_rules = [
+    { proto = "tcp", dport = "5800", source = local.internal_src, comment = "iDRAC HTML5 KVM R410 from internal" },
+    { proto = "tcp", dport = "5801", source = local.internal_src, comment = "iDRAC HTML5 KVM R710 from internal" },
+  ]
 }

--- a/modules/firewall/locals.tf
+++ b/modules/firewall/locals.tf
@@ -84,7 +84,7 @@ locals {
 
   # iDRAC KVM: inbound noVNC HTTP ports from internal; egress reuses outbound_internal
   idrac_kvm_services_rules = [
-    { proto = "tcp", dport = "5800", source = local.internal_src, comment = "iDRAC HTML5 KVM R410 from internal" },
-    { proto = "tcp", dport = "5801", source = local.internal_src, comment = "iDRAC HTML5 KVM R710 from internal" },
+    { proto = "tcp", dport = "5800", source = local.internal_src, comment = "iDRAC HTML5 KVM R410 (TCP 5800) from internal" },
+    { proto = "tcp", dport = "5801", source = local.internal_src, comment = "iDRAC HTML5 KVM R710 (TCP 5801) from internal" },
   ]
 }

--- a/modules/firewall/security_groups.tf
+++ b/modules/firewall/security_groups.tf
@@ -266,3 +266,20 @@ resource "proxmox_virtual_environment_cluster_firewall_security_group" "ntp_serv
     }
   }
 }
+
+resource "proxmox_virtual_environment_cluster_firewall_security_group" "idrac_kvm_svc" {
+  name    = "idrac-kvm-svc"
+  comment = "iDRAC KVM HTML5 noVNC ports (5800, 5801) from internal networks"
+
+  dynamic "rule" {
+    for_each = local.idrac_kvm_services_rules
+    content {
+      type    = "in"
+      action  = "ACCEPT"
+      proto   = rule.value.proto
+      dport   = rule.value.dport
+      source  = rule.value.source
+      comment = rule.value.comment
+    }
+  }
+}

--- a/modules/firewall/variables.tf
+++ b/modules/firewall/variables.tf
@@ -57,6 +57,12 @@ variable "minio_container_ids" {
   default     = {}
 }
 
+variable "idrac_kvm_vm_ids" {
+  description = "Map of iDRAC KVM host VM names to IDs (tag-driven, set by root locals)"
+  type        = map(number)
+  default     = {}
+}
+
 variable "management_network" {
   description = "CIDR of management network for SSH/Web access. Configure in terraform.tfvars for your environment."
   type        = string

--- a/modules/firewall/vm_rules.tf
+++ b/modules/firewall/vm_rules.tf
@@ -81,7 +81,7 @@ resource "proxmox_virtual_environment_firewall_rules" "idrac_kvm" {
 
   rule {
     security_group = proxmox_virtual_environment_cluster_firewall_security_group.idrac_kvm_svc.name
-    comment        = "iDRAC KVM HTML5 noVNC (5800, 5801)"
+    comment        = "iDRAC KVM HTML5 noVNC (TCP 5800, 5801)"
   }
 
   rule {

--- a/modules/firewall/vm_rules.tf
+++ b/modules/firewall/vm_rules.tf
@@ -49,3 +49,45 @@ resource "proxmox_virtual_environment_firewall_rules" "splunk_vm" {
 
   depends_on = [proxmox_virtual_environment_firewall_options.splunk_vm]
 }
+
+# =============================================================================
+# iDRAC KVM VM Firewall Configuration
+# =============================================================================
+
+resource "proxmox_virtual_environment_firewall_options" "idrac_kvm" {
+  for_each = var.idrac_kvm_vm_ids
+
+  node_name     = var.node_name
+  vm_id         = each.value
+  enabled       = local.firewall_defaults.enabled
+  input_policy  = local.firewall_defaults.input_policy
+  output_policy = local.firewall_defaults.output_policy
+  log_level_in  = local.firewall_defaults.log_level_in
+  log_level_out = local.firewall_defaults.log_level_out
+
+  depends_on = [proxmox_virtual_environment_cluster_firewall.main]
+}
+
+resource "proxmox_virtual_environment_firewall_rules" "idrac_kvm" {
+  for_each = var.idrac_kvm_vm_ids
+
+  node_name = var.node_name
+  vm_id     = each.value
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.internal_access.name
+    comment        = "Internal access (SSH, ICMP)"
+  }
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.idrac_kvm_svc.name
+    comment        = "iDRAC KVM HTML5 noVNC (5800, 5801)"
+  }
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.outbound_internal.name
+    comment        = "Outbound to internal only (covers iDRAC BMC egress on 443/5900)"
+  }
+
+  depends_on = [proxmox_virtual_environment_firewall_options.idrac_kvm]
+}

--- a/terraform.sops.json
+++ b/terraform.sops.json
@@ -1,18 +1,18 @@
 {
-	"domain": "ENC[AES256_GCM,data:Y3L4e+m4m4ViB0+wOJ6+,iv:QZEYQpjcvxHpPgMgM2rfQuWluFkwmoXq8VTXnmX6JII=,tag:Xp2a4/VXUvqsfts+HBXqcA==,type:str]",
-	"network_prefix": "ENC[AES256_GCM,data:/7ffzsqb,iv:EeRIw6wMbI9x5KD5dJA225eENwIht3/9r7I8RfTK864=,tag:m5OG4gRN2Ue9UN6YV4ipkg==,type:str]",
-	"vm_ssh_public_key_path": "ENC[AES256_GCM,data:8/zDv2w+5QA7dhBHnm7BR8mn+lk=,iv:HsPYx+n05mftqghhvvlrSqhIMM453SoILzO0Z76w9rQ=,tag:AMqPcJ52O3QgKyRnYZslvg==,type:str]",
-	"vm_ssh_private_key_path": "ENC[AES256_GCM,data:PK2R1FI5j/NxBFzPoj13lA==,iv:+kxuxz9UnO07ckO8wC37JuShKRAwv43gfViGcpO+mn4=,tag:54P9c6qarnVXiUtXbdEsiQ==,type:str]",
-	"proxmox_ssh_username": "ENC[AES256_GCM,data:eZN2hQ==,iv:o/BGRyUs/ILeYG87acAJc7ZBmMAykyRTiu4MYAB85B4=,tag:2MmDjJKwrW/RgO8MlAg/mQ==,type:str]",
+	"domain": "ENC[AES256_GCM,data:DNnrNRzIIxdwtAqFiTrj,iv:xcGBGEqvW6uyv30f5bvAiDhTHSMWP59SmWwbsU6hxIY=,tag:jsSa83fsJ5HffqvVjFryZg==,type:str]",
+	"network_prefix": "ENC[AES256_GCM,data:VApTgEIz,iv:ktksY2qSjvXY3fOuVyYf162xy5f/BfxLT2WP1M3xL60=,tag:DmFfle3QFB7WejQ8nEtynQ==,type:str]",
+	"vm_ssh_public_key_path": "ENC[AES256_GCM,data:VXFFu5N5zeH8Lp0BFR02iWQbU+4=,iv:c+o6Wh2uPjZdkgxmutm4vrnmOLuQWRkplM+5zoEj+Gs=,tag:BK7rF42PBDaefPgFkTSpmg==,type:str]",
+	"vm_ssh_private_key_path": "ENC[AES256_GCM,data:viaPT9Fy17DTsrnX96ZWLw==,iv:LNsu2QY4FlA5vEd2sSLoCWdqZSFyJjJKkNDfJMQpbQg=,tag:IDaUmVZweuIaNVxxOJQtxQ==,type:str]",
+	"proxmox_ssh_username": "ENC[AES256_GCM,data:J0I4nw==,iv:hsHkoBHBrKemNmxagPOgR+lvcMrATcDRUmxheNCVJa0=,tag:ebYHcF3G65t4MPuT5m5fxA==,type:str]",
 	"sops": {
 		"age": [
 			{
 				"recipient": "age1y0jvtlp2ac8fwwvh2nzm88ehye74jlseywjrjcjqll7u8vycsedq788tp9",
-				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBUQi90UHpJbWVGaWwxLy91\na2I2OE80UCtweHFjbWFwSnUwb1JXcGQwWGlnCmdmTzlwSUdscDRoVGtDdEFDOEFF\nWDZENzlzMVg3ZGRSQXhYQmhJWVlBTzQKLS0tIGl3dEgwYUthVkIzS3gzMWNTTzhZ\nK2tPSGJIUUluWEUwVWt6UzRBUlViNnMKui5IQscD0rTsOfulOUyhi8pPQUFn2+6L\nKmN4s09sJxeZeXzBUpnD5V+9xgnZHAh/8bBaEdAAmSB4qdaXYvdtEA==\n-----END AGE ENCRYPTED FILE-----\n"
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBuODVPV1pIQ21vMFg2WXhU\nd2piN3Vtc3d2eFYyMzNLcUl1RGVLendCTzAwCmRJNWQzbWtwUnMvRE9OOWYrU09T\nTzhnWThnU3pUc2Y3UFZIS0FsMktWUUkKLS0tIGJRdVpVTGFSMmNLYnhkYndCNmxk\nVEJrRUFoSFQwbFhLUlM0Qyt6MFVBd0UKbDcikfaO1Wi+2qq2mU7mTMT82vdAGc1f\nXu4RW3uNMn4Otoj2reDLPhToGsJUxEuo5wUy4q/0VmLTqviHo2fqIQ==\n-----END AGE ENCRYPTED FILE-----\n"
 			}
 		],
-		"lastmodified": "2026-03-14T03:02:37Z",
-		"mac": "ENC[AES256_GCM,data:0/c2L5k+G1z1u9fVf3bTBgAd/LpgGybQYWenPCGVFDHExWUYfc+VgXtIMyE3OoyBeO6MH7GoNcjS3Cmfk2FnENJqST7U6ETqlU4tgxQ6xGPKXPCdTld/QxbKDQP2FvMM9D+7k1BZBPylQUe/3A+fhVLJk315Du3j0BbHfmbmLz4=,iv:r+zyFPFOQLPRxpcFVK6Tm2ZN+I5bgLF4t3QpJRZTlGk=,tag:oWRrNeilHY1P5iyvWgaJpQ==,type:str]",
+		"lastmodified": "2026-05-16T22:52:47Z",
+		"mac": "ENC[AES256_GCM,data:X30IKakIcZ6O1FN4N1Run8u5wTLp4osdmdX2/8H1nS/ui3BsHNh1XqL1qe8Qqmhpb2e5soCToJrgH7hZ/DANmc/3IUFgI2YFu0xpIKv/+0f33OLo29DeuJzQbDiFOD+ep6TDpiekDt902pkB1A0fiBEe6dDEsHZ5E8lXJmlL83M=,iv:Fj7rA6Ak1/druuwgHYSdaan8l5Dt7Z/ggbJJvYRstOM=,tag:EI8pFbCPB2L4xDgxaMkO7A==,type:str]",
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.12.1"
 	}

--- a/tests/firewall_filtering.tftest.hcl
+++ b/tests/firewall_filtering.tftest.hcl
@@ -342,3 +342,53 @@ run "pipeline_and_stream_containers_mutually_exclusive" {
     error_message = "pipeline_container_ids and cribl_stream_container_ids must be mutually exclusive"
   }
 }
+
+# --- idrac_kvm_vm_ids tests ---
+
+run "idrac_tagged_vm_in_idrac_kvm_vm_ids" {
+  command = plan
+
+  variables {
+    vms = {
+      "idrac-kvm" = {
+        vm_id = 251
+        name  = "idrac-kvm"
+        tags  = ["terraform", "docker", "idrac", "oob", "management"]
+      }
+    }
+  }
+
+  assert {
+    condition     = contains(keys(local.idrac_kvm_vm_ids), "idrac-kvm")
+    error_message = "VM with 'idrac' tag must be in idrac_kvm_vm_ids"
+  }
+
+  assert {
+    condition     = local.idrac_kvm_vm_ids["idrac-kvm"] == 251
+    error_message = "idrac_kvm_vm_ids['idrac-kvm'] should be vm_id 251"
+  }
+}
+
+run "non_idrac_vm_not_in_idrac_kvm_vm_ids" {
+  command = plan
+
+  variables {
+    vms = {
+      "docker-host" = {
+        vm_id = 250
+        name  = "docker-host"
+        tags  = ["terraform", "docker", "logging"]
+      }
+    }
+  }
+
+  assert {
+    condition     = !contains(keys(local.idrac_kvm_vm_ids), "docker-host")
+    error_message = "VM without 'idrac' tag must NOT be in idrac_kvm_vm_ids"
+  }
+
+  assert {
+    condition     = length(local.idrac_kvm_vm_ids) == 0
+    error_message = "idrac_kvm_vm_ids should be empty when no VMs have the 'idrac' tag"
+  }
+}


### PR DESCRIPTION
## Summary

- New VM 251 (`idrac-kvm`) hosts `domistyle/idrac6` Docker containers for R410/R710 HTML5 KVM access (paired with JacobPEvans/ansible-proxmox-apps#256)
- One new tag-driven cluster firewall security group: `idrac-kvm-svc` — inbound TCP 5800/5801 from `local.internal_src`
- iDRAC egress (HTTPS to BMC API, KVM data on 5900) reuses the existing `outbound_internal` security group — no new variable, no new SOPS key

## Changes

- `deployment.json` — `idrac-kvm` VM entry with `idrac` tag, `network_interfaces[0].firewall=true`
- `locals.tf` — `idrac_kvm_vm_ids` derived map from VMs tagged `idrac`
- `main.tf` — pass `idrac_kvm_vm_ids` into the firewall module
- `modules/firewall/` — new `idrac-kvm-svc` security group + per-VM firewall rules (3 groups: `internal_access`, `idrac-kvm-svc`, `outbound_internal`)
- `tests/firewall_filtering.tftest.hcl` — tag-filter assertions for idrac_kvm_vm_ids

## Review fixes applied

NIC firewall flag enabled on deployment.json to ensure Proxmox enforces the attached cluster security groups (module default would have been a no-op). Firewall rule comments updated to include protocol/port per repo convention (TCP 5800/5801). Tag-filter tests added covering both positive (tagged VM picked up) and negative (untagged VM excluded) cases.

## Test plan

- [x] tofu test (mock-provider) — passed
- [x] terragrunt validate — passed
- [x] terragrunt plan — passed
- [ ] Real terragrunt apply creates VM 251 and the new security group
- [ ] Inventory sync updates `docker_vms.idrac-kvm` in ansible-proxmox-apps
- [ ] Confirm VM 251 firewall has three groups attached

Related: JacobPEvans/ansible-proxmox-apps#256

🤖 Generated with [Claude Code](https://claude.com/claude-code)