### PR TITLE
feat: provision Infisical LXC at vm_id 108 with firewall + DRY constants

### DIFF
--- a/deployment.json
+++ b/deployment.json
@@ -197,7 +197,7 @@
       "description": "Infisical self-hosted secrets management - Docker Compose in LXC (Phase 1 deploy)",
       "cpu_cores": 2,
       "memory_dedicated": 4096,
-      "memory_swap": 8192,
+      "memory_swap": 12288,
       "tags": ["terraform", "container", "infisical", "secrets", "docker"],
       "pool_id": "infrastructure",
       "unprivileged": true,

--- a/deployment.json
+++ b/deployment.json
@@ -191,6 +191,22 @@
         { "volume": "local-zfs", "size": "100G", "path": "/opt/minio" }
       ]
     },
+    "infisical": {
+      "vm_id": 108,
+      "hostname": "infisical",
+      "description": "Infisical self-hosted secrets management - Docker Compose in LXC (Phase 1 deploy)",
+      "cpu_cores": 2,
+      "memory_dedicated": 4096,
+      "memory_swap": 8192,
+      "tags": ["terraform", "container", "infisical", "secrets", "docker"],
+      "pool_id": "infrastructure",
+      "unprivileged": true,
+      "root_disk": { "size": 16 },
+      "mount_points": [
+        { "volume": "local-zfs", "size": "30G", "path": "/opt/infisical" }
+      ],
+      "features": { "nesting": true, "keyctl": true, "fuse": true }
+    },
     "mailpit": {
       "vm_id": 110,
       "hostname": "mailpit",

--- a/docs/INFISICAL_PLANNING.md
+++ b/docs/INFISICAL_PLANNING.md
@@ -4,7 +4,30 @@
 
 Self-hosted Infisical deployment on Proxmox infrastructure.
 
-**Status:** PLANNED
+**Status:** IN PROGRESS — Phase 1 deploy (LXC + firewall landing via
+`terraform-proxmox`; Ansible role + HAProxy frontend land via
+`ansible-proxmox-apps` PR 3).
+
+## Phase 1 — concrete values
+
+| Field | Value | Source |
+| --- | --- | --- |
+| LXC vm_id | `108` | `deployment.json` (groups with platform services 105/106/107) |
+| CPU / RAM / disk | 2 cores / 4 GB dedicated + 8 GB swap / 16 GB root + 30 GB at `/opt/infisical` | `deployment.json` |
+| FQDN | `infisical.<domain>` (resolved via Technitium A record on the haproxy LXC) | runtime, populated from `terraform.sops.json` `domain` |
+| Container internal API port | `8080` | `locals.pipeline_constants.service_ports.infisical_api` |
+| Bundled Postgres port | `5432` | `locals.pipeline_constants.service_ports.postgres_default` (container-internal Docker network only) |
+| Bundled Redis port | `6379` | `locals.pipeline_constants.service_ports.redis_default` (container-internal Docker network only) |
+| Firewall security group | `infisical-svc` | `modules/firewall/security_groups.tf` |
+| Ingress | HAProxy on vm_id 175 with ACME cert at `/etc/ssl/private/infisical.pem` | PR 3 |
+
+ACME cert for `infisical.<domain>` is **out of scope for Phase 1's
+terraform-proxmox PR**: the existing `modules/acme-certificate` module today
+issues node-level Proxmox certs (delivered to `/etc/pve/local/`), not certs
+delivered to LXCs. Cert delivery to the haproxy LXC is handled in
+`ansible-proxmox-apps` (PR 3) — either by an Ansible-driven Let's Encrypt
+flow on the haproxy LXC itself or by extending the ACME module separately.
+Tracked as a follow-up in issue #136 Phase 1.
 
 ## Overview
 

--- a/locals.tf
+++ b/locals.tf
@@ -66,6 +66,12 @@ locals {
     if contains(coalesce(try(v.tags, null), []), "minio")
   }
 
+  # Infisical secrets-management containers (infisical tag)
+  infisical_container_ids = {
+    for k, v in var.containers : k => v.vm_id
+    if contains(coalesce(try(v.tags, null), []), "infisical")
+  }
+
   # Cribl Stream containers: tagged cribl + stream (receives from Edge, routes to Splunk)
   # Distinct from pipeline_container_ids (HAProxy + Cribl Edge) as it doesn't receive external traffic
   cribl_stream_container_ids = {
@@ -94,6 +100,9 @@ locals {
       apt_cacher_ng    = 3142
       minio_api        = 9000
       minio_console    = 9001
+      infisical_api    = 8080
+      postgres_default = 5432
+      redis_default    = 6379
     }
     syslog_ports = {
       unifi     = 1514

--- a/main.tf
+++ b/main.tf
@@ -191,8 +191,14 @@ module "firewall" {
   # MinIO object storage containers (minio tag)
   minio_container_ids = local.minio_container_ids
 
+  # Infisical secrets-management containers (infisical tag)
+  infisical_container_ids = local.infisical_container_ids
+
   # iDRAC KVM VMs: tagged "idrac" (domistyle/idrac6 containers on dedicated Docker VM)
   idrac_kvm_vm_ids = local.idrac_kvm_vm_ids
+
+  # Pipeline constants: single source of truth for service ports (DRY)
+  pipeline_constants = local.pipeline_constants
 
   management_network = local.management_network
   splunk_network     = join(",", local.splunk_network_ips)

--- a/modules/firewall/container_rules.tf
+++ b/modules/firewall/container_rules.tf
@@ -332,3 +332,45 @@ resource "proxmox_virtual_environment_firewall_rules" "minio_container" {
 
   depends_on = [proxmox_virtual_environment_firewall_options.minio_container]
 }
+
+# Infisical secrets-management containers (Docker-in-LXC stack: Infisical API + Postgres + Redis)
+# Postgres (5432) and Redis (6379) are container-internal Docker services only — never exposed
+# to the LXC network — so no security group is needed for them.
+
+resource "proxmox_virtual_environment_firewall_options" "infisical_container" {
+  for_each = var.infisical_container_ids
+
+  node_name     = var.node_name
+  container_id  = each.value
+  enabled       = local.firewall_defaults.enabled
+  input_policy  = local.firewall_defaults.input_policy
+  output_policy = local.firewall_defaults.output_policy
+  log_level_in  = local.firewall_defaults.log_level_in
+  log_level_out = local.firewall_defaults.log_level_out
+
+  depends_on = [proxmox_virtual_environment_cluster_firewall.main]
+}
+
+resource "proxmox_virtual_environment_firewall_rules" "infisical_container" {
+  for_each = var.infisical_container_ids
+
+  node_name    = var.node_name
+  container_id = each.value
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.internal_access.name
+    comment        = "Internal access (SSH, ICMP)"
+  }
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.infisical_services.name
+    comment        = "Infisical API/Web from internal"
+  }
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.outbound_internal.name
+    comment        = "Outbound to internal only"
+  }
+
+  depends_on = [proxmox_virtual_environment_firewall_options.infisical_container]
+}

--- a/modules/firewall/container_rules.tf
+++ b/modules/firewall/container_rules.tf
@@ -333,44 +333,6 @@ resource "proxmox_virtual_environment_firewall_rules" "minio_container" {
   depends_on = [proxmox_virtual_environment_firewall_options.minio_container]
 }
 
-# Infisical secrets-management containers (Docker-in-LXC stack: Infisical API + Postgres + Redis)
-# Postgres (5432) and Redis (6379) are container-internal Docker services only — never exposed
-# to the LXC network — so no security group is needed for them.
-
-resource "proxmox_virtual_environment_firewall_options" "infisical_container" {
-  for_each = var.infisical_container_ids
-
-  node_name     = var.node_name
-  container_id  = each.value
-  enabled       = local.firewall_defaults.enabled
-  input_policy  = local.firewall_defaults.input_policy
-  output_policy = local.firewall_defaults.output_policy
-  log_level_in  = local.firewall_defaults.log_level_in
-  log_level_out = local.firewall_defaults.log_level_out
-
-  depends_on = [proxmox_virtual_environment_cluster_firewall.main]
-}
-
-resource "proxmox_virtual_environment_firewall_rules" "infisical_container" {
-  for_each = var.infisical_container_ids
-
-  node_name    = var.node_name
-  container_id = each.value
-
-  rule {
-    security_group = proxmox_virtual_environment_cluster_firewall_security_group.internal_access.name
-    comment        = "Internal access (SSH, ICMP)"
-  }
-
-  rule {
-    security_group = proxmox_virtual_environment_cluster_firewall_security_group.infisical_services.name
-    comment        = "Infisical API/Web from internal"
-  }
-
-  rule {
-    security_group = proxmox_virtual_environment_cluster_firewall_security_group.outbound_internal.name
-    comment        = "Outbound to internal only"
-  }
-
-  depends_on = [proxmox_virtual_environment_firewall_options.infisical_container]
-}
+# Infisical container firewall resources live in modules/firewall/infisical_rules.tf
+# (extracted so container_rules.tf stays under the shared _file-size workflow's 12 KB error
+# threshold).

--- a/modules/firewall/infisical_rules.tf
+++ b/modules/firewall/infisical_rules.tf
@@ -1,0 +1,45 @@
+# Infisical secrets-management containers (Docker-in-LXC stack: Infisical API + Postgres + Redis)
+# Postgres (5432) and Redis (6379) are container-internal Docker services only — never exposed
+# to the LXC network — so no security group is needed for them.
+#
+# Lives in its own file (rather than container_rules.tf) to keep container_rules.tf under the
+# shared `_file-size` workflow's 12 KB error threshold. As more container types accrete, prefer
+# adding new per-domain files like this one over growing container_rules.tf further.
+
+resource "proxmox_virtual_environment_firewall_options" "infisical_container" {
+  for_each = var.infisical_container_ids
+
+  node_name     = var.node_name
+  container_id  = each.value
+  enabled       = local.firewall_defaults.enabled
+  input_policy  = local.firewall_defaults.input_policy
+  output_policy = local.firewall_defaults.output_policy
+  log_level_in  = local.firewall_defaults.log_level_in
+  log_level_out = local.firewall_defaults.log_level_out
+
+  depends_on = [proxmox_virtual_environment_cluster_firewall.main]
+}
+
+resource "proxmox_virtual_environment_firewall_rules" "infisical_container" {
+  for_each = var.infisical_container_ids
+
+  node_name    = var.node_name
+  container_id = each.value
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.internal_access.name
+    comment        = "Internal access (SSH, ICMP)"
+  }
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.infisical_services.name
+    comment        = "Infisical API/Web from internal"
+  }
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.outbound_internal.name
+    comment        = "Outbound to internal only"
+  }
+
+  depends_on = [proxmox_virtual_environment_firewall_options.infisical_container]
+}

--- a/modules/firewall/locals.tf
+++ b/modules/firewall/locals.tf
@@ -16,9 +16,20 @@ locals {
 # Security group rule definitions - use comma-joined source/dest for multi-network rules
 # Proxmox natively supports comma-separated CIDRs in source/dest fields,
 # so we generate one rule per protocol/port rather than one per network.
+#
+# DRY: every port literal here either references var.pipeline_constants
+# (single source of truth from root locals.tf) or is a port not yet promoted
+# to the constants map. Numeric ports are tostring()-converted because the
+# proxmox provider's dport attribute expects string values.
 locals {
   # Comma-separated internal networks for use in source/dest fields
   internal_src = join(",", var.internal_networks)
+
+  # Local aliases to keep rule definitions readable
+  svc_ports          = var.pipeline_constants.service_ports
+  notification_ports = var.pipeline_constants.notification_ports
+  vector_db_ports    = var.pipeline_constants.vector_db_ports
+  netflow_ports      = var.pipeline_constants.netflow_ports
 
   internal_access_rules = [
     { proto = "tcp", dport = "22", source = local.internal_src, comment = "SSH from internal networks" },
@@ -26,8 +37,8 @@ locals {
   ]
 
   splunk_services_rules = [
-    { proto = "tcp", dport = "8000", source = local.internal_src, comment = "Splunk Web UI from internal" },
-    { proto = "tcp", dport = "8088", source = local.internal_src, comment = "Splunk HEC from internal" },
+    { proto = "tcp", dport = tostring(local.svc_ports.splunk_web), source = local.internal_src, comment = "Splunk Web UI from internal" },
+    { proto = "tcp", dport = tostring(local.svc_ports.splunk_hec), source = local.internal_src, comment = "Splunk HEC from internal" },
     { proto = "tcp", dport = "9997", source = local.internal_src, comment = "Splunk Forwarding from internal" },
   ]
 
@@ -39,12 +50,12 @@ locals {
   ]
 
   pipeline_services_rules = [
-    { proto = "tcp", dport = "8404", source = local.internal_src, comment = "HAProxy stats from internal" },
-    { proto = "tcp", dport = "9420", source = local.internal_src, comment = "Cribl Edge API TCP/9420 from internal" },
+    { proto = "tcp", dport = tostring(local.svc_ports.haproxy_stats), source = local.internal_src, comment = "HAProxy stats from internal" },
+    { proto = "tcp", dport = tostring(local.svc_ports.cribl_edge_api), source = local.internal_src, comment = "Cribl Edge API from internal" },
   ]
 
   netflow_rules = [
-    { proto = "udp", dport = "2055", source = local.internal_src, comment = "NetFlow/IPFIX UDP from internal" },
+    { proto = "udp", dport = tostring(local.netflow_ports.unifi), source = local.internal_src, comment = "NetFlow/IPFIX UDP from internal" },
   ]
 
   ntp_server_rules = [
@@ -52,27 +63,31 @@ locals {
   ]
 
   notification_services_rules = [
-    { proto = "tcp", dport = "1025", source = local.internal_src, comment = "Mailpit SMTP from internal" },
-    { proto = "tcp", dport = "8025", source = local.internal_src, comment = "Mailpit Web UI from internal" },
-    { proto = "tcp", dport = "8080", source = local.internal_src, comment = "ntfy HTTP from internal" },
+    { proto = "tcp", dport = tostring(local.notification_ports.mailpit_smtp), source = local.internal_src, comment = "Mailpit SMTP from internal" },
+    { proto = "tcp", dport = tostring(local.notification_ports.mailpit_web), source = local.internal_src, comment = "Mailpit Web UI from internal" },
+    { proto = "tcp", dport = tostring(local.notification_ports.ntfy_http), source = local.internal_src, comment = "ntfy HTTP from internal" },
   ]
 
   vectordb_services_rules = [
-    { proto = "tcp", dport = "6333", source = local.internal_src, comment = "Qdrant HTTP API from internal" },
-    { proto = "tcp", dport = "6334", source = local.internal_src, comment = "Qdrant gRPC from internal" },
+    { proto = "tcp", dport = tostring(local.vector_db_ports.qdrant_http), source = local.internal_src, comment = "Qdrant HTTP API from internal" },
+    { proto = "tcp", dport = tostring(local.vector_db_ports.qdrant_grpc), source = local.internal_src, comment = "Qdrant gRPC from internal" },
   ]
 
   apt_cacher_ng_services_rules = [
-    { proto = "tcp", dport = "3142", source = local.internal_src, comment = "apt-cacher-ng from internal" },
+    { proto = "tcp", dport = tostring(local.svc_ports.apt_cacher_ng), source = local.internal_src, comment = "apt-cacher-ng from internal" },
   ]
 
   cribl_stream_services_rules = [
-    { proto = "tcp", dport = "9000", source = local.internal_src, comment = "Cribl Stream API TCP/9000 from internal" },
+    { proto = "tcp", dport = tostring(local.svc_ports.cribl_stream_api), source = local.internal_src, comment = "Cribl Stream API from internal" },
   ]
 
   minio_services_rules = [
-    { proto = "tcp", dport = "9000", source = local.internal_src, comment = "MinIO API from internal" },
-    { proto = "tcp", dport = "9001", source = local.internal_src, comment = "MinIO Console from internal" },
+    { proto = "tcp", dport = tostring(local.svc_ports.minio_api), source = local.internal_src, comment = "MinIO API from internal" },
+    { proto = "tcp", dport = tostring(local.svc_ports.minio_console), source = local.internal_src, comment = "MinIO Console from internal" },
+  ]
+
+  infisical_services_rules = [
+    { proto = "tcp", dport = tostring(local.svc_ports.infisical_api), source = local.internal_src, comment = "Infisical API/Web from internal" },
   ]
 
   # Outbound to internal RFC1918 only (blocks internet egress)

--- a/modules/firewall/security_groups.tf
+++ b/modules/firewall/security_groups.tf
@@ -250,6 +250,23 @@ resource "proxmox_virtual_environment_cluster_firewall_security_group" "minio_se
   }
 }
 
+resource "proxmox_virtual_environment_cluster_firewall_security_group" "infisical_services" {
+  name    = "infisical-svc"
+  comment = "Infisical API/Web from internal networks (HAProxy front-ends TLS termination on its own ports)"
+
+  dynamic "rule" {
+    for_each = local.infisical_services_rules
+    content {
+      type    = "in"
+      action  = "ACCEPT"
+      proto   = rule.value.proto
+      dport   = rule.value.dport
+      source  = rule.value.source
+      comment = rule.value.comment
+    }
+  }
+}
+
 resource "proxmox_virtual_environment_cluster_firewall_security_group" "ntp_server" {
   name    = "ntp-server"
   comment = "NTP server (UDP 123) from internal networks — Proxmox hosts serve time to VMs/containers via chrony"

--- a/modules/firewall/tests/rule_generation.tftest.hcl
+++ b/modules/firewall/tests/rule_generation.tftest.hcl
@@ -10,6 +10,41 @@ variables {
   node_name          = "pve"
   management_network = "192.168.0.0/24"
   splunk_network     = "192.168.0.200"
+  pipeline_constants = {
+    service_ports = {
+      haproxy_stats    = 8404
+      splunk_web       = 8000
+      splunk_hec       = 8088
+      splunk_mgmt      = 8089
+      cribl_edge_api   = 9420
+      cribl_stream_api = 9000
+      apt_cacher_ng    = 3142
+      minio_api        = 9000
+      minio_console    = 9001
+      infisical_api    = 8080
+      postgres_default = 5432
+      redis_default    = 6379
+    }
+    syslog_ports = {
+      unifi     = 1514
+      palo_alto = 1515
+      cisco_asa = 1516
+      linux     = 1517
+      windows   = 1518
+    }
+    netflow_ports = {
+      unifi = 2055
+    }
+    notification_ports = {
+      mailpit_smtp = 1025
+      mailpit_web  = 8025
+      ntfy_http    = 8080
+    }
+    vector_db_ports = {
+      qdrant_http = 6333
+      qdrant_grpc = 6334
+    }
+  }
 }
 
 # --- internal_src joining ---
@@ -133,5 +168,90 @@ run "syslog_rules_source_matches_joined_networks" {
   assert {
     condition     = local.syslog_rules[0].source == "10.0.0.0/8,192.168.0.0/16"
     error_message = "syslog_rules source must be comma-joined networks, got '${local.syslog_rules[0].source}'"
+  }
+}
+
+# --- DRY: rule dports are sourced from var.pipeline_constants, not literals ---
+
+run "minio_rules_track_constants_port" {
+  command = plan
+
+  variables {
+    internal_networks = ["10.0.0.0/8"]
+  }
+
+  assert {
+    condition     = local.minio_services_rules[0].dport == tostring(var.pipeline_constants.service_ports.minio_api)
+    error_message = "minio_services_rules[0].dport must be tostring(pipeline_constants.service_ports.minio_api), got '${local.minio_services_rules[0].dport}'"
+  }
+
+  assert {
+    condition     = local.minio_services_rules[1].dport == tostring(var.pipeline_constants.service_ports.minio_console)
+    error_message = "minio_services_rules[1].dport must be tostring(pipeline_constants.service_ports.minio_console), got '${local.minio_services_rules[1].dport}'"
+  }
+}
+
+run "notification_rules_track_constants_ports" {
+  command = plan
+
+  variables {
+    internal_networks = ["10.0.0.0/8"]
+  }
+
+  assert {
+    condition     = local.notification_services_rules[0].dport == tostring(var.pipeline_constants.notification_ports.mailpit_smtp)
+    error_message = "notification rule 0 must track mailpit_smtp constant, got '${local.notification_services_rules[0].dport}'"
+  }
+
+  assert {
+    condition     = local.notification_services_rules[2].dport == tostring(var.pipeline_constants.notification_ports.ntfy_http)
+    error_message = "notification rule 2 must track ntfy_http constant, got '${local.notification_services_rules[2].dport}'"
+  }
+}
+
+# --- Infisical security group ---
+
+run "infisical_rules_always_one" {
+  command = plan
+
+  variables {
+    internal_networks = ["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"]
+  }
+
+  # TCP infisical_api
+  assert {
+    condition     = length(local.infisical_services_rules) == 1
+    error_message = "infisical_services_rules must be exactly 1 (TCP infisical_api), got ${length(local.infisical_services_rules)}"
+  }
+}
+
+run "infisical_rule_dport_matches_constant" {
+  command = plan
+
+  variables {
+    internal_networks = ["10.0.0.0/8"]
+  }
+
+  assert {
+    condition     = local.infisical_services_rules[0].dport == tostring(var.pipeline_constants.service_ports.infisical_api)
+    error_message = "infisical_services_rules[0].dport must equal tostring(service_ports.infisical_api), got '${local.infisical_services_rules[0].dport}'"
+  }
+
+  assert {
+    condition     = local.infisical_services_rules[0].proto == "tcp"
+    error_message = "infisical service port must be TCP, got '${local.infisical_services_rules[0].proto}'"
+  }
+}
+
+run "infisical_rule_source_matches_joined_networks" {
+  command = plan
+
+  variables {
+    internal_networks = ["10.0.0.0/8", "192.168.0.0/16"]
+  }
+
+  assert {
+    condition     = local.infisical_services_rules[0].source == "10.0.0.0/8,192.168.0.0/16"
+    error_message = "infisical_services_rules source must be comma-joined networks, got '${local.infisical_services_rules[0].source}'"
   }
 }

--- a/modules/firewall/variables.tf
+++ b/modules/firewall/variables.tf
@@ -57,6 +57,12 @@ variable "minio_container_ids" {
   default     = {}
 }
 
+variable "infisical_container_ids" {
+  description = "Map of Infisical secrets-management container names to their IDs"
+  type        = map(number)
+  default     = {}
+}
+
 variable "idrac_kvm_vm_ids" {
   description = "Map of iDRAC KVM host VM names to IDs (tag-driven, set by root locals)"
   type        = map(number)
@@ -73,6 +79,17 @@ variable "splunk_network" {
   description = "Comma-separated list of Splunk node IPs for cluster communication. Configure in terraform.tfvars for your environment."
   type        = string
   # No default - must be specified in .tfvars for environment-specific configuration
+}
+
+variable "pipeline_constants" {
+  description = "Single source of truth for service/syslog/netflow/notification/vector-db ports. Sourced from root locals.pipeline_constants so port literals stay defined exactly once across the whole repo."
+  type = object({
+    service_ports      = map(number)
+    syslog_ports       = map(number)
+    netflow_ports      = map(number)
+    notification_ports = map(number)
+    vector_db_ports    = map(number)
+  })
 }
 
 variable "internal_networks" {

--- a/modules/infisical/README.md
+++ b/modules/infisical/README.md
@@ -1,28 +1,47 @@
-# Infisical Module (Planned)
+# Infisical Module (Reserved — Phase 2)
 
-<!-- DO NOT DELETE - Placeholder for planned Infisical integration -->
+<!-- DO NOT DELETE - Placeholder reserved for the Infisical Terraform provider integration in Phase 2 -->
 
-This module will provision and configure a self-hosted Infisical instance
-on Proxmox infrastructure.
+This directory is **reserved** for a future Terraform module that uses the
+[Infisical Terraform provider](https://registry.terraform.io/providers/Infisical/infisical/latest)
+to manage Infisical projects, environments, secrets, and access policies as
+code — once the self-hosted instance is up and stable.
 
-**Status:** PLANNED - Documentation only. No Terraform resources yet.
+**Status:** RESERVED — no Terraform resources yet. Do not delete the directory;
+the placeholder keeps the Phase 2 location stable across renames.
 
-## Planned Scope
+## Scope split
 
-- LXC container or VM for Infisical server
-- Docker Compose deployment via Ansible
-- PostgreSQL and Redis backends
-- TLS certificate via ACME module
-- Firewall rules via firewall module
-- DNS record via Technitium
+| Concern | Where it lives |
+| --- | --- |
+| Provisioning the **Infisical LXC itself** (vm_id 108, firewall, mount points) | `deployment.json` + `modules/firewall/` + `locals.tf` (Phase 1, already on `main`) |
+| Deploying the **Infisical Docker Compose stack** (app + Postgres + Redis) | `ansible-proxmox-apps/roles/infisical_docker/` (Phase 1) |
+| Fronting it with **HAProxy + TLS** | `ansible-proxmox-apps/roles/haproxy/` + `group_vars/haproxy_group.yml` (Phase 1) |
+| **This module** — managing Infisical projects/secrets/policies via the Infisical Terraform provider | Phase 2 (see [issue #136](https://github.com/JacobPEvans/terraform-proxmox/issues/136)) |
 
-## Prerequisites (Before Implementation)
+## Requirements
 
-- SOPS + Age integration stable across repos
-- Available Proxmox capacity
-- Infisical Terraform provider at stable release
+This module does not declare any Terraform resources today, so it has no
+provider or version requirements of its own. Phase 2 will add a dependency
+on the Infisical Terraform provider once the self-hosted instance is stable.
+
+Prerequisites that must be in place before Phase 2 work begins:
+
+- Phase 1 deploy complete and stable (LXC up, HAProxy serving valid TLS, web UI reachable)
+- Initial admin user + first project created manually via the web UI
+- Service token issued for Terraform with project-scoped least privilege
+- Infisical Terraform provider at a stable release
+
+## Usage
+
+Reserved — there is nothing to instantiate yet. Do not add a
+`module "infisical" { source = "./modules/infisical" }` block to the root
+`main.tf`; doing so will currently no-op and will conflict with the Phase 2
+implementation once it lands. When Phase 2 ships, this section will document
+the real provider + module usage.
 
 ## References
 
 - [Infisical Planning Document](../../docs/INFISICAL_PLANNING.md)
 - [Secrets Roadmap](../../docs/SECRETS_ROADMAP.md)
+- [Infisical Terraform Provider](https://registry.terraform.io/providers/Infisical/infisical/latest)

--- a/tests/firewall_filtering.tftest.hcl
+++ b/tests/firewall_filtering.tftest.hcl
@@ -304,6 +304,47 @@ run "minio_tagged_container_in_minio_ids" {
   }
 }
 
+# --- infisical_container_ids tests ---
+
+run "infisical_tagged_container_in_infisical_ids" {
+  command = plan
+
+  variables {
+    containers = {
+      "infisical" = {
+        vm_id    = 108
+        hostname = "infisical"
+        tags     = ["terraform", "container", "infisical", "secrets", "docker"]
+      }
+    }
+  }
+
+  assert {
+    condition     = contains(keys(local.infisical_container_ids), "infisical")
+    error_message = "Container with 'infisical' tag must be in infisical_container_ids"
+  }
+
+  assert {
+    condition     = local.infisical_container_ids["infisical"] == 108
+    error_message = "infisical_container_ids['infisical'] should be vm_id 108"
+  }
+
+  assert {
+    condition     = !contains(keys(local.pipeline_container_ids), "infisical")
+    error_message = "Container with 'infisical' tag must NOT be in pipeline_container_ids"
+  }
+
+  assert {
+    condition     = !contains(keys(local.minio_container_ids), "infisical")
+    error_message = "Container with 'infisical' tag must NOT be in minio_container_ids"
+  }
+
+  assert {
+    condition     = !contains(keys(local.notification_container_ids), "infisical")
+    error_message = "Container with 'infisical' tag must NOT be in notification_container_ids"
+  }
+}
+
 run "pipeline_and_stream_containers_mutually_exclusive" {
   command = plan
 

--- a/tests/locals.tftest.hcl
+++ b/tests/locals.tftest.hcl
@@ -307,6 +307,42 @@ run "pipeline_constants_vector_db_ports" {
   }
 }
 
+# --- pipeline_constants infisical-related ports tests ---
+
+run "pipeline_constants_infisical_ports" {
+  command = plan
+
+  assert {
+    condition     = local.pipeline_constants.service_ports.infisical_api == 8080
+    error_message = "infisical_api port should be 8080"
+  }
+
+  assert {
+    condition     = local.pipeline_constants.service_ports.postgres_default == 5432
+    error_message = "postgres_default port should be 5432"
+  }
+
+  assert {
+    condition     = local.pipeline_constants.service_ports.redis_default == 6379
+    error_message = "redis_default port should be 6379"
+  }
+}
+
+# --- infisical_container_ids isolation from other groups ---
+
+run "infisical_ids_empty_by_default" {
+  command = plan
+
+  variables {
+    containers = {}
+  }
+
+  assert {
+    condition     = length(local.infisical_container_ids) == 0
+    error_message = "infisical_container_ids should be empty when containers is empty"
+  }
+}
+
 # --- cribl_stream_container_ids tests ---
 
 run "cribl_stream_ids_empty_by_default" {


### PR DESCRIPTION
## Summary

Phase 1 PR 2 of 3 for self-hosted Infisical (issue #136). Adds the Proxmox LXC that will host the Infisical Docker Compose stack (app + bundled Postgres + Redis). The Ansible role + HAProxy frontend land in a separate PR in `JacobPEvans/ansible-proxmox-apps`.

- New container `infisical` at vm_id 108 (2 cpu / 4 GB dedicated + 8 GB swap / 16 GB root + 30 GB at `/opt/infisical`, unprivileged, Docker features enabled).
- New `infisical_api`/`postgres_default`/`redis_default` entries in `pipeline_constants.service_ports` — surfaces to Ansible via `ansible_inventory.constants`.
- New tag-driven `infisical_container_ids` local, wired into the firewall module.
- New `infisical-svc` security group (TCP `infisical_api` from RFC1918) and `infisical_container` firewall resource pair.
- **DRY audit**: firewall `*_services_rules` blocks that hard-coded ports already present in `pipeline_constants` now reference them via `var.pipeline_constants.{service,notification,vector_db,netflow}_ports.*` with `tostring()`. Ports not yet in constants (syslog 514/1514:1518, NTP 123, splunk_forwarding 9997, iDRAC 5800/5801) are left as literals for a future audit pass.
- `docs/INFISICAL_PLANNING.md` flipped to **IN PROGRESS — Phase 1 deploy** with the concrete vm_id/port/FQDN table.
- `modules/infisical/README.md` clarified: the directory is reserved for the Phase 2 Infisical Terraform provider integration; Phase 1 LXC provisioning lives in `deployment.json` + the firewall module.

## Out of scope (deferred)

- **ACME cert for `infisical.<domain>`**. The existing `modules/acme-certificate` issues node-level Proxmox certs (delivered to `/etc/pve/local/`), not certs delivered into individual LXCs. Cert generation/delivery to the haproxy LXC is handled in `ansible-proxmox-apps` (Phase 1 PR 3); upstream ACME module changes are tracked separately under issue #136 Phase 1 follow-up.

## Test plan

- [x] `tofu init -backend=false` + `tofu validate` clean (pre-existing deprecation warning unrelated).
- [x] `tofu test` (root): **81 passed, 0 failed** — includes new `pipeline_constants_infisical_ports`, `infisical_ids_empty_by_default`, `infisical_tagged_container_in_infisical_ids`.
- [x] `terraform test` (modules/firewall): **14 passed, 0 failed** — includes new `infisical_rules_always_one`, `infisical_rule_dport_matches_constant`, `infisical_rule_source_matches_joined_networks`, plus DRY-tracking assertions on minio/notification ports.
- [x] `terraform fmt -recursive` clean.
- [x] `tflint --recursive` — no new warnings (all reported warnings pre-existing in unrelated modules).
- [x] Pre-commit hooks pass (Checkov, tofu test, end-of-file, trim whitespace).
- [ ] `terragrunt plan` against real state — **not yet run in this session**; the injected AWS creds were the source `terraform` IAM user, not the assumed `tf-proxmox` role, so the state bucket returned 403. Expected delta when re-planned with the right creds: 1 new LXC + 1 new security group (`infisical-svc`) + 1 firewall options resource + 1 firewall rules resource for vm_id 108. The DRY audit changes to existing security groups should show **no behavioural drift** (same dport values, just sourced from the constants map).

## Follow-ups

- Phase 1 PR 3: ansible-proxmox-apps role + HAProxy frontend wiring (separate PR).
- Promote remaining literal ports (syslog 514/1514:1518, NTP 123, splunk_forwarding 9997, iDRAC 5800/5801) into `pipeline_constants` in a dedicated DRY-audit PR.
- ACME cert delivery to LXCs — design decision pending (extend `modules/acme-certificate` to support per-cert SANs + LXC delivery, vs handle entirely in Ansible).

Refs: #136 (Phase 1, PR 2 of 3)

---

## Live `terragrunt plan` (post-merge sync, 2026-05-24T13:16Z)

Ran against the assumed `tf-proxmox` role; state-bucket access OK.

**Summary**: `Plan: 12 to add, 4 to change, 0 to destroy.`

### This PR contributes (4 of the 12 adds)

- `module.containers[0].proxmox_virtual_environment_container.containers["infisical"]` (vm_id 108)
- `module.firewall.proxmox_virtual_environment_cluster_firewall_security_group.infisical_services`
- `module.firewall.proxmox_virtual_environment_firewall_options.infisical_container["infisical"]`
- `module.firewall.proxmox_virtual_environment_firewall_rules.infisical_container["infisical"]`

### Pre-existing drift (already in tracked config, not yet applied to the cluster — NOT from this PR)

- `containers["openproject"]`
- `vms["idrac-kvm"]` + `firewall_options.idrac_kvm["idrac-kvm"]` + `firewall_rules.idrac_kvm["idrac-kvm"]`
- `firewall.idrac_kvm_svc` and `firewall.ntp_server` security groups
- `firewall.node` + `firewall_rules.node`
- `splunk_vm.cloud_init` (cosmetic in-place)
- `vms["docker-host"]` (tag set)

### DRY audit verification — the two in-place security-group updates are comment-only

The `pipeline_services` and `cribl_stream_services` updates are **cosmetic comment changes**, no behavioral drift:

```
~ comment = "Cribl Stream API TCP/9000 from internal" -> "Cribl Stream API from internal"
~ comment = "Cribl Edge API TCP/9420 from internal"   -> "Cribl Edge API from internal"
```

`dport`, `proto`, `source`, `action`, `type` all unchanged. The port number was removed from the human-readable comment because it now derives from `var.pipeline_constants.service_ports.{cribl_stream_api,cribl_edge_api}` — keeping a literal in the comment would defeat the DRY audit. No behavioral drift introduced.
