### PR TITLE
fix(ci): retarget reusable-workflow uses: refs to current org homes

### DIFF
--- a/.github/workflows/ai-merge-gate.yml
+++ b/.github/workflows/ai-merge-gate.yml
@@ -3,5 +3,5 @@ on: pull_request
 permissions: read-all
 jobs:
   gate:
-    uses: JacobPEvans/ai-workflows/.github/workflows/_ai-merge-gate.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/_ai-merge-gate.yml@main
     secrets: inherit

--- a/.github/workflows/best-practices.yml
+++ b/.github/workflows/best-practices.yml
@@ -15,5 +15,5 @@ permissions:
 
 jobs:
   recommend:
-    uses: JacobPEvans/ai-workflows/.github/workflows/best-practices.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/best-practices.yml@main
     secrets: inherit

--- a/.github/workflows/ci-fail-issue.yml
+++ b/.github/workflows/ci-fail-issue.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   handle-failure:
     if: github.event.workflow_run.conclusion == 'failure'
-    uses: JacobPEvans/ai-workflows/.github/workflows/ci-fail-issue.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/ci-fail-issue.yml@main
     with:
       workflow_name: "Terraform CI"
     secrets: inherit

--- a/.github/workflows/ci-fix.yml
+++ b/.github/workflows/ci-fix.yml
@@ -28,7 +28,7 @@ jobs:
     #   github.event.workflow_run.conclusion == 'failure' &&
     #   github.event.workflow_run.head_branch != 'main'
     # --- END DISABLED ---
-    uses: JacobPEvans/ai-workflows/.github/workflows/ci-fix.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/ci-fix.yml@main
     with:
       repo_context: "Terraform/OpenTofu project managing Proxmox VE infrastructure"
       ci_structure: "terraform.yml (tofu fmt/init/validate/test), markdown-lint.yml (markdownlint)"

--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -90,13 +90,13 @@ jobs:
     name: Markdown Lint
     needs: changes
     if: needs.changes.outputs.markdown == 'true'
-    uses: JacobPEvans/.github/.github/workflows/_markdown-lint.yml@main
+    uses: JacobPEvans-personal/.github/.github/workflows/_markdown-lint.yml@main
 
   file-size:
     name: File Size
     needs: changes
     if: needs.changes.outputs.terraform == 'true' || needs.changes.outputs.markdown == 'true'
-    uses: JacobPEvans/.github/.github/workflows/_file-size.yml@main
+    uses: JacobPEvans-personal/.github/.github/workflows/_file-size.yml@main
 
   # ==========================================================================
   # MERGE GATE - The ONLY required check in branch protection

--- a/.github/workflows/code-simplifier.yml
+++ b/.github/workflows/code-simplifier.yml
@@ -14,5 +14,5 @@ permissions:
 
 jobs:
   simplify:
-    uses: JacobPEvans/ai-workflows/.github/workflows/code-simplifier.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/code-simplifier.yml@main
     secrets: inherit

--- a/.github/workflows/final-pr-review.yml
+++ b/.github/workflows/final-pr-review.yml
@@ -22,5 +22,5 @@ concurrency:
 
 jobs:
   review:
-    uses: JacobPEvans/ai-workflows/.github/workflows/final-pr-review.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/final-pr-review.yml@main
     secrets: inherit

--- a/.github/workflows/issue-auto-resolve.yml
+++ b/.github/workflows/issue-auto-resolve.yml
@@ -68,7 +68,7 @@ jobs:
 
   run-triage:
     if: github.event_name == 'workflow_dispatch'
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-triage.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/issue-triage.yml@main
     secrets: inherit
     with:
       issue_number: ${{ inputs.issue_number }}
@@ -79,7 +79,7 @@ jobs:
       always() &&
       github.event_name == 'workflow_dispatch' &&
       (needs.run-triage.result == 'success' || needs.run-triage.result == 'skipped')
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-resolver.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/issue-resolver.yml@main
     secrets: inherit
     with:
       repo_context: "Terraform Proxmox VM/container provisioning"

--- a/.github/workflows/issue-hygiene.yml
+++ b/.github/workflows/issue-hygiene.yml
@@ -15,5 +15,5 @@ permissions:
 
 jobs:
   hygiene:
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-hygiene.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/issue-hygiene.yml@main
     secrets: inherit

--- a/.github/workflows/issue-sweeper.yml
+++ b/.github/workflows/issue-sweeper.yml
@@ -15,5 +15,5 @@ permissions:
 
 jobs:
   sweep:
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-sweeper.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/issue-sweeper.yml@main
     secrets: inherit

--- a/.github/workflows/next-steps.yml
+++ b/.github/workflows/next-steps.yml
@@ -15,5 +15,5 @@ permissions:
 
 jobs:
   analyze:
-    uses: JacobPEvans/ai-workflows/.github/workflows/next-steps.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/next-steps.yml@main
     secrets: inherit

--- a/.github/workflows/osv-scan.yml
+++ b/.github/workflows/osv-scan.yml
@@ -1,7 +1,7 @@
 # Periodic + per-PR OSV vulnerability scan.
 #
-# Inherits the centralized reusable workflow from JacobPEvans/.github.
-# Config: JacobPEvans/.github/osv-scanner.toml (org default) or local
+# Inherits the centralized reusable workflow from JacobPEvans-personal/.github.
+# Config: JacobPEvans-personal/.github/osv-scanner.toml (org default) or local
 # osv-scanner.toml in this repo (takes precedence).
 #
 # Make this a required check via branch protection on `main` after merge.
@@ -24,8 +24,8 @@ permissions:
 
 jobs:
   scan:
-    # SHA pin → JacobPEvans/.github main as of 2026-05-20.
+    # SHA pin → JacobPEvans-personal/.github main as of 2026-05-20.
     # Bump intentionally when the upstream workflow changes.
-    uses: JacobPEvans/.github/.github/workflows/_osv-scan.yml@a76cf8faec4ea24036c9042bf52d18b573f172ae
+    uses: JacobPEvans-personal/.github/.github/workflows/_osv-scan.yml@a76cf8faec4ea24036c9042bf52d18b573f172ae
     with:
       runner_label: ubuntu-latest

--- a/.github/workflows/post-merge-docs-review.yml
+++ b/.github/workflows/post-merge-docs-review.yml
@@ -41,7 +41,7 @@ jobs:
 
   review:
     if: github.event_name == 'workflow_dispatch'
-    uses: JacobPEvans/ai-workflows/.github/workflows/post-merge-docs-review.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/post-merge-docs-review.yml@main
     with:
       commit_sha: ${{ inputs.commit_sha || github.sha }}
     secrets: inherit

--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -41,7 +41,7 @@ jobs:
 
   review:
     if: github.event_name == 'workflow_dispatch'
-    uses: JacobPEvans/ai-workflows/.github/workflows/post-merge-tests.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/post-merge-tests.yml@main
     with:
       commit_sha: ${{ inputs.commit_sha || github.sha }}
     secrets: inherit

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,6 +11,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: JacobPEvans/.github/.github/workflows/_release-please.yml@main
+    uses: JacobPEvans-personal/.github/.github/workflows/_release-please.yml@main
     secrets:
       GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}

--- a/.github/workflows/retrigger-pr-checks.yml
+++ b/.github/workflows/retrigger-pr-checks.yml
@@ -1,8 +1,8 @@
 name: Retrigger PR Checks
 
 # Ensures bot-created PRs (GITHUB_TOKEN) get the Merge Gate check.
-# Calls shared logic from JacobPEvans/.github.
-# See: .github/workflows/_retrigger-pr-checks.yml in JacobPEvans/.github
+# Calls shared logic from JacobPEvans-personal/.github.
+# See: .github/workflows/_retrigger-pr-checks.yml in JacobPEvans-personal/.github
 
 on:
   schedule:
@@ -17,6 +17,6 @@ permissions:
 
 jobs:
   retrigger:
-    uses: JacobPEvans/.github/.github/workflows/_retrigger-pr-checks.yml@main
+    uses: JacobPEvans-personal/.github/.github/workflows/_retrigger-pr-checks.yml@main
     secrets:
       GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}


### PR DESCRIPTION
The shared reusable workflows this repo consumes moved to new owners: `ai-workflows` migrated JacobPEvans->dryvist, and the shared `.github` reusable workflows now live at JacobPEvans-personal/.github. GitHub Actions `uses:` clauses do not follow repo move/rename redirects and cannot use variables or expressions, so the old hard-coded owners fail at workflow parse time before any job runs; this PR corrects the literal owner segment in every `uses:` clause (preserving each path and `@ref`, including the SHA pin) and updates two now-inaccurate inline comments. Part of an org-wide sweep applying the same fix across all affected consumer repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)