### PR TITLE
feat(acme): SAN list + per-LXC/VM cert delivery via null_resource

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -72,6 +72,14 @@ locals {
     if contains(coalesce(try(v.tags, null), []), "infisical")
   }
 
+  # HAProxy LXCs (haproxy tag) — receive delivered ACME certs for HTTPS frontends.
+  # Distinct from pipeline_container_ids (which also includes Cribl Edge); this
+  # local is dedicated to cert-delivery targeting.
+  haproxy_container_ids = {
+    for k, v in var.containers : k => v.vm_id
+    if contains(coalesce(try(v.tags, null), []), "haproxy")
+  }
+
   # Cribl Stream containers: tagged cribl + stream (receives from Edge, routes to Splunk)
   # Distinct from pipeline_container_ids (HAProxy + Cribl Edge) as it doesn't receive external traffic
   cribl_stream_container_ids = {

--- a/main.tf
+++ b/main.tf
@@ -219,7 +219,16 @@ module "acme_certificates" {
   acme_certificates = var.acme_certificates
   environment       = var.environment
 
-  depends_on = [module.pools]
+  # SSH credentials for the null_resource cert-delivery provisioner.
+  # The provisioner SSHes to the Proxmox node and uses `pct push` (LXC) or
+  # `scp` (VM) to deliver the issued cert to each destination configured
+  # in acme_certificates[*].destinations.
+  proxmox_ssh_host        = var.proxmox_ssh_host
+  proxmox_ssh_username    = var.proxmox_ssh_username
+  proxmox_ssh_private_key = var.proxmox_ssh_private_key
+
+  # Ensure the LXCs/VMs we deliver to exist before the cert lands.
+  depends_on = [module.pools, module.containers, module.vms, module.splunk_vm]
 }
 
 # Rack-server cluster inventory. Declarative-only today (no resources

--- a/modules/acme-certificate/README.md
+++ b/modules/acme-certificate/README.md
@@ -1,29 +1,29 @@
 # ACME Certificate Module
 
-This module manages ACME (Let's Encrypt) certificates for Proxmox VE nodes using the BPG Proxmox provider.
+Manages Let's Encrypt certificates for Proxmox VE nodes (via the BPG provider) and optionally
+delivers the issued certs to LXCs and VMs for use by services like HAProxy and Splunk.
 
-## Overview
+## What this module owns
 
-The module handles three key components:
+- **`proxmox_acme_account`** — Let's Encrypt account registration.
+- **`proxmox_acme_dns_plugin`** — DNS-01 challenge provider config (credentials carried in `data`).
+- **`proxmox_acme_certificate`** — the per-node cert resource. Supports a primary domain + SANs.
+- **`null_resource.cert_delivery`** — pushes the issued cert to LXC/VM destinations via SSH to the
+  Proxmox node, using `pct push` (LXC) or `scp` (VM).
 
-1. **ACME Accounts** - Let's Encrypt account registration
-2. **DNS Challenge Plugins** - DNS-01 validation via AWS Route53
-3. **ACME Certificates** - Certificate ordering and lifecycle management
-
-## Features
-
-- ✅ Let's Encrypt certificate provisioning
-- ✅ AWS Route53 DNS-01 challenge support
-- ✅ Automatic certificate renewal (via Proxmox)
-- ✅ Multi-account and multi-certificate support via `for_each`
-- ✅ Terraform state management for existing certificates
+The module does **not** manage Route53 hosted zones (see `aws-infra/` for that).
 
 ## Requirements
 
-1. **Proxmox VE** with ACME support (tested with 7.x+)
-2. **AWS Route53** access for DNS challenge validation
-3. **Doppler** configured with Route53 credentials
-4. **BPG Proxmox Provider** >= 0.90.0
+- Proxmox VE node with cluster-level ACME support (PVE 7.x+).
+- BPG Proxmox provider `~> 0.106`, hashicorp/null `~> 3.2`.
+- A reachable ACME directory (Let's Encrypt prod or staging).
+- A DNS-01 challenge provider (this repo uses AWS Route53; credentials must live in SOPS or
+  Doppler, never plaintext).
+- SSH access from the Terraform-runner host to the Proxmox node (`var.proxmox_ssh_host`,
+  `var.proxmox_ssh_username`, `var.proxmox_ssh_private_key`).
+- For VM delivery destinations: SSH access from the Proxmox node to each VM's `target_ip` as
+  `root` (cloud-init sets this up via the `vm-access-key` injected at template build time).
 
 ## Usage
 
@@ -32,275 +32,197 @@ module "acme_certificates" {
   source = "./modules/acme-certificate"
 
   acme_accounts = {
-    "letsencrypt" = {
-      email      = "admin@example.com"
-      directory  = "https://acme-v02.api.letsencrypt.org/directory"
-      tos_agreed = true
+    default = {
+      email     = "you@example.com"
+      directory = "https://acme-v02.api.letsencrypt.org/directory"
+      tos       = "https://letsencrypt.org/documents/LE-SA-v1.5-February-24-2025.pdf"
     }
   }
 
   dns_plugins = {
-    "route53" = {
-      plugin_type = "route53"
-      api_type    = "aws"
+    AWS = {
+      plugin_type = "aws"
+      data = {
+        AWS_ACCESS_KEY_ID     = "<from SOPS>"
+        AWS_SECRET_ACCESS_KEY = "<from SOPS>"
+      }
     }
   }
 
   acme_certificates = {
-    "pve-cert" = {
-      node_name      = "pve"
-      domain         = "pve.example.com"
-      account_id     = "letsencrypt"
-      dns_plugin_id  = "route53"
+    pve = {
+      node_name     = "pve"
+      domain        = "pve.example.com"
+      account_id    = "default"
+      dns_plugin_id = "AWS"
+      sans = [
+        "infisical.example.com",
+        "splunk.example.com",
+      ]
+      destinations = [
+        {
+          kind        = "lxc"
+          target_id   = 175
+          bundle_path = "/etc/ssl/private/haproxy.pem"
+          reload_cmd  = "systemctl reload haproxy"
+        },
+        {
+          kind       = "vm"
+          target_id  = 200
+          target_ip  = "10.0.1.200"
+          cert_path  = "/opt/splunk/etc/auth/server.pem"
+          key_path   = "/opt/splunk/etc/auth/server.key"
+          owner      = "splunk"
+          group      = "splunk"
+          reload_cmd = "/opt/splunk/bin/splunk restart splunkweb"
+        },
+      ]
     }
   }
 
-  environment = "homelab"
+  proxmox_ssh_host        = var.proxmox_ssh_host
+  proxmox_ssh_username    = var.proxmox_ssh_username
+  proxmox_ssh_private_key = var.proxmox_ssh_private_key
+  environment             = "homelab"
 }
 ```
 
-## Variables
+## Schema
 
 ### `acme_accounts`
 
-Map of ACME account configurations.
-
-**Example:**
-
-```hcl
-acme_accounts = {
-  "letsencrypt" = {
-    email      = "admin@example.com"
-    directory  = "https://acme-v02.api.letsencrypt.org/directory"  # Production
-    tos_agreed = true
-  }
-  "letsencrypt-staging" = {
-    email      = "admin@example.com"
-    directory  = "https://acme-staging-v02.api.letsencrypt.org/directory"  # Testing
-    tos_agreed = true
-  }
-}
-```
-
-**Fields:**
-
-- `email` - Email for Let's Encrypt notifications (required)
-- `directory` - ACME directory URL (required)
-  - Production: `https://acme-v02.api.letsencrypt.org/directory`
-  - Staging: `https://acme-staging-v02.api.letsencrypt.org/directory`
-- `tos_agreed` - Agree to Let's Encrypt TOS (default: true)
+Same shape as before. `directory` is the LE production or staging URL; `tos` is the current
+ToS URL (drift on `tos` is ignored via lifecycle).
 
 ### `dns_plugins`
 
-Map of DNS challenge plugin configurations.
-
-**Example (Route53):**
-
-```hcl
-dns_plugins = {
-  "route53" = {
-    plugin_type = "route53"
-    api_type    = "aws"
-  }
-}
-```
-
-**Fields:**
-
-- `plugin_type` - Plugin identifier (e.g., "route53", "dns01")
-- `api_type` - API type (e.g., "aws")
-
-**Note:** API credentials (AWS access key, secret key) are stored in Proxmox at `/etc/pve/priv/acme/plugins.cfg`, not managed by this module.
+`data` is a free-form map carrying provider credentials. For Route53:
+`{ AWS_ACCESS_KEY_ID = "...", AWS_SECRET_ACCESS_KEY = "..." }`. Must come from SOPS/Doppler.
 
 ### `acme_certificates`
 
-Map of certificate configurations.
+Each entry produces one `proxmox_acme_certificate` covering `domain` (CN) plus all `sans` (each
+validated through the same `dns_plugin_id`). Optional `destinations` list configures cert
+delivery to LXCs/VMs after issuance.
 
-**Example:**
+#### Destination fields
 
-```hcl
-acme_certificates = {
-  "pve-cert" = {
-    node_name      = "pve"
-    domain         = "pve.example.com"
-    account_id     = "letsencrypt"
-    dns_plugin_id  = "route53"
-  }
-}
+| Field | Required | Notes |
+| --- | --- | --- |
+| `kind` | yes | `"lxc"` or `"vm"` |
+| `target_id` | yes | vm_id of the LXC or VM |
+| `target_ip` | when kind = `"vm"` | SSH host for `scp` (pve node SSHes to this IP) |
+| `bundle_path` | one of... | Combined cert+key PEM (HAProxy, Caddy, nginx) |
+| `cert_path` | ...these... | Cert+chain PEM only (Splunk, Elasticsearch) |
+| `key_path` | ...combos | Private key (required alongside `cert_path`) |
+| `mode` | optional | File mode, default `0600` |
+| `owner` | optional | File owner, default `root` |
+| `group` | optional | File group, default `root` |
+| `reload_cmd` | optional | Command run on the target after delivery; runs on every re-trigger |
+
+Validation: each destination must set **either** `bundle_path` **or** both `cert_path` and
+`key_path`. VMs additionally require `target_ip`.
+
+### `proxmox_ssh_host` / `proxmox_ssh_username` / `proxmox_ssh_private_key`
+
+SSH credentials for the cert-delivery null_resource. Sourced from Doppler
+(`PROXMOX_VE_HOSTNAME`, `PROXMOX_SSH_USERNAME`, `PROXMOX_SSH_PRIVATE_KEY`) and threaded through
+`terragrunt.hcl` → root `main.tf`.
+
+## Delivery model
+
+The Proxmox node is the source of truth for the issued cert
+(`/etc/pve/local/pveproxy-ssl.{pem,key}`). When `proxmox_acme_certificate` renews (Proxmox does
+this automatically ~30 days before expiry via `pve-daily-update.service`), the cert's
+`not_after` and `fingerprint` attributes change. The `null_resource.cert_delivery` triggers on
+those changes and re-pushes the cert to every destination, then runs each `reload_cmd`.
+
+For **LXC** destinations:
+
+1. SSH to the Proxmox node.
+2. Build the bundle (`cat pveproxy-ssl.pem pveproxy-ssl.key`) and/or split files in a per-job tmpdir.
+3. `pct exec` to ensure target directories exist.
+4. `pct push` the file(s) with `--user 0 --group 0 --perms <mode>`.
+5. `pct exec` the `reload_cmd` if set.
+
+For **VM** destinations:
+
+1. SSH to the Proxmox node.
+2. Build the bundle/split files in a per-job tmpdir.
+3. SSH from the Proxmox node to the VM's `target_ip` to create target directories.
+4. `scp` the file(s) from the Proxmox node to the VM.
+5. SSH to set `chmod`/`chown`.
+6. SSH to run the `reload_cmd` if set.
+
+## Importing existing resources
+
+If your Proxmox node already has a manually-configured ACME account, plugin, and certificate,
+import them before the first `apply`:
+
+```bash
+cd <repo>/main
+
+# 1. Account — name from `pvesh get /cluster/acme/account` (default in homelab is "default")
+doppler run -- terragrunt run -- import \
+  'module.acme_certificates[0].proxmox_acme_account.accounts["default"]' \
+  'default'
+
+# 2. DNS plugin — name from `pvesh get /cluster/acme/plugins`
+doppler run -- terragrunt run -- import \
+  'module.acme_certificates[0].proxmox_acme_dns_plugin.dns_plugins["AWS"]' \
+  'AWS'
+
+# 3. Certificate — ID is the node name
+doppler run -- terragrunt run -- import \
+  'module.acme_certificates[0].proxmox_acme_certificate.certificates["pve"]' \
+  'pve'
 ```
 
-**Fields:**
+After import, run `terragrunt plan`. Expected diff:
 
-- `node_name` - Proxmox node name (e.g., "pve")
-- `domain` - Primary domain for certificate
-- `account_id` - Associated ACME account ID
-- `dns_plugin_id` - DNS plugin ID for DNS-01 validation
+- **Account**: zero changes (assuming HCL email/directory/tos match).
+- **DNS plugin**: zero changes if HCL `data` matches what's stored in PVE. Update SOPS to match
+  if there's drift.
+- **Certificate**: drift on `domains` if you're adding SANs in HCL that weren't on the live
+  cert. Apply triggers re-issuance with the new SAN list.
 
-### `environment`
-
-Environment name for organization and tagging.
-
-**Default:** `"homelab"`
+`null_resource.cert_delivery` is not importable; the first apply pushes the cert to every
+configured destination.
 
 ## Outputs
 
-### `acme_accounts`
+| Output | Sensitive | Notes |
+| --- | --- | --- |
+| `acme_accounts` | no | Map of `{id, email}` per account |
+| `dns_plugins` | yes | Map of `{id, plugin}` per plugin |
+| `certificates` | no | Map of `{node_name, account, domains, not_after, issuer, subject}` |
+| `cert_deliveries` | no | Map of `{cert_key, kind, target_id, target_ip, bundle_path, cert_path, key_path}` per delivery job |
 
-Account information including ID and email address.
-
-```hcl
-output "accounts" {
-  value = module.acme_certificates.acme_accounts
-}
-# {
-#   "letsencrypt" = {
-#     id    = "letsencrypt"
-#     email = "admin@example.com"
-#   }
-# }
-```
-
-### `dns_plugins`
-
-Configured DNS challenge plugins.
-
-```hcl
-output "plugins" {
-  value = module.acme_certificates.dns_plugins
-}
-# {
-#   "route53" = {
-#     id       = "route53"
-#     plugin   = "route53"
-#     api_type = "aws"
-#   }
-# }
-```
-
-### `certificates`
-
-Certificate details including node, account, and domains.
-
-```hcl
-output "certs" {
-  value = module.acme_certificates.certificates
-}
-# {
-#   "pve-cert" = {
-#     node_name = "pve"
-#     account   = "letsencrypt"
-#     domains   = ["pve.example.com"]
-#   }
-# }
-```
-
-## Certificate Lifecycle
-
-### Ordering
-
-When a certificate is first created:
-
-1. Proxmox contacts Let's Encrypt ACME directory
-2. Proxmox creates DNS TXT records for validation
-3. Let's Encrypt validates DNS records
-4. Certificate is issued and stored in Proxmox
-
-### Renewal
-
-Proxmox automatically renews certificates via `pve-daily-update.service`:
-
-- Runs daily
-- Checks certificates 30 days before expiry
-- Re-validates via DNS-01 challenge
-- Updates certificate in place
-
-**Monitor renewal:**
+## Renewal monitoring
 
 ```bash
-systemctl status pve-daily-update.timer
-journalctl -u pve-daily-update.service --since "7 days ago"
+ssh root@<pve-host> 'systemctl status pve-daily-update.timer'
+ssh root@<pve-host> 'journalctl -u pve-daily-update.service --since "7 days ago"'
+# Manual order:
+ssh root@<pve-host> 'pvenode acme cert order'
 ```
 
-### Manual Renewal
-
-If needed, trigger renewal manually:
-
-```bash
-pvenode acme cert order
-```
-
-## Importing Existing Certificates
-
-If you have existing ACME certificates in Proxmox, import them:
-
-```bash
-# Import ACME account
-terraform import 'module.acme_certificates.proxmox_virtual_environment_acme_account.accounts["letsencrypt"]' 'letsencrypt'
-
-# Import DNS plugin
-terraform import 'module.acme_certificates.proxmox_virtual_environment_acme_dns_plugin.dns_plugins["route53"]' 'route53'
-
-# Import certificate
-terraform import 'module.acme_certificates.proxmox_virtual_environment_acme_certificate.certificates["pve-cert"]' 'pve'
-```
+When Proxmox renews, the next `terragrunt apply` (or any plan that refreshes the `null_resource`
+triggers) will re-push the cert to every destination automatically.
 
 ## Troubleshooting
 
-### Certificate ordering fails with DNS validation error
-
-**Issue:** Let's Encrypt cannot validate DNS records
-
-**Causes:**
-
-- Route53 credentials incorrect
-- IAM permissions insufficient
-- DNS records not propagating
-- Proxmox cannot reach AWS
-
-**Solution:**
-
-1. Verify Route53 IAM policy allows DNS operations
-2. Check DNS propagation: `dig -t TXT _acme-challenge.pve.example.com @8.8.8.8`
-3. Monitor Proxmox logs: `journalctl -u pve-daily-update.service`
-
-### Certificate renewal fails
-
-**Issue:** Proxmox cannot renew existing certificate
-
-**Causes:**
-
-- Route53 credentials expired or revoked
-- DNS plugin misconfiguration
-- Proxmox service issues
-
-**Solution:**
-
-1. Verify Doppler secrets are up to date
-2. Check Proxmox service status: `systemctl status pveproxy`
-3. Review renewal logs: `journalctl -u pve-daily-update.service`
-
-### Terraform plan shows changes after import
-
-**Issue:** Imported resources don't match Terraform configuration
-
-**Solution:**
-
-1. Extract imported state: `terraform state show 'module.acme_certificates.proxmox_virtual_environment_acme_account.accounts["letsencrypt"]'`
-2. Compare with variable values
-3. Update variables to match Proxmox configuration
-4. Re-run plan to verify zero drift
-
-## Best Practices
-
-1. **Use production Let's Encrypt** - Only use staging for testing due to rate limits
-2. **Monitor renewals** - Set up alerts for renewal failures
-3. **Rotate credentials** - Rotate Route53 IAM keys quarterly
-4. **Backup certificates** - Keep exported certificate copies
-5. **Document changes** - Keep Terraform configuration in sync with manual changes
+| Symptom | Likely cause |
+| --- | --- |
+| Plan wants to recreate the account | `tos` or `directory` mismatch — update SOPS to match the live account |
+| Plan wants to recreate the DNS plugin | `data` map drift (AWS key rotated outside Terraform) — update SOPS |
+| Cert order fails with DNS validation | Route53 IAM perms insufficient, or wrong zone; check `journalctl -u pveproxy` |
+| `pct push` fails with "no such file" | Target directory doesn't exist — module auto-`mkdir -p`s but check the path |
+| `scp` to VM fails with auth error | PVE node lacks SSH access to the VM as `root`; check `~/.ssh/authorized_keys` |
+| `reload_cmd` fails but cert is delivered | Command syntax issue — run it manually on the target to debug |
 
 ## References
 
-- [BPG Proxmox Provider](https://github.com/bpg/terraform-provider-proxmox)
-- [Proxmox Certificate Management](https://pve.proxmox.com/wiki/Certificate_Management)
-- [Let's Encrypt Documentation](https://letsencrypt.org/docs/)
-- [ACME DNS API Support](https://github.com/acmesh-official/acme.sh/blob/master/dnsapi/README.md)
+- [BPG Proxmox Provider — proxmox_acme_certificate](https://registry.terraform.io/providers/bpg/proxmox/latest/docs/resources/acme_certificate)
+- [Proxmox Wiki — Certificate Management](https://pve.proxmox.com/wiki/Certificate_Management)
+- [Let's Encrypt — ACME v2 directory](https://letsencrypt.org/docs/)

--- a/modules/acme-certificate/main.tf
+++ b/modules/acme-certificate/main.tf
@@ -4,11 +4,15 @@ terraform {
       source  = "bpg/proxmox"
       version = "~> 0.106"
     }
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.2"
+    }
   }
 }
 
-# ACME Account - Let's Encrypt account registration
-# This is a prerequisite for certificate ordering
+# ACME Account - Let's Encrypt account registration.
+# Prerequisite for certificate ordering.
 resource "proxmox_acme_account" "accounts" {
   for_each = var.acme_accounts
 
@@ -17,45 +21,142 @@ resource "proxmox_acme_account" "accounts" {
   directory = each.value.directory
   tos       = each.value.tos
 
-  # Prevent unnecessary drift after initial creation
-  # Account properties are managed by Let's Encrypt
+  # Account ToS URL drifts as Let's Encrypt updates it; ignoring prevents
+  # spurious diffs after creation.
   lifecycle {
     ignore_changes = [tos]
   }
 }
 
-# DNS Challenge Plugin - AWS Route53
-# Configures Route53 as the DNS-01 challenge provider for ACME validation
-# This allows certificate validation without exposing port 80 publicly
+# DNS Challenge Plugin - configures the DNS-01 challenge provider.
+# `data` carries provider credentials and MUST come from SOPS or Doppler.
+# Never write plaintext credentials to the repo.
 resource "proxmox_acme_dns_plugin" "dns_plugins" {
   for_each = var.dns_plugins
 
-  plugin = each.key               # Plugin identifier (e.g., "myroute53")
-  api    = each.value.plugin_type # API plugin name (e.g., "route53")
-  data   = each.value.data        # DNS plugin data (credentials as key=value pairs)
+  plugin = each.key
+  api    = each.value.plugin_type
+  data   = each.value.data
 }
 
-# ACME Certificate - the actual TLS certificate
-# This resource manages the certificate lifecycle including ordering and renewal
-# Proxmox automatically renews certificates 30 days before expiry via pve-daily-update.service
+# ACME Certificate - the actual TLS certificate.
+#
+# Multi-domain: each cert covers `domain` (primary CN) plus all `sans`
+# entries. Every domain in the list validates via DNS-01 using the same
+# dns_plugin_id (DRY: single plugin per cert). The issued cert lands at
+# /etc/pve/local/pveproxy-ssl.{pem,key} on `node_name`.
+#
+# Proxmox auto-renews certs ~30 days before expiry via
+# pve-daily-update.service. Terraform manages the resource declaratively
+# and respects Proxmox's renewal cadence.
 resource "proxmox_acme_certificate" "certificates" {
   for_each = var.acme_certificates
 
   node_name = each.value.node_name
   account   = each.value.account_id
-  domains = [
-    {
-      domain = each.value.domain
-      plugin = each.value.dns_plugin_id
-    }
-  ]
 
-  # Note: Proxmox manages certificate renewal automatically via pve-daily-update.service
-  # Terraform manages the certificate resource but respects Proxmox's automatic renewal
+  domains = concat(
+    [{ domain = each.value.domain, plugin = each.value.dns_plugin_id }],
+    [for s in each.value.sans : { domain = s, plugin = each.value.dns_plugin_id }]
+  )
 
-  # Ensure dependencies are satisfied
   depends_on = [
     proxmox_acme_account.accounts,
     proxmox_acme_dns_plugin.dns_plugins
   ]
+}
+
+locals {
+  # Flatten cert -> destinations into a list of delivery jobs, keyed by
+  # "<cert_key>__<dest_index>" so the null_resource for_each can index it.
+  cert_deliveries = merge([
+    for cert_key, cert in var.acme_certificates : {
+      for idx, dest in cert.destinations :
+      "${cert_key}__${idx}" => {
+        cert_key    = cert_key
+        node_name   = cert.node_name
+        kind        = dest.kind
+        target_id   = dest.target_id
+        target_ip   = coalesce(dest.target_ip, "")
+        bundle_path = coalesce(dest.bundle_path, "")
+        cert_path   = coalesce(dest.cert_path, "")
+        key_path    = coalesce(dest.key_path, "")
+        mode        = dest.mode
+        owner       = dest.owner
+        group       = dest.group
+        reload_cmd  = dest.reload_cmd
+      }
+    }
+  ]...)
+}
+
+# Cert delivery to LXCs/VMs.
+#
+# Connection: SSH to the Proxmox node (var.proxmox_ssh_*). The provisioner
+# reads /etc/pve/local/pveproxy-ssl.{pem,key} (where Proxmox writes the
+# node's cert, including auto-renewals) and pushes it to each destination
+# via `pct push` (LXC) or `scp` (VM).
+#
+# Trigger model: re-runs when the cert's not_after timestamp or fingerprint
+# changes (on renewal), when any destination shape changes, or when the
+# reload command changes. The reload_cmd runs on every re-run.
+#
+# Bundle vs split mode:
+#   - bundle_path: combined cert+key PEM (HAProxy, Caddy, nginx)
+#   - cert_path + key_path: separate files (Splunk, Elasticsearch)
+# Either or both can be set per destination.
+resource "null_resource" "cert_delivery" {
+  for_each = local.cert_deliveries
+
+  triggers = {
+    not_after   = proxmox_acme_certificate.certificates[each.value.cert_key].not_after
+    fingerprint = proxmox_acme_certificate.certificates[each.value.cert_key].fingerprint
+    target      = "${each.value.kind}:${each.value.target_id}:${each.value.bundle_path}:${each.value.cert_path}:${each.value.key_path}:${each.value.mode}:${each.value.owner}:${each.value.group}"
+    reload      = each.value.reload_cmd
+  }
+
+  connection {
+    type        = "ssh"
+    host        = var.proxmox_ssh_host
+    user        = var.proxmox_ssh_username
+    private_key = var.proxmox_ssh_private_key
+  }
+
+  provisioner "remote-exec" {
+    inline = each.value.kind == "lxc" ? [
+      "set -e",
+      "umask 077",
+      "TMPDIR=$(mktemp -d)",
+      "trap 'rm -rf $TMPDIR' EXIT",
+      each.value.bundle_path != "" ? "cat /etc/pve/local/pveproxy-ssl.pem /etc/pve/local/pveproxy-ssl.key > $TMPDIR/bundle.pem" : ":",
+      each.value.cert_path != "" ? "cp /etc/pve/local/pveproxy-ssl.pem $TMPDIR/cert.pem" : ":",
+      each.value.key_path != "" ? "cp /etc/pve/local/pveproxy-ssl.key $TMPDIR/key.pem" : ":",
+      each.value.bundle_path != "" ? "pct exec ${each.value.target_id} -- mkdir -p $(dirname '${each.value.bundle_path}')" : ":",
+      each.value.bundle_path != "" ? "pct push ${each.value.target_id} $TMPDIR/bundle.pem '${each.value.bundle_path}' --user 0 --group 0 --perms ${each.value.mode}" : ":",
+      each.value.cert_path != "" ? "pct exec ${each.value.target_id} -- mkdir -p $(dirname '${each.value.cert_path}')" : ":",
+      each.value.cert_path != "" ? "pct push ${each.value.target_id} $TMPDIR/cert.pem '${each.value.cert_path}' --user 0 --group 0 --perms ${each.value.mode}" : ":",
+      each.value.key_path != "" ? "pct exec ${each.value.target_id} -- mkdir -p $(dirname '${each.value.key_path}')" : ":",
+      each.value.key_path != "" ? "pct push ${each.value.target_id} $TMPDIR/key.pem '${each.value.key_path}' --user 0 --group 0 --perms ${each.value.mode}" : ":",
+      each.value.reload_cmd != "" ? "pct exec ${each.value.target_id} -- sh -c '${each.value.reload_cmd}'" : ":",
+      ] : [
+      "set -e",
+      "umask 077",
+      "TMPDIR=$(mktemp -d)",
+      "trap 'rm -rf $TMPDIR' EXIT",
+      each.value.bundle_path != "" ? "cat /etc/pve/local/pveproxy-ssl.pem /etc/pve/local/pveproxy-ssl.key > $TMPDIR/bundle.pem" : ":",
+      each.value.cert_path != "" ? "cp /etc/pve/local/pveproxy-ssl.pem $TMPDIR/cert.pem" : ":",
+      each.value.key_path != "" ? "cp /etc/pve/local/pveproxy-ssl.key $TMPDIR/key.pem" : ":",
+      "SSH_OPTS='-o BatchMode=yes -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/root/.ssh/known_hosts'",
+      each.value.bundle_path != "" ? "ssh $SSH_OPTS root@${each.value.target_ip} \"mkdir -p $(dirname '${each.value.bundle_path}')\"" : ":",
+      each.value.bundle_path != "" ? "scp $SSH_OPTS $TMPDIR/bundle.pem root@${each.value.target_ip}:'${each.value.bundle_path}'" : ":",
+      each.value.cert_path != "" ? "ssh $SSH_OPTS root@${each.value.target_ip} \"mkdir -p $(dirname '${each.value.cert_path}')\"" : ":",
+      each.value.cert_path != "" ? "scp $SSH_OPTS $TMPDIR/cert.pem root@${each.value.target_ip}:'${each.value.cert_path}'" : ":",
+      each.value.key_path != "" ? "ssh $SSH_OPTS root@${each.value.target_ip} \"mkdir -p $(dirname '${each.value.key_path}')\"" : ":",
+      each.value.key_path != "" ? "scp $SSH_OPTS $TMPDIR/key.pem root@${each.value.target_ip}:'${each.value.key_path}'" : ":",
+      each.value.bundle_path != "" ? "ssh $SSH_OPTS root@${each.value.target_ip} \"chmod ${each.value.mode} '${each.value.bundle_path}' && chown ${each.value.owner}:${each.value.group} '${each.value.bundle_path}'\"" : ":",
+      each.value.cert_path != "" ? "ssh $SSH_OPTS root@${each.value.target_ip} \"chmod ${each.value.mode} '${each.value.cert_path}' && chown ${each.value.owner}:${each.value.group} '${each.value.cert_path}'\"" : ":",
+      each.value.key_path != "" ? "ssh $SSH_OPTS root@${each.value.target_ip} \"chmod ${each.value.mode} '${each.value.key_path}' && chown ${each.value.owner}:${each.value.group} '${each.value.key_path}'\"" : ":",
+      each.value.reload_cmd != "" ? "ssh $SSH_OPTS root@${each.value.target_ip} \"${each.value.reload_cmd}\"" : ":",
+    ]
+  }
 }

--- a/modules/acme-certificate/main.tf
+++ b/modules/acme-certificate/main.tf
@@ -111,7 +111,7 @@ resource "null_resource" "cert_delivery" {
   triggers = {
     not_after   = proxmox_acme_certificate.certificates[each.value.cert_key].not_after
     fingerprint = proxmox_acme_certificate.certificates[each.value.cert_key].fingerprint
-    target      = "${each.value.kind}:${each.value.target_id}:${each.value.bundle_path}:${each.value.cert_path}:${each.value.key_path}:${each.value.mode}:${each.value.owner}:${each.value.group}"
+    target      = "${each.value.kind}:${each.value.target_id}:${each.value.target_ip}:${each.value.bundle_path}:${each.value.cert_path}:${each.value.key_path}:${each.value.mode}:${each.value.owner}:${each.value.group}"
     reload      = each.value.reload_cmd
   }
 
@@ -132,11 +132,11 @@ resource "null_resource" "cert_delivery" {
       each.value.cert_path != "" ? "cp /etc/pve/local/pveproxy-ssl.pem $TMPDIR/cert.pem" : ":",
       each.value.key_path != "" ? "cp /etc/pve/local/pveproxy-ssl.key $TMPDIR/key.pem" : ":",
       each.value.bundle_path != "" ? "pct exec ${each.value.target_id} -- mkdir -p $(dirname '${each.value.bundle_path}')" : ":",
-      each.value.bundle_path != "" ? "pct push ${each.value.target_id} $TMPDIR/bundle.pem '${each.value.bundle_path}' --user 0 --group 0 --perms ${each.value.mode}" : ":",
+      each.value.bundle_path != "" ? "pct push ${each.value.target_id} $TMPDIR/bundle.pem '${each.value.bundle_path}' --user ${each.value.owner} --group ${each.value.group} --perms ${each.value.mode}" : ":",
       each.value.cert_path != "" ? "pct exec ${each.value.target_id} -- mkdir -p $(dirname '${each.value.cert_path}')" : ":",
-      each.value.cert_path != "" ? "pct push ${each.value.target_id} $TMPDIR/cert.pem '${each.value.cert_path}' --user 0 --group 0 --perms ${each.value.mode}" : ":",
+      each.value.cert_path != "" ? "pct push ${each.value.target_id} $TMPDIR/cert.pem '${each.value.cert_path}' --user ${each.value.owner} --group ${each.value.group} --perms ${each.value.mode}" : ":",
       each.value.key_path != "" ? "pct exec ${each.value.target_id} -- mkdir -p $(dirname '${each.value.key_path}')" : ":",
-      each.value.key_path != "" ? "pct push ${each.value.target_id} $TMPDIR/key.pem '${each.value.key_path}' --user 0 --group 0 --perms ${each.value.mode}" : ":",
+      each.value.key_path != "" ? "pct push ${each.value.target_id} $TMPDIR/key.pem '${each.value.key_path}' --user ${each.value.owner} --group ${each.value.group} --perms ${each.value.mode}" : ":",
       each.value.reload_cmd != "" ? "pct exec ${each.value.target_id} -- sh -c '${each.value.reload_cmd}'" : ":",
       ] : [
       "set -e",

--- a/modules/acme-certificate/outputs.tf
+++ b/modules/acme-certificate/outputs.tf
@@ -20,12 +20,30 @@ output "dns_plugins" {
 }
 
 output "certificates" {
-  description = "ACME certificates information"
+  description = "ACME certificates information (includes primary CN + all SANs)"
   value = {
     for k, v in proxmox_acme_certificate.certificates : k => {
       node_name = v.node_name
       account   = v.account
       domains   = [for d in v.domains : d.domain]
+      not_after = v.not_after
+      issuer    = v.issuer
+      subject   = v.subject
+    }
+  }
+}
+
+output "cert_deliveries" {
+  description = "Cert delivery destinations (after null_resource provisioning)"
+  value = {
+    for k, j in local.cert_deliveries : k => {
+      cert_key    = j.cert_key
+      kind        = j.kind
+      target_id   = j.target_id
+      target_ip   = j.target_ip
+      bundle_path = j.bundle_path
+      cert_path   = j.cert_path
+      key_path    = j.key_path
     }
   }
 }

--- a/modules/acme-certificate/variables.tf
+++ b/modules/acme-certificate/variables.tf
@@ -39,14 +39,54 @@ variable "dns_plugins" {
 }
 
 variable "acme_certificates" {
-  description = "ACME certificates to provision and manage"
+  description = <<-EOT
+    ACME certificates to provision and manage. Each entry maps to a single
+    proxmox_acme_certificate resource per node, covering one primary domain
+    plus optional SANs. After issuance, the cert (combined PEM bundle and/or
+    split cert+key) can be delivered to LXCs or VMs via the module's
+    null_resource provisioner.
+
+    See README.md for the full schema and import procedure.
+  EOT
   type = map(object({
-    node_name     = string # Proxmox node name (e.g., "pve")
-    domain        = string # Primary domain for certificate
-    account_id    = string # Associated ACME account ID
-    dns_plugin_id = string # DNS plugin ID for validation
+    node_name     = string                      # Proxmox node name (e.g., "pve")
+    domain        = string                      # Primary domain (CN)
+    account_id    = string                      # ACME account name (key in var.acme_accounts)
+    dns_plugin_id = string                      # DNS plugin name (key in var.dns_plugins)
+    sans          = optional(list(string), []) # Additional SANs (each uses dns_plugin_id)
+    destinations = optional(list(object({
+      kind        = string                      # "lxc" or "vm"
+      target_id   = number                      # vm_id of the LXC or VM
+      target_ip   = optional(string)            # required when kind = "vm"
+      bundle_path = optional(string)            # combined cert+key PEM
+      cert_path   = optional(string)            # separate cert+chain PEM
+      key_path    = optional(string)            # separate private key
+      mode        = optional(string, "0600")
+      owner       = optional(string, "root")
+      group       = optional(string, "root")
+      reload_cmd  = optional(string, "")        # ran on target after delivery
+    })), [])
   }))
   default = {}
+}
+
+variable "proxmox_ssh_host" {
+  description = "Hostname/IP for SSH access to the Proxmox node. Used by the cert-delivery null_resource provisioner."
+  type        = string
+  default     = ""
+}
+
+variable "proxmox_ssh_username" {
+  description = "SSH username for the Proxmox node (e.g., \"root\")."
+  type        = string
+  default     = "root"
+}
+
+variable "proxmox_ssh_private_key" {
+  description = "SSH private key content or file path for connecting to the Proxmox node."
+  type        = string
+  sensitive   = true
+  default     = ""
 }
 
 variable "environment" {

--- a/modules/acme-certificate/variables.tf
+++ b/modules/acme-certificate/variables.tf
@@ -49,22 +49,22 @@ variable "acme_certificates" {
     See README.md for the full schema and import procedure.
   EOT
   type = map(object({
-    node_name     = string                      # Proxmox node name (e.g., "pve")
-    domain        = string                      # Primary domain (CN)
-    account_id    = string                      # ACME account name (key in var.acme_accounts)
-    dns_plugin_id = string                      # DNS plugin name (key in var.dns_plugins)
+    node_name     = string                     # Proxmox node name (e.g., "pve")
+    domain        = string                     # Primary domain (CN)
+    account_id    = string                     # ACME account name (key in var.acme_accounts)
+    dns_plugin_id = string                     # DNS plugin name (key in var.dns_plugins)
     sans          = optional(list(string), []) # Additional SANs (each uses dns_plugin_id)
     destinations = optional(list(object({
-      kind        = string                      # "lxc" or "vm"
-      target_id   = number                      # vm_id of the LXC or VM
-      target_ip   = optional(string)            # required when kind = "vm"
-      bundle_path = optional(string)            # combined cert+key PEM
-      cert_path   = optional(string)            # separate cert+chain PEM
-      key_path    = optional(string)            # separate private key
+      kind        = string           # "lxc" or "vm"
+      target_id   = number           # vm_id of the LXC or VM
+      target_ip   = optional(string) # required when kind = "vm"
+      bundle_path = optional(string) # combined cert+key PEM
+      cert_path   = optional(string) # separate cert+chain PEM
+      key_path    = optional(string) # separate private key
       mode        = optional(string, "0600")
       owner       = optional(string, "root")
       group       = optional(string, "root")
-      reload_cmd  = optional(string, "")        # ran on target after delivery
+      reload_cmd  = optional(string, "") # ran on target after delivery
     })), [])
   }))
   default = {}

--- a/terragrunt.hcl
+++ b/terragrunt.hcl
@@ -31,6 +31,7 @@ locals {
   env_var_defaults = {
     proxmox_node            = get_env("PROXMOX_VE_NODE", "pve")
     proxmox_ssh_private_key = get_env("PROXMOX_SSH_PRIVATE_KEY", "")
+    proxmox_ssh_host        = get_env("PROXMOX_VE_HOSTNAME", "")
     # Keep in sync with local.proxmox_ssh_user (SOPS-first, env fallback)
     proxmox_ssh_username    = local.proxmox_ssh_user
   }

--- a/tests/variables.tftest.hcl
+++ b/tests/variables.tftest.hcl
@@ -429,3 +429,75 @@ run "acme_account_non_https_directory_rejected" {
     var.acme_accounts,
   ]
 }
+
+run "acme_certificates_invalid_destination_kind_rejected" {
+  command = plan
+
+  variables {
+    acme_certificates = {
+      bad = {
+        node_name     = "pve"
+        domain        = "pve.example.com"
+        account_id    = "default"
+        dns_plugin_id = "AWS"
+        destinations = [{
+          kind        = "container"
+          target_id   = 175
+          bundle_path = "/etc/ssl/private/x.pem"
+        }]
+      }
+    }
+  }
+
+  expect_failures = [
+    var.acme_certificates,
+  ]
+}
+
+run "acme_certificates_vm_missing_target_ip_rejected" {
+  command = plan
+
+  variables {
+    acme_certificates = {
+      bad = {
+        node_name     = "pve"
+        domain        = "pve.example.com"
+        account_id    = "default"
+        dns_plugin_id = "AWS"
+        destinations = [{
+          kind        = "vm"
+          target_id   = 200
+          bundle_path = "/etc/ssl/private/x.pem"
+        }]
+      }
+    }
+  }
+
+  expect_failures = [
+    var.acme_certificates,
+  ]
+}
+
+run "acme_certificates_missing_path_combo_rejected" {
+  command = plan
+
+  variables {
+    acme_certificates = {
+      bad = {
+        node_name     = "pve"
+        domain        = "pve.example.com"
+        account_id    = "default"
+        dns_plugin_id = "AWS"
+        destinations = [{
+          kind      = "lxc"
+          target_id = 175
+          # No bundle_path, no cert_path/key_path — must be rejected.
+        }]
+      }
+    }
+  }
+
+  expect_failures = [
+    var.acme_certificates,
+  ]
+}

--- a/variables-acme.tf
+++ b/variables-acme.tf
@@ -47,21 +47,21 @@ variable "acme_certificates" {
   EOT
   type = map(object({
     node_name     = string
-    domain        = string                      # primary CN (e.g., "pve.example.com")
-    account_id    = string                      # ACME account name (key in var.acme_accounts)
-    dns_plugin_id = string                      # DNS plugin name (key in var.dns_plugins)
+    domain        = string                     # primary CN (e.g., "pve.example.com")
+    account_id    = string                     # ACME account name (key in var.acme_accounts)
+    dns_plugin_id = string                     # DNS plugin name (key in var.dns_plugins)
     sans          = optional(list(string), []) # Additional SANs (each uses dns_plugin_id)
     destinations = optional(list(object({
-      kind        = string                       # "lxc" or "vm"
-      target_id   = number                       # vm_id of the LXC or VM
-      target_ip   = optional(string)             # required when kind = "vm" (SSH host for scp)
-      bundle_path = optional(string)             # combined cert+key PEM (e.g., "/etc/ssl/private/infisical.pem")
-      cert_path   = optional(string)             # separate cert+chain PEM (e.g., "/opt/splunk/etc/auth/server.pem")
-      key_path    = optional(string)             # separate private key (e.g., "/opt/splunk/etc/auth/server.key")
-      mode        = optional(string, "0600")     # file mode for delivered files
-      owner       = optional(string, "root")     # file owner
-      group       = optional(string, "root")     # file group
-      reload_cmd  = optional(string, "")         # command to run on the target after delivery
+      kind        = string                   # "lxc" or "vm"
+      target_id   = number                   # vm_id of the LXC or VM
+      target_ip   = optional(string)         # required when kind = "vm" (SSH host for scp)
+      bundle_path = optional(string)         # combined cert+key PEM (e.g., "/etc/ssl/private/infisical.pem")
+      cert_path   = optional(string)         # separate cert+chain PEM (e.g., "/opt/splunk/etc/auth/server.pem")
+      key_path    = optional(string)         # separate private key (e.g., "/opt/splunk/etc/auth/server.key")
+      mode        = optional(string, "0600") # file mode for delivered files
+      owner       = optional(string, "root") # file owner
+      group       = optional(string, "root") # file group
+      reload_cmd  = optional(string, "")     # command to run on the target after delivery
     })), [])
   }))
   default = {}

--- a/variables-acme.tf
+++ b/variables-acme.tf
@@ -38,14 +38,63 @@ variable "dns_plugins" {
 }
 
 variable "acme_certificates" {
-  description = "ACME certificates to provision and manage"
+  description = <<-EOT
+    ACME certificates to provision and manage. Each entry maps to a single
+    proxmox_acme_certificate resource per node, which can cover one primary
+    domain plus a list of SANs. After issuance, the cert (combined PEM
+    bundle and/or split cert+key files) can be delivered to LXCs or VMs
+    via the module's null_resource provisioner.
+  EOT
   type = map(object({
     node_name     = string
-    domain        = string
-    account_id    = string
-    dns_plugin_id = string
+    domain        = string                      # primary CN (e.g., "pve.example.com")
+    account_id    = string                      # ACME account name (key in var.acme_accounts)
+    dns_plugin_id = string                      # DNS plugin name (key in var.dns_plugins)
+    sans          = optional(list(string), []) # Additional SANs (each uses dns_plugin_id)
+    destinations = optional(list(object({
+      kind        = string                       # "lxc" or "vm"
+      target_id   = number                       # vm_id of the LXC or VM
+      target_ip   = optional(string)             # required when kind = "vm" (SSH host for scp)
+      bundle_path = optional(string)             # combined cert+key PEM (e.g., "/etc/ssl/private/infisical.pem")
+      cert_path   = optional(string)             # separate cert+chain PEM (e.g., "/opt/splunk/etc/auth/server.pem")
+      key_path    = optional(string)             # separate private key (e.g., "/opt/splunk/etc/auth/server.key")
+      mode        = optional(string, "0600")     # file mode for delivered files
+      owner       = optional(string, "root")     # file owner
+      group       = optional(string, "root")     # file group
+      reload_cmd  = optional(string, "")         # command to run on the target after delivery
+    })), [])
   }))
   default = {}
+
+  validation {
+    condition = alltrue([
+      for k, v in var.acme_certificates : alltrue([
+        for d in v.destinations : contains(["lxc", "vm"], d.kind)
+      ])
+    ])
+    error_message = "Each destination.kind must be either \"lxc\" or \"vm\"."
+  }
+
+  validation {
+    condition = alltrue([
+      for k, v in var.acme_certificates : alltrue([
+        for d in v.destinations : (d.kind == "vm" ? d.target_ip != null && d.target_ip != "" : true)
+      ])
+    ])
+    error_message = "destinations with kind = \"vm\" must set target_ip (SSH host for scp delivery)."
+  }
+
+  validation {
+    condition = alltrue([
+      for k, v in var.acme_certificates : alltrue([
+        for d in v.destinations : (
+          d.bundle_path != null && d.bundle_path != "" ||
+          (d.cert_path != null && d.cert_path != "" && d.key_path != null && d.key_path != "")
+        )
+      ])
+    ])
+    error_message = "Each destination must set either bundle_path (combined PEM) or both cert_path and key_path (split)."
+  }
 }
 
 # NOTE: Route53 DNS configuration is now managed separately in aws-infra/

--- a/variables-infrastructure.tf
+++ b/variables-infrastructure.tf
@@ -34,3 +34,9 @@ variable "proxmox_ssh_private_key" {
     error_message = "SSH private key must be either a file path starting with ~/ or /, or the actual key content starting with -----BEGIN."
   }
 }
+
+variable "proxmox_ssh_host" {
+  description = "Hostname or IP for SSH access to the Proxmox node. Used by the acme-certificate module's null_resource provisioner to deliver issued certs to LXCs/VMs. Sourced from PROXMOX_VE_HOSTNAME via Doppler/terragrunt."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
## Summary

Extends `modules/acme-certificate` to bring the existing manually-configured ACME setup under Terraform management AND deliver the issued cert to downstream LXCs and VMs (HAProxy in front of Infisical, Splunk on port 8000).

## Discovery (drove the design)

The Proxmox node already has a working manual ACME setup:

- ACME account `default` (Let's Encrypt prod)
- DNS plugin `AWS` (Route53, with valid AWS creds stored in PVE config)
- Node config `acmedomain0: pve.<domain>,plugin=AWS`
- Cert auto-renewed via `pve-daily-update.service`

The `modules/acme-certificate` was dormant **because** ACME was managed manually on the node, not because it was unused. This PR closes that gap.

## Changes

### `modules/acme-certificate`

- `proxmox_acme_certificate.domains` is now `concat([primary CN], sans)` — each cert can carry an arbitrary SAN list using the same DNS plugin.
- New `null_resource.cert_delivery` flatmaps cert → destinations and SSHes to the Proxmox node to push the cert to LXCs (`pct push`) or VMs (`scp`). Triggers on cert renewal (`not_after`/`fingerprint`) and on destination/reload changes.
- Supports both **bundle mode** (combined cert+key PEM for HAProxy/Caddy/nginx) and **split mode** (separate cert+key files for Splunk/Elasticsearch).
- New module inputs: `proxmox_ssh_host`, `proxmox_ssh_username`, `proxmox_ssh_private_key`. Wired from Doppler via `terragrunt.hcl`.
- Outputs now include `not_after`, `issuer`, `subject`, plus a new `cert_deliveries` map for visibility into delivery jobs.
- README rewritten to match real schema + adds activation/import procedure.

### Root module

- `variables-acme.tf`: `acme_certificates` map extended with `sans` (list of strings) and `destinations` (list of objects). Validations enforce `kind ∈ {lxc, vm}`, VMs must set `target_ip`, and each destination needs `bundle_path` OR `cert_path`+`key_path`.
- `variables-infrastructure.tf`: new `proxmox_ssh_host` variable.
- `terragrunt.hcl`: pipes `PROXMOX_VE_HOSTNAME` env var to `proxmox_ssh_host`.
- `locals.tf`: new `haproxy_container_ids` (mirrors `infisical_container_ids` shape).
- `main.tf`: passes the new SSH vars to the module; module now `depends_on` `module.containers`, `module.vms`, `module.splunk_vm` so the delivery targets exist before the null_resource runs.

### Tests

- 3 new validations in `tests/variables.tftest.hcl`:
  - invalid `destination.kind` rejected
  - `kind=vm` without `target_ip` rejected
  - destination without `bundle_path` AND without `cert_path`+`key_path` rejected
- All 29 tests (26 existing + 3 new) pass.

## What this PR does NOT do (next steps for the user)

This PR ships the module **capability**. To activate it for the live cluster, in a follow-up commit:

1. Add the ACME values to `terraform.sops.json` (account, plugin with AWS creds from the live PVE config, cert with SAN list and destinations for infisical/splunk).
2. Get the real `AWS_ACCESS_KEY_ID`/`SECRET_ACCESS_KEY` from `pvesh get /cluster/acme/plugins` and put them in SOPS via \`sops terraform.sops.json\`.
3. Import the existing resources:
   \`\`\`bash
   doppler run -- terragrunt run -- import 'module.acme_certificates[0].proxmox_acme_account.accounts[\"default\"]' default
   doppler run -- terragrunt run -- import 'module.acme_certificates[0].proxmox_acme_dns_plugin.dns_plugins[\"AWS\"]' AWS
   doppler run -- terragrunt run -- import 'module.acme_certificates[0].proxmox_acme_certificate.certificates[\"pve\"]' pve
   \`\`\`
4. \`terragrunt plan\`. Expected diff: account/plugin = 0 changes (assuming HCL matches PVE), certificate = \`domains\` grows from 1→3 (primary + infisical + splunk SANs), null_resource.cert_delivery = 2 new resources.
5. \`terragrunt apply\`. Proxmox re-issues the cert covering all 3 domains; null_resource pushes it to the haproxy LXC (bundle) and the splunk VM (split).

Full procedure in [`modules/acme-certificate/README.md`](./modules/acme-certificate/README.md).

## Test plan

- [x] \`tofu validate\` (via terragrunt) succeeds
- [x] \`tofu test\` passes — **29/29** including the 3 new destination validations
- [ ] User: complete activation steps above and verify end-to-end (cert lands at \`/etc/ssl/private/infisical.pem\` on haproxy LXC and the splunk VM serves with the new cert on :8000)

## Related

- Related: #136 (Phase 1 Infisical deploy)
- Related: #315 (Infisical LXC + DRY constants)
- Related: #318 (drop keyctl/fuse from infisical+openproject — merged)