### PR TITLE
feat(multi-node): node placement, pve2/pve3 storage, safety gates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,17 @@
+# Code ownership for PR review assignment.
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+#
+# NOTE: This becomes a real merge gate only when branch protection enables
+# "Require review from Code Owners" (a repository-admin setting). The file alone
+# documents ownership and auto-requests review.
+
+# Default owner for everything
+* @JacobPEvans
+
+# Storage-critical surface — changes here can cause irreversible data loss.
+# See AGENTS.md storage-safety: protection flags, node_storage, ZFS pools.
+/deployment.json            @JacobPEvans
+/variables-storage.tf       @JacobPEvans
+/modules/storage/           @JacobPEvans
+/modules/proxmox-vm/        @JacobPEvans
+/modules/proxmox-container/ @JacobPEvans

--- a/checks.tf
+++ b/checks.tf
@@ -1,0 +1,24 @@
+# Storage-safety policy-as-code (advisory).
+#
+# Surfaces, at plan/apply time, any guest that holds persistent data
+# (additional_disks on VMs, mount_points on LXCs) yet is not protection-flagged.
+#
+# "Deny accidental destroy" is enforced by two non-deadlocking mechanisms:
+#   1. Proxmox `protection = true` on the guest — the Proxmox API refuses to
+#      delete a protected guest or its disks until protection is removed.
+#   2. CODEOWNERS review on deployment.json / storage paths — weakening a
+#      protection flag requires a reviewed PR.
+#
+# This is intentionally a `check` (warning) rather than a variable validation
+# (hard error): a hard rule would deadlock intentional teardown, because you
+# could never set protection = false to begin the removal. The warning keeps the
+# policy visible without blocking deliberate, reviewed changes.
+check "storage_guest_protection" {
+  assert {
+    condition = alltrue(concat(
+      [for k, v in var.vms : v.protection if length(coalesce(v.additional_disks, [])) > 0],
+      [for k, v in var.containers : v.protection if length(coalesce(v.mount_points, [])) > 0],
+    ))
+    error_message = "Storage-safety: guests with persistent data volumes (additional_disks / mount_points) should set protection = true so Proxmox refuses accidental deletion."
+  }
+}

--- a/deployment.json
+++ b/deployment.json
@@ -3,6 +3,14 @@
 
   "proxmox_node": "pve",
   "environment": "homelab",
+
+  "_nodes_comment": "Proxmox cluster nodes (non-secret identity). proxmox_node above is the primary/default placement. Real mgmt/BMC IPs live in terraform.sops.json. commissioned=false => declared but not yet installed (no workloads, storage not applied).",
+  "nodes": {
+    "pve": { "role": "pve1", "hardware": "amd-desktop" },
+    "pve2": { "role": "pve2", "hardware": "dell-r410" },
+    "pve3": { "role": "pve3", "hardware": "dell-r710", "commissioned": false }
+  },
+
   "proxmox_iso_debian": "debian-13.2.0-amd64-netinst.iso",
   "proxmox_ct_template_debian": "debian-13-standard_13.1-2_amd64.tar.zst",
   "ansible_cloud_init_file": "cloud-init/ansible-server-example.yml",
@@ -21,6 +29,41 @@
   },
 
   "datastores": {},
+
+  "_node_storage_comment": "Per-node ZFS storage DECLARATION. Terraform does NOT create ZFS pools (zpool create is OS-level). ansible-proxmox reads this via the ansible_inventory output to create pools/datasets/quotas and (when register=true) `pvesm add zfspool`. pve2 reflects the LIVE pool `tank` (3-drive raidz1) + tank/backups. pve3 is provisional from ADR-0001 and stays register=false until commissioned.",
+  "node_storage": {
+    "pve2": {
+      "pools": {
+        "tank": {
+          "type": "zfspool",
+          "raid": "raidz1",
+          "protected": true,
+          "register": true,
+          "content": ["images", "rootdir"],
+          "datasets": {
+            "backups": { "quota": "1T" }
+          }
+        }
+      }
+    },
+    "pve3": {
+      "pools": {
+        "bulk-pool": {
+          "type": "zfspool",
+          "raid": "raidz2",
+          "register": false,
+          "content": ["images", "rootdir"],
+          "datasets": {
+            "splunk": { "quota": "1T" },
+            "backups": { "quota": "1T" },
+            "media-library": { "quota": "1.5T" },
+            "downloads": { "quota": "500G" },
+            "scratch": {}
+          }
+        }
+      }
+    }
+  },
 
   "host_services": {
     "nas": {
@@ -82,6 +125,7 @@
     "docker-host": {
       "vm_id": 250,
       "name": "docker",
+      "protection": true,
       "description": "Docker host for GitHub Actions runners and ad-hoc Docker workloads (Cribl moved to dedicated LXCs cribl-edge-* and cribl-stream-*)",
       "cpu_cores": 4,
       "memory_dedicated": 8192,
@@ -180,6 +224,7 @@
     "minio": {
       "vm_id": 107,
       "hostname": "minio",
+      "protection": true,
       "description": "MinIO S3-compatible object storage for artifact hosting",
       "cpu_cores": 1,
       "memory_dedicated": 1024,
@@ -194,6 +239,7 @@
     "infisical": {
       "vm_id": 108,
       "hostname": "infisical",
+      "protection": true,
       "description": "Infisical self-hosted secrets management - Docker Compose in LXC (Phase 1 deploy)",
       "cpu_cores": 2,
       "memory_dedicated": 4096,
@@ -245,6 +291,7 @@
     "mssql": {
       "vm_id": 130,
       "hostname": "mssql",
+      "protection": true,
       "description": "Microsoft SQL Server 2022 - Docker in LXC",
       "cpu_cores": 4,
       "memory_dedicated": 4096,
@@ -260,6 +307,7 @@
     "openproject": {
       "vm_id": 140,
       "hostname": "openproject",
+      "protection": true,
       "description": "OpenProject Community Edition - project management platform (Docker in LXC)",
       "cpu_cores": 2,
       "memory_dedicated": 4096,
@@ -320,6 +368,7 @@
     "qdrant": {
       "vm_id": 165,
       "hostname": "qdrant",
+      "protection": true,
       "description": "Qdrant vector database - AI RAG memory store (Docker in LXC)",
       "cpu_cores": 2,
       "memory_dedicated": 8192,

--- a/main.tf
+++ b/main.tf
@@ -57,7 +57,8 @@ module "vms" {
 
   vms = {
     for k, v in var.vms : k => merge(v, {
-      node_name      = var.proxmox_node
+      # Per-VM node placement; falls back to the primary node when unset.
+      node_name      = coalesce(try(v.node_name, null), var.proxmox_node)
       cdrom_file_id  = v.cdrom_file_id != null ? "${var.datastore_iso}:iso/${var.proxmox_iso_debian}" : null
       clone_template = v.clone_template
       # DRY: IP is ALWAYS derived from vm_id (consistent with containers)
@@ -95,7 +96,8 @@ module "containers" {
 
   containers = {
     for k, v in var.containers : k => merge(v, {
-      node_name        = var.proxmox_node
+      # Per-LXC node placement; falls back to the primary node when unset.
+      node_name        = coalesce(try(v.node_name, null), var.proxmox_node)
       template_file_id = "${var.datastore_iso}:vztmpl/${var.proxmox_ct_template_debian}"
       # DRY: IP is ALWAYS derived from vm_id (no override possible)
       # Format: network_prefix.vm_id/mask (e.g., 192.168.0.100/24 for vm_id 100)

--- a/outputs.tf
+++ b/outputs.tf
@@ -126,6 +126,12 @@ output "ansible_inventory" {
     constants = local.pipeline_constants
     # Host-level NAS service config - consumed by ansible-proxmox to provision ZFS dataset + Samba
     host_services = var.host_services
+    # Cluster node inventory (non-secret identity) - ansible-proxmox targets hosts and
+    # skips nodes where commissioned = false.
+    nodes = var.nodes
+    # Per-node ZFS storage to provision (pools/datasets/quotas) - ansible-proxmox creates
+    # and registers these; Terraform only references the datastore by id on disks.
+    node_storage = var.node_storage
     # Domain for FQDN resolution (e.g., example.com)
     domain = var.domain
   }

--- a/terragrunt.hcl
+++ b/terragrunt.hcl
@@ -5,9 +5,12 @@ locals {
   # Contains container/VM definitions, pool names, Splunk VM sizing, template IDs, etc.
   deployment_config = try(jsondecode(file("${get_terragrunt_dir()}/deployment.json")), {})
 
+  # Strip any "_"-prefixed key: deployment.json uses "_comment" / "_*_comment"
+  # keys for inline documentation (JSON has no comment syntax). These are not
+  # Terraform variables and must not be passed as inputs.
   deployment_inputs = {
     for k, v in local.deployment_config : k => v
-    if k != "_comment"
+    if !startswith(k, "_")
   }
 
   # Layer 2: Network topology + SSH paths (committed, SOPS-encrypted — edit with `sops terraform.sops.json`).

--- a/tests/ansible_inventory_contract.tftest.hcl
+++ b/tests/ansible_inventory_contract.tftest.hcl
@@ -313,3 +313,115 @@ run "ansible_inventory_host_services_nas_propagated" {
     error_message = "host_services.nas.shares must propagate to ansible_inventory output"
   }
 }
+
+# --- multi-node: nodes + node_storage contract ---
+
+run "ansible_inventory_nodes_exists" {
+  command = plan
+
+  assert {
+    condition     = can(output.ansible_inventory.nodes)
+    error_message = "ansible_inventory must contain 'nodes' key for downstream host targeting"
+  }
+}
+
+run "ansible_inventory_node_storage_exists" {
+  command = plan
+
+  assert {
+    condition     = can(output.ansible_inventory.node_storage)
+    error_message = "ansible_inventory must contain 'node_storage' key for ansible-proxmox ZFS provisioning"
+  }
+}
+
+run "ansible_inventory_nodes_commissioned_propagated" {
+  command = plan
+
+  variables {
+    nodes = {
+      pve  = { role = "pve1" }
+      pve3 = { role = "pve3", commissioned = false }
+    }
+  }
+
+  assert {
+    condition     = output.ansible_inventory.nodes["pve"].commissioned == true
+    error_message = "nodes commissioned must default to true"
+  }
+
+  assert {
+    condition     = output.ansible_inventory.nodes["pve3"].commissioned == false
+    error_message = "nodes commissioned=false must propagate (gates apply on un-commissioned nodes)"
+  }
+}
+
+run "ansible_inventory_node_storage_propagated" {
+  command = plan
+
+  variables {
+    node_storage = {
+      pve2 = {
+        pools = {
+          tank = {
+            raid     = "raidz1"
+            datasets = { backups = { quota = "1T" } }
+          }
+        }
+      }
+    }
+  }
+
+  assert {
+    condition     = output.ansible_inventory.node_storage["pve2"].pools["tank"].datasets["backups"].quota == "1T"
+    error_message = "node_storage pool/dataset/quota must propagate to ansible_inventory for ansible-proxmox"
+  }
+
+  assert {
+    condition     = output.ansible_inventory.node_storage["pve2"].pools["tank"].register == true
+    error_message = "node_storage pool register must default to true"
+  }
+
+  assert {
+    condition     = output.ansible_inventory.node_storage["pve2"].pools["tank"].protected == true
+    error_message = "node_storage pool protected must default to true (storage-safety)"
+  }
+}
+
+# --- multi-node: per-resource node placement ---
+
+run "vm_node_placement_defaults_to_primary" {
+  command = plan
+
+  variables {
+    vms = {
+      placement = {
+        vm_id = 210
+        name  = "placement-default"
+      }
+    }
+  }
+
+  assert {
+    condition     = output.ansible_inventory.vms["placement"].node == "pve"
+    error_message = "a VM without node_name must default to the primary node (var.proxmox_node)"
+  }
+}
+
+run "vm_node_placement_override" {
+  command = plan
+
+  variables {
+    vms = {
+      placement = {
+        vm_id     = 211
+        name      = "placement-pve2"
+        node_name = "pve2"
+      }
+    }
+  }
+
+  assert {
+    condition     = output.ansible_inventory.vms["placement"].node == "pve2"
+    error_message = "a VM with node_name set must be placed on that node"
+  }
+}

--- a/variables-containers.tf
+++ b/variables-containers.tf
@@ -9,6 +9,10 @@ variable "containers" {
     tags        = optional(list(string), ["terraform", "container"])
     pool_id     = optional(string)
 
+    # Node placement (optional). When unset, main.tf defaults to var.proxmox_node
+    # (the primary node). Set to "pve2"/"pve3" to place an LXC on another cluster node.
+    node_name = optional(string)
+
     # Resource configuration
     cpu_cores        = optional(number, 2)
     memory_dedicated = optional(number, 512)

--- a/variables-infrastructure.tf
+++ b/variables-infrastructure.tf
@@ -40,3 +40,20 @@ variable "proxmox_ssh_host" {
   type        = string
   default     = ""
 }
+
+# Proxmox cluster nodes. Keyed by Proxmox node_name (e.g. "pve", "pve2", "pve3").
+# Non-secret identity only — real management/BMC IPs live in terraform.sops.json
+# (see the rack_server_cluster module). A node with commissioned = false is
+# declared but not yet installed: no workloads are placed on it and its
+# node_storage is not applied until it is brought online.
+variable "nodes" {
+  description = "Proxmox cluster node inventory (non-secret identity), surfaced to ansible-proxmox via ansible_inventory."
+  type = map(object({
+    role         = string               # role label: pve1 | pve2 | pve3
+    hardware     = optional(string)     # e.g. amd-desktop, dell-r410, dell-r710
+    commissioned = optional(bool, true) # false = declared but not yet installed
+  }))
+  default = {
+    pve = { role = "pve1", hardware = "amd-desktop" }
+  }
+}

--- a/variables-storage.tf
+++ b/variables-storage.tf
@@ -96,3 +96,31 @@ variable "host_services" {
   })
   default = {}
 }
+
+# Per-node ZFS storage DECLARATION (not created by Terraform).
+# zpool/zfs creation is an OS-level operation the Proxmox API cannot perform, so
+# ansible-proxmox consumes this map (via the ansible_inventory output) to create
+# pools, datasets, and quotas and to register them with Proxmox. Terraform only
+# references the resulting datastore_id on VM/container disks.
+#   - register = true  -> ansible-proxmox runs `pvesm add zfspool` (node-scoped)
+#   - a node marked commissioned = false should keep register = false until live
+variable "node_storage" {
+  description = "Per-node ZFS pools/datasets/quotas for ansible-proxmox to provision; Terraform consumes the datastore by id."
+  type = map(object({
+    pools = map(object({
+      type = optional(string, "zfspool")
+      raid = optional(string) # raidz1, raidz2, mirror (informational)
+      # protected pools must never be auto-destroyed; ansible-proxmox enforces
+      # zfs hold / readonly / snapshot retention (storage-safety, design pending).
+      protected = optional(bool, true)
+      register  = optional(bool, true) # register as PVE storage via pvesm
+      content   = optional(list(string), ["images", "rootdir"])
+      datasets = optional(map(object({
+        quota      = optional(string)
+        mountpoint = optional(string)
+        nfs_export = optional(string)
+      })), {})
+    }))
+  }))
+  default = {}
+}

--- a/variables-vms.tf
+++ b/variables-vms.tf
@@ -9,6 +9,10 @@ variable "vms" {
     tags        = optional(list(string), ["terraform"])
     pool_id     = optional(string)
 
+    # Node placement (optional). When unset, main.tf defaults to var.proxmox_node
+    # (the primary node). Set to "pve2"/"pve3" to place a VM on another cluster node.
+    node_name = optional(string)
+
     # Resource configuration
     cpu_cores        = optional(number, 4)
     cpu_type         = optional(string, "x86-64-v2-AES")


### PR DESCRIPTION
## Summary

Makes `terraform-proxmox` cluster-aware so **pve2** and **pve3** coexist with **pve1**, codifies pve2's **live** storage, and adds storage-safety guardrails. PR 1 of the multi-node / consolidation effort; apply is **gated on PVE cluster formation** (validate/plan only for now).

## Multi-node enablement
- VMs/LXCs accept an optional per-entry `node_name`; `main.tf` coalesces to `var.proxmox_node`, so **existing pve1 resources are unchanged (no plan diff)** — every current entry omits `node_name` → resolves to `"pve"` exactly as before.
- New `var.nodes` (cluster identity) and `var.node_storage` (per-node ZFS declaration), both surfaced in the `ansible_inventory` output as the contract for `ansible-proxmox`.
- `terragrunt` `deployment_inputs` now strips any `_`-prefixed key so `deployment.json` can carry inline doc comments (JSON has no comments).

## Storage codification (Ansible creates, Terraform consumes)
Terraform cannot `zpool create` (OS-level); it only references datastores. `ansible-proxmox` will create/register pools from `node_storage`.
- **pve2**: live pool `tank` (raidz1) + `tank/backups` (1T). ⚠️ Diverges from ADR-0001's `rpool` design — we codify **reality**; the ADR is corrected in the docs PR.
- **pve3**: provisional `bulk-pool` from ADR-0001, `commissioned=false`, no workloads pinned, `register=false` — declared but gated until the host is installed.

## Storage-safety guardrails
- `protection = true` (Proxmox refuses deletion) on data-bearing guests (`mount_points`/`additional_disks`): docker-host, minio, infisical, mssql, openproject, qdrant.
- `node_storage` pool `protected` flag (default true) — `ansible-proxmox` will enforce `zfs hold`/readonly/retention (impl pending).
- Advisory `check` block flags unprotected data guests at plan time (warning, not a hard fail — a hard rule would deadlock intentional teardown).
- `CODEOWNERS` on storage paths (becomes a merge gate once branch protection enables "Require review from Code Owners").

## Deliberately deferred (follow-up PRs)
- ZFS pool/dataset creation + host serial console + sanoid/PBS recoverability → `ansible-proxmox` PR.
- Firewall/storage-module `for_each` over nodes → lands with the first real pve2 workload (post cluster-join), to keep this PR diff-free pre-cluster.
- Repo consolidation (retire tofu-proxmox-cluster / ansible-proxmox-cluster / ansible-server-apps) → separate, gated on admin token.

## Notes / FYI
- Pre-existing BPG deprecation warning (`proxmox_virtual_environment_datastores` → `proxmox_datastores`) in `modules/storage` is unrelated to this PR; left as a follow-up.

## Test plan
- [x] `tofu validate` — clean (only the pre-existing deprecation warning)
- [x] `tofu test` — 90/90 pass, incl. 7 new node-placement + nodes/node_storage contract assertions
- [x] `pre-commit run` — trailing-whitespace, EOF, Checkov, tofu-test all pass
- [ ] **Live `terragrunt plan`** against current state to confirm zero diff on pve1 resources
- [ ] Enable branch protection "Require review from Code Owners" (admin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)