### PR TITLE
feat(poweredge): declarative inventory module for cluster join

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -216,6 +216,15 @@ module "acme_certificates" {
   depends_on = [module.pools]
 }
 
+# PowerEdge cluster inventory. Declarative-only today (no resources created);
+# real values come from SOPS-encrypted terraform.sops.json. Outputs are
+# consumed by ansible-proxmox via terraform_remote_state to keep
+# IP/MAC/service-tag identity DRY across repos.
+module "poweredge_cluster" {
+  source           = "./modules/poweredge-cluster"
+  poweredge_nodes  = var.poweredge_nodes
+}
+
 # Secure SSH key provisioning for Ansible VM
 resource "null_resource" "ansible_ssh_key_setup" {
   count = contains(keys(var.vms), "ansible") ? 1 : 0

--- a/main.tf
+++ b/main.tf
@@ -221,8 +221,8 @@ module "acme_certificates" {
 # consumed by ansible-proxmox via terraform_remote_state to keep
 # IP/MAC/service-tag identity DRY across repos.
 module "poweredge_cluster" {
-  source           = "./modules/poweredge-cluster"
-  poweredge_nodes  = var.poweredge_nodes
+  source          = "./modules/poweredge-cluster"
+  poweredge_nodes = var.poweredge_nodes
 }
 
 # Secure SSH key provisioning for Ansible VM

--- a/modules/poweredge-cluster/README.md
+++ b/modules/poweredge-cluster/README.md
@@ -1,0 +1,63 @@
+# poweredge-cluster module
+
+Declarative inventory of Dell PowerEdge nodes joining the Proxmox cluster.
+
+## Usage
+
+Set `poweredge_nodes` via the SOPS-encrypted `terraform.sops.json` at the
+repo root (real values supplied this way; the example file shows the shape
+with `192.168.0.x` placeholders):
+
+```json
+{
+  "poweredge_nodes": {
+    "node-a": {
+      "chassis": "r410",
+      "idrac_ip": "192.168.0.10",
+      "idrac_mac": "00:00:00:00:00:00",
+      "service_tag": "EXAMPLE1",
+      "mgmt_ip": "192.168.0.11"
+    }
+  }
+}
+```
+
+The module emits outputs that `ansible-proxmox` reads via
+`terraform_remote_state` so IP / MAC / service-tag values stay in one
+SOPS-encrypted source.
+
+## Requirements
+
+- Terraform >= 1.10
+- bpg/proxmox provider ~> 0.106 (only needed once cluster-membership
+  verification is enabled — see "Current scope" below)
+- SOPS for editing `terraform.sops.json`
+
+## Outputs
+
+| Output | Shape | Use |
+| ------ | ----- | --- |
+| `node_names` | sorted list of node names | iteration |
+| `idrac_ips` | map(name → ip) | racadm / ipmitool targeting |
+| `idrac_macs` | map(name → mac) | DHCP reservations, switch port mapping |
+| `mgmt_ips` | map(name → ip) | PVE web UI, SSH, ansible inventory |
+| `service_tags` | map(name → tag) | Dell warranty / support lookup |
+| `by_chassis` | map(chassis → map of nodes) | ansible group_vars selection |
+| `ansible_inventory` | list of objects | drop-in ansible inventory shape |
+
+## Current scope
+
+Inventory-only. No resources are created — this module exists so that nodes
+can be declared once (in SOPS) and consumed everywhere without duplication.
+
+When nodes are physically online and joined to the cluster, uncomment the
+`proxmox_virtual_environment_nodes` data source + `check` block in `main.tf`
+to verify the declared inventory matches the live cluster.
+
+## Why nothing is hard-coded
+
+`terraform-proxmox` is the org's source of truth for cluster identity, but
+this repo is public. Real values (IPs, MACs, service tags, hostnames) must
+be supplied via SOPS or environment, never committed. The
+`terraform.sops.json.example` at the repo root shows the placeholder shape
+using the `192.168.0.x` sample prefix.

--- a/modules/poweredge-cluster/README.md
+++ b/modules/poweredge-cluster/README.md
@@ -28,7 +28,7 @@ SOPS-encrypted source.
 
 ## Requirements
 
-- Terraform >= 1.10
+- OpenTofu >= 1.10 (Terraform >= 1.10 also compatible — repo standardizes on OpenTofu)
 - bpg/proxmox provider ~> 0.106 (only needed once cluster-membership
   verification is enabled — see "Current scope" below)
 - SOPS for editing `terraform.sops.json`

--- a/modules/poweredge-cluster/main.tf
+++ b/modules/poweredge-cluster/main.tf
@@ -12,10 +12,12 @@
 
 locals {
   # Group by chassis model — handy for ansible-proxmox group_vars selection.
+  # Normalize to lowercase so "R410" and "r410" group together. Safe to
+  # normalize here because by_chassis is not used as a for_each resource key.
   by_chassis = {
-    for chassis in distinct([for k, v in var.poweredge_nodes : v.chassis]) :
+    for chassis in distinct([for k, v in var.poweredge_nodes : lower(v.chassis)]) :
     chassis => {
-      for k, v in var.poweredge_nodes : k => v if v.chassis == chassis
+      for k, v in var.poweredge_nodes : k => v if lower(v.chassis) == chassis
     }
   }
 }

--- a/modules/poweredge-cluster/main.tf
+++ b/modules/poweredge-cluster/main.tf
@@ -1,0 +1,35 @@
+# PowerEdge cluster module.
+#
+# Scope today: declarative inventory of PowerEdge nodes that will join the
+# Proxmox cluster. Emits outputs that other repos (ansible-proxmox) consume
+# via terraform_remote_state so the IP/MAC/service-tag values stay DRY across
+# the org and out of public files.
+#
+# Future scope (commented enable below): when nodes are physically online and
+# joined to the cluster, swap the locals-only mode for data sources against the
+# bpg/proxmox provider's proxmox_virtual_environment_nodes to verify the live
+# node list matches the declared inventory.
+
+locals {
+  # Group by chassis model — handy for ansible-proxmox group_vars selection.
+  by_chassis = {
+    for chassis in distinct([for k, v in var.poweredge_nodes : v.chassis]) :
+    chassis => {
+      for k, v in var.poweredge_nodes : k => v if v.chassis == chassis
+    }
+  }
+}
+
+# Future cluster-membership verification (uncomment when nodes are joined):
+#
+# data "proxmox_virtual_environment_nodes" "live" {}
+#
+# check "all_declared_nodes_in_cluster" {
+#   assert {
+#     condition = alltrue([
+#       for name, _ in var.poweredge_nodes :
+#       contains(data.proxmox_virtual_environment_nodes.live.names, name)
+#     ])
+#     error_message = "One or more declared PowerEdge nodes are not present in the live Proxmox cluster."
+#   }
+# }

--- a/modules/poweredge-cluster/outputs.tf
+++ b/modules/poweredge-cluster/outputs.tf
@@ -1,5 +1,5 @@
 output "node_names" {
-  description = "Set of PowerEdge node names declared in the cluster inventory."
+  description = "Sorted list of PowerEdge node names declared in the cluster inventory."
   value       = sort(keys(var.poweredge_nodes))
 }
 
@@ -29,12 +29,13 @@ output "by_chassis" {
 }
 
 output "ansible_inventory" {
-  description = "Ansible-friendly inventory shape: list of hosts with iDRAC/mgmt addresses + chassis tag. Consume from ansible-proxmox via terraform_remote_state."
+  description = "Ansible-friendly inventory shape: list of hosts with iDRAC/mgmt addresses, MAC, and chassis tag. Consume from ansible-proxmox via terraform_remote_state."
   value = [
     for name, node in var.poweredge_nodes : {
       name        = name
       mgmt_ip     = node.mgmt_ip
       idrac_ip    = node.idrac_ip
+      idrac_mac   = node.idrac_mac
       chassis     = node.chassis
       service_tag = node.service_tag
     }

--- a/modules/poweredge-cluster/outputs.tf
+++ b/modules/poweredge-cluster/outputs.tf
@@ -1,0 +1,42 @@
+output "node_names" {
+  description = "Set of PowerEdge node names declared in the cluster inventory."
+  value       = sort(keys(var.poweredge_nodes))
+}
+
+output "idrac_ips" {
+  description = "Map of node name to iDRAC management IP."
+  value       = { for k, v in var.poweredge_nodes : k => v.idrac_ip }
+}
+
+output "idrac_macs" {
+  description = "Map of node name to iDRAC NIC MAC address."
+  value       = { for k, v in var.poweredge_nodes : k => v.idrac_mac }
+}
+
+output "mgmt_ips" {
+  description = "Map of node name to host OS management IP."
+  value       = { for k, v in var.poweredge_nodes : k => v.mgmt_ip }
+}
+
+output "service_tags" {
+  description = "Map of node name to Dell service tag."
+  value       = { for k, v in var.poweredge_nodes : k => v.service_tag }
+}
+
+output "by_chassis" {
+  description = "Nodes grouped by chassis model (e.g. r410, r710) — useful for ansible group_vars selection."
+  value       = local.by_chassis
+}
+
+output "ansible_inventory" {
+  description = "Ansible-friendly inventory shape: list of hosts with iDRAC/mgmt addresses + chassis tag. Consume from ansible-proxmox via terraform_remote_state."
+  value = [
+    for name, node in var.poweredge_nodes : {
+      name        = name
+      mgmt_ip     = node.mgmt_ip
+      idrac_ip    = node.idrac_ip
+      chassis     = node.chassis
+      service_tag = node.service_tag
+    }
+  ]
+}

--- a/modules/poweredge-cluster/variables.tf
+++ b/modules/poweredge-cluster/variables.tf
@@ -1,0 +1,10 @@
+variable "poweredge_nodes" {
+  description = "Map of PowerEdge nodes — passed through from the root variables-poweredge.tf."
+  type = map(object({
+    chassis     = string
+    idrac_ip    = string
+    idrac_mac   = string
+    service_tag = string
+    mgmt_ip     = string
+  }))
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -133,7 +133,7 @@ output "ansible_inventory" {
 
 # PowerEdge cluster inventory - consumed by ansible-proxmox via terraform_remote_state
 output "poweredge_nodes" {
-  description = "PowerEdge node identity (names, iDRAC IPs/MACs, mgmt IPs, service tags, by-chassis grouping, ansible inventory shape). Real values come from terraform.sops.json; default is empty map."
+  description = "PowerEdge node identity (names, iDRAC IPs/MACs, mgmt IPs, service tags, by-chassis grouping, ansible inventory shape). Real values come from terraform.sops.json; when var.poweredge_nodes defaults to an empty map, this output is an object whose collections are all empty."
   value = {
     names             = module.poweredge_cluster.node_names
     idrac_ips         = module.poweredge_cluster.idrac_ips

--- a/outputs.tf
+++ b/outputs.tf
@@ -130,3 +130,17 @@ output "ansible_inventory" {
     domain = var.domain
   }
 }
+
+# PowerEdge cluster inventory - consumed by ansible-proxmox via terraform_remote_state
+output "poweredge_nodes" {
+  description = "PowerEdge node identity (names, iDRAC IPs/MACs, mgmt IPs, service tags, by-chassis grouping, ansible inventory shape). Real values come from terraform.sops.json; default is empty map."
+  value = {
+    names             = module.poweredge_cluster.node_names
+    idrac_ips         = module.poweredge_cluster.idrac_ips
+    idrac_macs        = module.poweredge_cluster.idrac_macs
+    mgmt_ips          = module.poweredge_cluster.mgmt_ips
+    service_tags      = module.poweredge_cluster.service_tags
+    by_chassis        = module.poweredge_cluster.by_chassis
+    ansible_inventory = module.poweredge_cluster.ansible_inventory
+  }
+}

--- a/terraform.sops.json.example
+++ b/terraform.sops.json.example
@@ -4,5 +4,21 @@
   "domain": "example.com",
   "vm_ssh_public_key_path": "~/.ssh/id_rsa_vm.pub",
   "vm_ssh_private_key_path": "~/.ssh/id_rsa_vm",
-  "proxmox_ssh_username": "root"
+  "proxmox_ssh_username": "root",
+  "poweredge_nodes": {
+    "node-a": {
+      "chassis": "r410",
+      "idrac_ip": "192.168.0.10",
+      "idrac_mac": "00:00:00:00:00:00",
+      "service_tag": "EXAMPLE1",
+      "mgmt_ip": "192.168.0.11"
+    },
+    "node-b": {
+      "chassis": "r710",
+      "idrac_ip": "192.168.0.20",
+      "idrac_mac": "00:00:00:00:00:00",
+      "service_tag": "EXAMPLE2",
+      "mgmt_ip": "192.168.0.21"
+    }
+  }
 }

--- a/variables-poweredge.tf
+++ b/variables-poweredge.tf
@@ -1,0 +1,39 @@
+# PowerEdge node variables: cluster identity for Dell PowerEdge servers
+# joining the Proxmox cluster.
+#
+# DRY: real values supplied via SOPS-encrypted terraform.sops.json — see
+# terraform.sops.json.example for the placeholder shape. Public repo never
+# contains real IPs, MACs, service tags, or hostnames.
+
+variable "poweredge_nodes" {
+  description = <<-EOT
+    Map of PowerEdge nodes joining the Proxmox cluster. Keyed by node name
+    (chosen by the operator — e.g. "node-a", "node-b"). Real values supplied
+    via SOPS-encrypted terraform.sops.json; default is an empty map so plans
+    succeed cleanly before any nodes are populated.
+
+    Fields:
+      chassis     - PowerEdge model identifier ("r410", "r710", etc.).
+      idrac_ip    - iDRAC management IP on the management VLAN.
+      idrac_mac   - iDRAC NIC MAC address (dedicated NIC when Enterprise
+                    daughter card is installed).
+      service_tag - Dell service tag, used for inventory + warranty lookup.
+      mgmt_ip     - Host OS management IP (PVE web UI, SSH).
+  EOT
+  type = map(object({
+    chassis     = string
+    idrac_ip    = string
+    idrac_mac   = string
+    service_tag = string
+    mgmt_ip     = string
+  }))
+  default = {}
+
+  validation {
+    condition = alltrue([
+      for k, v in var.poweredge_nodes :
+      contains(["r410", "r710", "r720", "r730", "r740"], lower(v.chassis))
+    ])
+    error_message = "Each poweredge_nodes entry must set chassis to a supported PowerEdge model (r410, r710, r720, r730, r740)."
+  }
+}


### PR DESCRIPTION
## Summary

Parameterized PowerEdge inventory layer so R410, R710, and future PowerEdge nodes can be declared **once** (in SOPS-encrypted `terraform.sops.json`) and consumed everywhere — root outputs, `ansible-proxmox` via `terraform_remote_state` — without leaking real IPs / MACs / service tags into this public repo.

- New root variable: `poweredge_nodes` (`map(object)`, empty default, chassis validation).
- New module `modules/poweredge-cluster/` — inventory-only today (no resources). Emits `node_names`, `idrac_ips`, `idrac_macs`, `mgmt_ips`, `service_tags`, `by_chassis`, `ansible_inventory`.
- `main.tf` — wires `module \"poweredge_cluster\"`.
- `outputs.tf` — exposes the aggregate `poweredge_nodes` output for downstream consumers (especially `ansible-proxmox`).
- `terraform.sops.json.example` — appended `poweredge_nodes` placeholder block using `192.168.0.x` sample prefix.

## Why

`terraform-proxmox` is the org's source of truth for cluster identity. Real cluster-membership values must come from one parameterized source — currently the SOPS-encrypted `terraform.sops.json` — so all consumers (terraform, ansible, int_homelab docs) stay DRY without exposing the values in any public repo.

This PR adds the structural layer. The R410 and R710 won't appear in any plan until their values land in your local `terraform.sops.json`; the empty map default keeps `plan` clean for anyone without those values populated.

When nodes are physically online and joined to the cluster, a commented `proxmox_virtual_environment_nodes` data source + `check` block in `modules/poweredge-cluster/main.tf` can be enabled to verify the declared inventory matches the live Proxmox node list.

## Test plan

- [x] `tofu validate` — passes (existing storage-module deprecation warnings are unrelated)
- [x] Pre-commit hooks — all passed (`Checkov`, `tofu test (mock providers)`, `terragrunt validate`, `terragrunt plan`)
- [x] Grep for forbidden values (real IPs `192.168.[1-9]`, MACs `00:26:b9` / `84:2b:2b`, service tag `774KVH`, domain `jacobpevans.com`) — CLEAN
- [ ] After merge: try a populated `terraform.sops.json` locally and confirm `terragrunt plan` shows the new `poweredge_nodes` output without any destructive ops

## Linked

- Linear epic: [Hardware Building (JAC-33)](https://linear.app/jacobpevans/issue/JAC-33)
- Will be consumed by upcoming `ansible-proxmox` commission_poweredge playbook PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)