### PR TITLE
chore(docs): fix aws-vault guidance (no Touch ID, no key export)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,17 +34,18 @@ aws-vault exec tf-proxmox -- doppler run -- terragrunt <COMMAND>
 
 ### When to use `aws-vault` vs ask for pre-injected credentials
 
-> Autonomy rule: every `aws-vault exec` call prompts for Touch ID / keychain
-> password. A session that hits `aws-vault` repeatedly cannot run autonomously
-> and violates the "always run autonomously" rule.
+> Autonomy rule: every `aws-vault exec` — and every keychain `security` read —
+> forces the user to type their full keychain password TWICE (there is no Touch
+> ID on this machine). A session that hits `aws-vault`/keychain repeatedly
+> cannot run autonomously — minimise these calls hard.
 
 - **Single one-off command** in the session: prefix with
-  `aws-vault exec tf-proxmox --`. One password prompt is acceptable.
-- **Two or more commands**: STOP and request pre-injected reusable
-  credentials. The user re-launches with `aws-vault exec tf-proxmox -- claude
-  …` or exports `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` /
-  `AWS_SESSION_TOKEN`. After injection, drop the prefix and call
-  `doppler run -- terragrunt …` directly.
+  `aws-vault exec tf-proxmox --`. One credential prompt is acceptable.
+- **Two or more commands**: STOP and ask the user to re-launch Claude with
+  credentials already injected: `aws-vault exec tf-proxmox -- claude`. This is
+  the ONLY supported injection method — never ask the user to export raw AWS
+  keys. After re-launch, AWS creds are live for the whole session: drop the
+  prefix and call `doppler run -- terragrunt …` directly.
 - **Never** loop `aws-vault exec` across worktrees, parallel invocations, or
   per-resource checks. Always batch behind one credential injection.
 - If unsure whether credentials are already live: `aws sts get-caller-identity`


### PR DESCRIPTION
## Summary
- Remove the inaccurate "Touch ID" reference in the `aws-vault` autonomy note — there is no Touch ID on this machine; each `aws-vault`/keychain read costs a full keychain password typed **twice**.
- Remove the raw `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`/`AWS_SESSION_TOKEN` export alternative. The only supported credential-injection method is re-launching with `aws-vault exec tf-proxmox -- claude`.

Docs-only; no infra impact.