### PR TITLE
chore(ci): allow README.md under extended file-size limit

### DIFF
--- a/.file-size.yml
+++ b/.file-size.yml
@@ -1,6 +1,7 @@
 # Overrides only — inherits defaults from shared workflow:
 #   warn: 6144, error: 12288, scan: [.md, .nix, .tf], exempt: [CHANGELOG]
 extended:
-  limit: 32768
+  limit: 49152
   files:
     - TROUBLESHOOTING
+    - README


### PR DESCRIPTION
## Summary

`README.md` is currently **33,650 bytes**, over the default 12 KB hard error in the shared file-size reusable workflow. The File Size / Check job fails on every PR (and Merge Gate fails as a downstream consequence) until this is fixed — including innocent PRs that don't touch README at all (e.g. #331).

This is a CI-config fix only, **no content change to README.md**.

## Changes
- `.file-size.yml`: add `README` to `extended.files`; bump `extended.limit` from 32,768 to 49,152 so the current README fits with ~14 KB headroom.

## Why this landed silently
The File Size check runs **on PRs only** — push-to-main doesn't trigger it (`gh api repos/.../commits/main/check-runs` shows no \`File Size\` runs on the current main HEAD). README must have grown past 12 KB on a recent merge without anyone seeing the check fire.

## Test Plan
- [ ] CI runs File Size / Check against this PR and passes.
- [ ] After merge, every other open PR (e.g. #331) goes from `UNSTABLE` → `CLEAN` on a re-run.

## Out of scope
Trimming README content. That can come later if desired; the README's size isn't a *correctness* problem, only a CI threshold one.