### PR TITLE
chore(ci): inherit centralized OSV scanner from .github

### DIFF
--- a/.github/workflows/osv-scan.yml
+++ b/.github/workflows/osv-scan.yml
@@ -1,0 +1,29 @@
+# Periodic + per-PR OSV vulnerability scan.
+#
+# Inherits the centralized reusable workflow from JacobPEvans/.github.
+# Config: JacobPEvans/.github/osv-scanner.toml (org default) or local
+# osv-scanner.toml in this repo (takes precedence).
+#
+# Make this a required check via branch protection on `main` after merge.
+name: OSV Scan
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches: [main]
+  schedule:
+    - cron: '17 11 * * 1'  # Weekly Monday 11:17 UTC (off-peak minute)
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    uses: JacobPEvans/.github/.github/workflows/_osv-scan.yml@main
+    with:
+      runner_label: ubuntu-latest

--- a/.github/workflows/osv-scan.yml
+++ b/.github/workflows/osv-scan.yml
@@ -24,6 +24,8 @@ permissions:
 
 jobs:
   scan:
-    uses: JacobPEvans/.github/.github/workflows/_osv-scan.yml@main
+    # SHA pin → JacobPEvans/.github main as of 2026-05-20.
+    # Bump intentionally when the upstream workflow changes.
+    uses: JacobPEvans/.github/.github/workflows/_osv-scan.yml@a76cf8faec4ea24036c9042bf52d18b573f172ae
     with:
       runner_label: ubuntu-latest


### PR DESCRIPTION
## Summary
Adds a thin wrapper workflow that inherits `JacobPEvans/.github/.github/workflows/_osv-scan.yml@main`. Triggers per-PR, on push to main, and weekly Monday. Brings this repo in line with the org-wide OSV coverage pattern (see nix-ai, mlx-benchmarks).

## Scanned target
`.terraform.lock.hcl` — verified clean locally with `osv-scanner --recursive .`.

## Test plan
- [ ] CI `OSV Scan / scan` passes
- [ ] After merge: add `OSV Scan / scan` as a required check in branch protection rule on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)