### PR TITLE
chore(ci): ungate static pre-commit hooks; remove aws-vault from automation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,23 +9,20 @@ repos:
       - id: check-yaml
       - id: check-added-large-files
 
-  # Terraform hooks - require terraform/tflint installed locally
-  # These run in CI via GitHub Actions instead
+  # Terraform static checks - run on every commit via direnv-provided tools
+  # (Nix shell at .envrc supplies terraform, tflint, terraform-docs).
+  # Same checks run in CI via .github/workflows/ci-gate.yml as a safety net.
   - repo: https://github.com/antonbabenko/pre-commit-terraform
     rev: v1.92.0
     hooks:
       - id: terraform_fmt
-        stages: [manual]  # Run manually or in CI, not on every commit
       - id: terraform_validate
-        stages: [manual]
       - id: terraform_docs
-        stages: [manual]
         args:
           - --hook-config=--path-to-file=README.md
           - --hook-config=--add-to-existing-file=true
           - --hook-config=--create-file-if-not-exist=true
       - id: terraform_tflint
-        stages: [manual]
         args:
           - --args=--only=terraform_deprecated_interpolation
           - --args=--only=terraform_deprecated_index

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,15 +128,15 @@ To sync manually after importing state without applying, see
 
 ## Development workflow
 
-Before any commit:
+Static checks (`tofu fmt -check`, `tofu validate`, `tofu test`) run
+automatically in pre-commit and CI — no manual invocation needed.
 
-1. `doppler run -- terragrunt validate` (with `aws-vault` wrapper if not
-   pre-injected — see "Running Terraform / Terragrunt").
-2. `doppler run -- terragrunt plan` and review the diff.
+Credentialed operations (`terragrunt plan` against the live state
+backend, `terragrunt apply`) only run in CI under OIDC, or interactively
+when explicitly preparing to apply. Do not gate commits on them.
 
 Test in isolated resource pools, never production-first. Use feature
-branches. Conventional-commit subjects only. Never commit without running
-validate + plan first.
+branches. Conventional-commit subjects only.
 
 For slow operations and "context deadline exceeded" debugging:
 [`TROUBLESHOOTING.md`](./TROUBLESHOOTING.md).

--- a/scripts/cleanup-orphaned-vms.sh
+++ b/scripts/cleanup-orphaned-vms.sh
@@ -1,8 +1,16 @@
 #!/usr/bin/env bash
-# Cleanup VMs in pool that aren't defined in Terraform
-# Usage: ./scripts/cleanup-orphaned-vms.sh <pool-name>
+# Cleanup VMs in pool that aren't defined in Terraform.
+#
+# Assumes AWS creds and Doppler are already injected in the parent shell.
+# Run as: aws-vault exec tf-proxmox -- doppler run -- ./scripts/cleanup-orphaned-vms.sh <pool-name>
+# (the wrapper is the user's responsibility; this script does not invoke aws-vault.)
 
 set -euo pipefail
+
+if ! aws sts get-caller-identity >/dev/null 2>&1; then
+  echo "AWS credentials not present; re-run under aws-vault exec tf-proxmox -- doppler run --" >&2
+  exit 1
+fi
 
 POOL="${1:-logging}"
 
@@ -23,8 +31,7 @@ echo "Fetching VMs from Terraform state..."
 cd "$(dirname "$0")/.."
 
 run_terragrunt() {
-    nix develop "github:JacobPEvans/nix-devenv?dir=shells/terraform" --command bash -c \
-        "aws-vault exec tf-proxmox -- doppler run -- terragrunt $*"
+    terragrunt "$@"
 }
 
 # Get VM IDs from state

--- a/scripts/cleanup-orphaned-vms.sh
+++ b/scripts/cleanup-orphaned-vms.sh
@@ -34,9 +34,18 @@ run_terragrunt() {
     terragrunt "$@"
 }
 
-# Get VM IDs from state
-STATE_VMS=$(run_terragrunt state list 2>/dev/null | grep 'module.vms.proxmox_virtual_environment_vm.vms' | sed -E 's/.*\["([^"]+)"\].*/\1/' || true)
-STATE_CTS=$(run_terragrunt state list 2>/dev/null | grep 'module.containers.proxmox_virtual_environment_container.containers' | sed -E 's/.*\["([^"]+)"\].*/\1/' || true)
+# Fetch the state list once and fail fast if the command itself errors.
+# Without this guard, a credential/network failure would silently leave
+# STATE_VMS/STATE_CTS empty, causing every live VM to be flagged as
+# orphaned and prompting destruction — see Gemini critical review on #322.
+if ! STATE_LIST=$(run_terragrunt state list 2>&1); then
+    echo "Error: terragrunt state list failed. Aborting before any destroy prompts." >&2
+    echo "$STATE_LIST" >&2
+    exit 1
+fi
+
+STATE_VMS=$(echo "$STATE_LIST" | grep 'module.vms.proxmox_virtual_environment_vm.vms' | sed -E 's/.*\["([^"]+)"\].*/\1/' || true)
+STATE_CTS=$(echo "$STATE_LIST" | grep 'module.containers.proxmox_virtual_environment_container.containers' | sed -E 's/.*\["([^"]+)"\].*/\1/' || true)
 
 echo "VMs in Terraform state: ${STATE_VMS:-none}"
 echo "Containers in Terraform state: ${STATE_CTS:-none}"


### PR DESCRIPTION
## Summary

Addresses the bulk of #283 — ungate static checks so they run on every commit, and strip the `aws-vault exec` wrapper from automation (it's the user's job, not the script's).

## Changes

### `.pre-commit-config.yaml`

- Removed `stages: [manual]` from `terraform_fmt`, `terraform_validate`, `terraform_docs`, `terraform_tflint`. These now run on every commit.
- Updated the comment block above the terraform hooks to point at `ci-gate.yml` as the CI safety net rather than implying the hooks are CI-only.
- The existing `tofu-test` local hook (already direnv-driven, no nix wrapper) is unchanged — it already matched the `terraform-checks-placement` policy.

### `scripts/cleanup-orphaned-vms.sh`

- Dropped the `aws-vault exec tf-proxmox --` prefix from the `run_terragrunt` helper.
- Added an early-exit guard that confirms `aws sts get-caller-identity` succeeds before running, with a clear "re-run under aws-vault exec…" error if not.
- Updated the header comment to document the new invocation pattern (`aws-vault exec tf-proxmox -- doppler run -- ./scripts/cleanup-orphaned-vms.sh <pool>`).
- Matches the existing pattern in `scripts/export-ansible-inventory.sh` and `scripts/test-splunk-protection.sh`.

### `AGENTS.md`

- Replaced the "Before any commit: run terragrunt validate/plan" instructions with a note that static checks run automatically (pre-commit + CI), and credentialed `terragrunt plan/apply` calls only happen interactively or in CI under OIDC. The user-facing "Running Terraform / Terragrunt" section with the `aws-vault exec` invocation stays (those are docs, not automation).

## Deferred to a follow-up

#283 also calls for a new OIDC-based `terragrunt-plan` job in `ci-gate.yml`. That needs:
1. An IAM role with a trust policy bound to `repo:JacobPEvans/terraform-proxmox:*`.
2. The role ARN added as a repo or org variable so the workflow can `role-to-assume:`.

Neither exists yet. Filing a follow-up to set those up; this PR ships the rest of #283 unblocked.

`continue-on-error: true` is also called out in #283 for the `fmt -check` step — verified clean already in both `terraform.yml` (line 28-29) and `ci-gate.yml` (line 80-81). No edit needed.

## Verification

```bash
# Verification command from the issue body — automation no longer references aws-vault
git grep -nE 'aws-vault' -- ':!*.md' ':!docs/**' ':!CLAUDE.md' ':!AGENTS.md'
```

Remaining matches are all script-header comments documenting the user-side wrapper, plus a `SECRETS_SETUP.md.example` doc (the `:!*.md` filter doesn't strip `.md.example`). Nothing in the matches actually invokes `aws-vault`.

```bash
# Pre-commit runs without AWS_* env vars
unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
pre-commit run --all-files
```

Refs #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)