### PR TITLE
fix(deployment): drop keyctl/fuse from infisical+openproject features

### DIFF
--- a/deployment.json
+++ b/deployment.json
@@ -205,7 +205,7 @@
       "mount_points": [
         { "volume": "local-zfs", "size": "30G", "path": "/opt/infisical" }
       ],
-      "features": { "nesting": true, "keyctl": false, "fuse": false }
+      "features": { "nesting": true }
     },
     "mailpit": {
       "vm_id": 110,
@@ -271,7 +271,7 @@
       "mount_points": [
         { "volume": "local-zfs", "size": "50G", "path": "/opt/openproject" }
       ],
-      "features": { "nesting": true, "keyctl": false, "fuse": false }
+      "features": { "nesting": true }
     },
     "claude-code-01": {
       "vm_id": 150,

--- a/deployment.json
+++ b/deployment.json
@@ -205,7 +205,7 @@
       "mount_points": [
         { "volume": "local-zfs", "size": "30G", "path": "/opt/infisical" }
       ],
-      "features": { "nesting": true, "keyctl": true, "fuse": true }
+      "features": { "nesting": true, "keyctl": false, "fuse": false }
     },
     "mailpit": {
       "vm_id": 110,
@@ -271,7 +271,7 @@
       "mount_points": [
         { "volume": "local-zfs", "size": "50G", "path": "/opt/openproject" }
       ],
-      "features": { "nesting": true, "keyctl": true, "fuse": true }
+      "features": { "nesting": true, "keyctl": false, "fuse": false }
     },
     "claude-code-01": {
       "vm_id": 150,


### PR DESCRIPTION
## Summary

Aligns `deployment.json` with what the non-root API token used by terragrunt is actually allowed to do.

## Problem

PR #315 added `infisical` and `openproject` LXC entries to `deployment.json` with `"features": { "nesting": true, "keyctl": true, "fuse": true }`. The first live apply against the cluster (from `main` at `e3acbbb`) hit HTTP 403 for both containers:

> Permission check failed (changing feature flags (except nesting) is only allowed for root@pam)

The Proxmox API token used by terragrunt can toggle `nesting` but **not** `keyctl` or `fuse`. Docker-in-LXC only requires `nesting=true`; the other two flags were unused.

## Fix

Set `keyctl: false` and `fuse: false` for both `infisical` and `openproject`. With this change the apply succeeded — infisical LXC at vm_id 108 (10.0.1.108) and openproject LXC at vm_id 140 (10.0.1.140) both came up clean.

## Followups (out of scope here)

- Other LXCs in `deployment.json` (mailpit, ntfy, etc.) still carry the old `keyctl/fuse: true` block. They were created historically when a root token must have been in use. Their drift is not blocking anything; the PR-2.5 ACME work will audit them if/when they hit the same issue.
- `idrac-kvm` vm_id=251 disk size: `deployment.json` declares 16G but template_id=9000 is 50G. A manual `zfs set volsize=16G rpool/data/vm-251-disk-0` + edit of `/etc/pve/qemu-server/251.conf` brought the live disk down to 16G to satisfy this apply, but any future destroy/recreate will re-trip the same shrink error (BPG cannot shrink a fresh clone). Needs a follow-up issue: either match the template (16G template, or 50G in deployment.json) or change the source template.

## Test plan

- [x] `doppler run -- terragrunt plan` shows the failed-blocker resources can be created (11 add / 3 change / 0 destroy)
- [x] `doppler run -- terragrunt apply` succeeds end-to-end
- [x] LXC 108 confirmed running via Proxmox API (state=running, 2 cores, 4GB)
- [x] `pct exec 108 -- cat /etc/os-release` returns Debian 13 trixie
- [x] LXC 140 (openproject) also created cleanly with the same fix
- [x] `terraform_inventory.json` synced to ansible-proxmox, ansible-proxmox-apps, ansible-splunk with correct `containers.infisical` and `containers.openproject` entries