### PR TITLE
fix: initialize OpenTofu in Copilot setup workflow

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -10,3 +10,5 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: opentofu/setup-opentofu@v2
+      - name: OpenTofu Init
+        run: tofu init -backend=false


### PR DESCRIPTION
## Summary

Adds a `tofu init -backend=false` step to `.github/workflows/copilot-setup-steps.yml` so the Copilot setup environment has providers ready before any subsequent work.

## Context

Recovered from abandoned branch (April 2026) during workspace cleanup. The workflow on `main` still lacks the init step, so the change remains relevant.

## Commits

- d3f2272 fix: initialize OpenTofu in Copilot setup workflow (+2 lines)

## Test plan

- [ ] Trigger the `copilot-setup-steps` workflow and confirm `tofu init` succeeds
- [ ] Confirm no regression in downstream Copilot agent runs

Drafted by cleanup sweep agent.