### PR TITLE
feat(media): redirect stack to pve1 + declare rpool node_storage (v1 per JAC-69)

### DIFF
--- a/deployment.json
+++ b/deployment.json
@@ -26,13 +26,28 @@
     "logging": { "comment": "Logging and observability infrastructure" },
     "ai": { "comment": "AI development environments" },
     "infrastructure": { "comment": "Core infrastructure services" },
-    "media": { "comment": "Media stack: VPN-locked downloaders + *arr + Plex (pve2)" }
+    "media": { "comment": "Media stack: VPN-locked downloaders + *arr + Plex (v1 pinned to pve1 per JAC-69; v2 = pve2)" }
   },
 
   "datastores": {},
 
-  "_node_storage_comment": "Per-node ZFS storage DECLARATION. Terraform does NOT create ZFS pools (zpool create is OS-level). ansible-proxmox reads this via the ansible_inventory output to create pools/datasets/quotas and (when register=true) `pvesm add zfspool`. pve2 reflects the LIVE pool `tank` (3-drive raidz1) + tank/backups. pve3 is provisional from ADR-0001 and stays register=false until commissioned.",
+  "_node_storage_comment": "Per-node ZFS storage DECLARATION. Terraform does NOT create ZFS pools (zpool create is OS-level). ansible-proxmox reads this via the ansible_inventory output to create pools/datasets/quotas and (when register=true) `pvesm add zfspool`. pve carries rpool/data datasets for the media stack v1 placement (per JAC-69) — register=false because rpool is already PVE-registered as `local-zfs`, we only want the datasets. pve2 reflects the LIVE pool `tank` (3-drive raidz1) + tank/backups (v2 target for media migration). pve3 is provisional from ADR-0001 and stays register=false until commissioned.",
   "node_storage": {
+    "pve": {
+      "pools": {
+        "rpool": {
+          "type": "zfspool",
+          "raid": "mirror",
+          "protected": true,
+          "register": false,
+          "content": ["images", "rootdir"],
+          "datasets": {
+            "data/downloads": { "quota": "500G", "mountpoint": "/rpool/data/downloads" },
+            "data/media": { "quota": "1.5T", "mountpoint": "/rpool/data/media" }
+          }
+        }
+      }
+    },
     "pve2": {
       "pools": {
         "tank": {
@@ -519,8 +534,8 @@
       "vm_id": 210,
       "vlan": "media_svc",
       "hostname": "download-vpn",
-      "description": "VPN-locked downloader: qBittorrent-nox + Prowlarr behind Proton WireGuard with an nftables killswitch (wg0 down => no egress). Configured by ansible-proxmox-apps download_vpn role. Pinned to pve2 (always-on NAS/media host).",
-      "node_name": "pve2",
+      "description": "VPN-locked downloader: qBittorrent-nox + Prowlarr behind Proton WireGuard with an nftables killswitch (wg0 down => no egress). Configured by ansible-proxmox-apps download_vpn role. Pinned to pve1 (always-on; v1 placement per JAC-69; v2 = pve2).",
+      "node_name": "pve",
       "cpu_cores": 2,
       "memory_dedicated": 2048,
       "memory_swap": 2048,
@@ -529,8 +544,8 @@
       "unprivileged": true,
       "root_disk": { "size": 16 },
       "mount_points": [
-        { "volume": "/tank/downloads", "path": "/mnt/downloads" },
-        { "volume": "/tank/media", "path": "/mnt/media" }
+        { "volume": "/rpool/data/downloads", "path": "/mnt/downloads" },
+        { "volume": "/rpool/data/media", "path": "/mnt/media" }
       ],
       "features": { "nesting": true, "keyctl": true },
       "device_passthrough": [
@@ -541,8 +556,8 @@
       "vm_id": 211,
       "vlan": "media_svc",
       "hostname": "sonarr",
-      "description": "Sonarr TV series PVR/management. LAN-only (no VPN); reaches Prowlarr+qBittorrent on download-vpn over the LAN. Configured by ansible-proxmox-apps sonarr role. Pinned to pve2.",
-      "node_name": "pve2",
+      "description": "Sonarr TV series PVR/management. LAN-only (no VPN); reaches Prowlarr+qBittorrent on download-vpn over the LAN. Configured by ansible-proxmox-apps sonarr role. Pinned to pve1 (always-on; v1 placement per JAC-69; v2 = pve2).",
+      "node_name": "pve",
       "cpu_cores": 2,
       "memory_dedicated": 1024,
       "memory_swap": 1024,
@@ -551,16 +566,16 @@
       "unprivileged": true,
       "root_disk": { "size": 16 },
       "mount_points": [
-        { "volume": "/tank/downloads", "path": "/mnt/downloads" },
-        { "volume": "/tank/media", "path": "/mnt/media" }
+        { "volume": "/rpool/data/downloads", "path": "/mnt/downloads" },
+        { "volume": "/rpool/data/media", "path": "/mnt/media" }
       ]
     },
     "radarr": {
       "vm_id": 212,
       "vlan": "media_svc",
       "hostname": "radarr",
-      "description": "Radarr movie PVR/management. LAN-only (no VPN); reaches Prowlarr+qBittorrent on download-vpn over the LAN. Configured by ansible-proxmox-apps radarr role. Pinned to pve2.",
-      "node_name": "pve2",
+      "description": "Radarr movie PVR/management. LAN-only (no VPN); reaches Prowlarr+qBittorrent on download-vpn over the LAN. Configured by ansible-proxmox-apps radarr role. Pinned to pve1 (always-on; v1 placement per JAC-69; v2 = pve2).",
+      "node_name": "pve",
       "cpu_cores": 2,
       "memory_dedicated": 1024,
       "memory_swap": 1024,
@@ -569,16 +584,16 @@
       "unprivileged": true,
       "root_disk": { "size": 16 },
       "mount_points": [
-        { "volume": "/tank/downloads", "path": "/mnt/downloads" },
-        { "volume": "/tank/media", "path": "/mnt/media" }
+        { "volume": "/rpool/data/downloads", "path": "/mnt/downloads" },
+        { "volume": "/rpool/data/media", "path": "/mnt/media" }
       ]
     },
     "plex": {
       "vm_id": 213,
       "vlan": "media_svc",
       "hostname": "plex",
-      "description": "Plex Media Server. LAN-only (no VPN); streams from tank/media. Configured by ansible-proxmox-apps plex role. Pinned to pve2.",
-      "node_name": "pve2",
+      "description": "Plex Media Server. LAN-only (no VPN); streams from rpool/data/media. Configured by ansible-proxmox-apps plex role. Pinned to pve1 (always-on; v1 placement per JAC-69; v2 = pve2).",
+      "node_name": "pve",
       "cpu_cores": 4,
       "memory_dedicated": 4096,
       "memory_swap": 4096,
@@ -587,15 +602,15 @@
       "unprivileged": true,
       "root_disk": { "size": 16 },
       "mount_points": [
-        { "volume": "/tank/media", "path": "/mnt/media" }
+        { "volume": "/rpool/data/media", "path": "/mnt/media" }
       ]
     },
     "jellyseerr": {
       "vm_id": 214,
       "vlan": "media_svc",
       "hostname": "jellyseerr",
-      "description": "Jellyseerr request UI (Docker in LXC). Self-service movie/TV request front-end that wires to Sonarr, Radarr, and Plex. Config-only: no /tank bind-mounts (reaches *arr + Plex over the LAN). Configured by ansible-proxmox-apps jellyseerr role. Pinned to pve2.",
-      "node_name": "pve2",
+      "description": "Jellyseerr request UI (Docker in LXC). Self-service movie/TV request front-end that wires to Sonarr, Radarr, and Plex. Config-only: no bind-mounts (reaches *arr + Plex over the LAN). Configured by ansible-proxmox-apps jellyseerr role. Pinned to pve1 (always-on; v1 placement per JAC-69; v2 = pve2).",
+      "node_name": "pve",
       "cpu_cores": 1,
       "memory_dedicated": 1024,
       "memory_swap": 1024,

--- a/deployment.json
+++ b/deployment.json
@@ -31,9 +31,9 @@
 
   "datastores": {},
 
-  "_node_storage_comment": "Per-node ZFS storage DECLARATION. Terraform does NOT create ZFS pools (zpool create is OS-level). ansible-proxmox reads this via the ansible_inventory output to create pools/datasets/quotas and (when register=true) `pvesm add zfspool`. pve carries rpool/data datasets for the media stack v1 placement (per JAC-69) — register=false because rpool is already PVE-registered as `local-zfs`, we only want the datasets. pve2 reflects the LIVE pool `tank` (3-drive raidz1) + tank/backups (v2 target for media migration). pve3 is provisional from ADR-0001 and stays register=false until commissioned.",
+  "_node_storage_comment": "Per-node ZFS storage DECLARATION. Terraform does NOT create ZFS pools (zpool create is OS-level). ansible-proxmox reads this via the ansible_inventory output to create pools/datasets/quotas and (when register=true) `pvesm add zfspool`. NOTE: keys here are ansible's `proxmox_node_name` (the inventory host label: pve1/pve2/pve3), NOT the PVE cluster member name — playbooks/load_terraform.yml looks up `node_storage[hostvars[item].proxmox_node_name]`. The PVE cluster member name on the live host is still `pve` (used by Terraform's bpg/proxmox provider as `node_name`). pve1 carries rpool/data datasets for the media stack v1 placement (per JAC-69) — register=false because rpool is already PVE-registered as `local-zfs`, we only want the datasets. pve2 reflects the LIVE pool `tank` (3-drive raidz1) + tank/backups (v2 target for media migration). pve3 is provisional from ADR-0001 and stays register=false until commissioned.",
   "node_storage": {
-    "pve": {
+    "pve1": {
       "pools": {
         "rpool": {
           "type": "zfspool",

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -175,9 +175,9 @@ Authoritative list lives in `deployment.json` `containers.*`. Summary by pool:
 - **`logging`** — `haproxy`, `cribl-edge-01/02`, `cribl-stream-01/02`,
   `splunk-mgmt` (SH + DS + LM + MC + CM)
 - **`ai`** — `claude-code-01/02`, `gemini-01/02`, `qdrant`, `llamaindex`
-- **`media`** (pinned to `pve2` via `node_name`) — `download-vpn`
+- **`media`** (v1 pinned to `pve` via `node_name` per JAC-69; v2 = `pve2`) — `download-vpn`
   (qBittorrent + Prowlarr behind Proton WireGuard with an nftables killswitch),
-  `sonarr`, `radarr`, `plex`
+  `sonarr`, `radarr`, `plex`, `jellyseerr`
 
 Notable per-container facts:
 
@@ -192,14 +192,16 @@ Notable per-container facts:
   internal notifications.
 - `download-vpn` is an unprivileged LXC with `/dev/net/tun` passed through
   (`device_passthrough`) so WireGuard can create `wg0` inside the container.
-  `tank/downloads` and `tank/media` are bind-mounted from the pve2 host
-  (size-less `mount_points`). Egress is locked to the VPN by an in-LXC nftables
-  killswitch (config + continuous validation owned by `ansible-proxmox-apps`
-  `download_vpn` role); Proxmox-level firewall is intentionally not applied to
-  the media pool — the killswitch is the security boundary.
+  `rpool/data/downloads` and `rpool/data/media` are bind-mounted from the pve1 host
+  (size-less `mount_points`); the `ansible-proxmox` `zfs_pools` role provisions
+  these datasets ahead of LXC creation. Egress is locked to the VPN by an in-LXC
+  nftables killswitch (config + continuous validation owned by
+  `ansible-proxmox-apps` `download_vpn` role); Proxmox-level firewall is
+  intentionally not applied to the media pool — the killswitch is the security
+  boundary.
 - `sonarr`, `radarr`, `plex` are LAN-only (no VPN); they reach Prowlarr +
   qBittorrent on `download-vpn` over the LAN and read/write the same
-  bind-mounted `tank/*` datasets.
+  bind-mounted `rpool/data/*` datasets.
 
 #### Notification Services
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -175,9 +175,10 @@ Authoritative list lives in `deployment.json` `containers.*`. Summary by pool:
 - **`logging`** — `haproxy`, `cribl-edge-01/02`, `cribl-stream-01/02`,
   `splunk-mgmt` (SH + DS + LM + MC + CM)
 - **`ai`** — `claude-code-01/02`, `gemini-01/02`, `qdrant`, `llamaindex`
-- **`media`** (v1 pinned to `pve` via `node_name` per JAC-69; v2 = `pve2`) — `download-vpn`
-  (qBittorrent + Prowlarr behind Proton WireGuard with an nftables killswitch),
-  `sonarr`, `radarr`, `plex`, `jellyseerr`
+- **`media`** (v1 pinned to pve1 — `node_name: "pve"` for the BPG provider,
+  `node_storage` and ansible inventory label `pve1` — per JAC-69; v2 = `pve2`) —
+  `download-vpn` (qBittorrent + Prowlarr behind Proton WireGuard with an
+  nftables killswitch), `sonarr`, `radarr`, `plex`, `jellyseerr`
 
 Notable per-container facts:
 

--- a/tests/ansible_inventory_contract.tftest.hcl
+++ b/tests/ansible_inventory_contract.tftest.hcl
@@ -466,15 +466,17 @@ run "ansible_inventory_node_storage_propagated" {
   }
 }
 
-# JAC-69 v1: pve carries rpool/data datasets for the media stack. register=false
+# JAC-69 v1: pve1 carries rpool/data datasets for the media stack. register=false
 # because rpool is already PVE-registered as `local-zfs`; ansible-proxmox just
-# creates the datasets, not a duplicate `pvesm add`.
-run "ansible_inventory_node_storage_pve_media_datasets" {
+# creates the datasets, not a duplicate `pvesm add`. The key is "pve1" (ansible's
+# proxmox_node_name inventory label), not "pve" (PVE cluster member name) —
+# playbooks/load_terraform.yml looks up node_storage[hostvars[item].proxmox_node_name].
+run "ansible_inventory_node_storage_pve1_media_datasets" {
   command = plan
 
   variables {
     node_storage = {
-      pve = {
+      pve1 = {
         pools = {
           rpool = {
             raid     = "mirror"
@@ -490,23 +492,23 @@ run "ansible_inventory_node_storage_pve_media_datasets" {
   }
 
   assert {
-    condition     = output.ansible_inventory.node_storage["pve"].pools["rpool"].datasets["data/downloads"].quota == "500G"
-    error_message = "node_storage.pve.rpool must declare data/downloads with quota 500G for the media stack"
+    condition     = output.ansible_inventory.node_storage["pve1"].pools["rpool"].datasets["data/downloads"].quota == "500G"
+    error_message = "node_storage.pve1.rpool must declare data/downloads with quota 500G for the media stack"
   }
 
   assert {
-    condition     = output.ansible_inventory.node_storage["pve"].pools["rpool"].datasets["data/media"].quota == "1.5T"
-    error_message = "node_storage.pve.rpool must declare data/media with quota 1.5T for the media stack"
+    condition     = output.ansible_inventory.node_storage["pve1"].pools["rpool"].datasets["data/media"].quota == "1.5T"
+    error_message = "node_storage.pve1.rpool must declare data/media with quota 1.5T for the media stack"
   }
 
   assert {
-    condition     = output.ansible_inventory.node_storage["pve"].pools["rpool"].register == false
-    error_message = "node_storage.pve.rpool must set register=false (rpool is already PVE-registered as local-zfs)"
+    condition     = output.ansible_inventory.node_storage["pve1"].pools["rpool"].register == false
+    error_message = "node_storage.pve1.rpool must set register=false (rpool is already PVE-registered as local-zfs)"
   }
 
   assert {
-    condition     = output.ansible_inventory.node_storage["pve"].pools["rpool"].protected == true
-    error_message = "node_storage.pve.rpool must default to protected=true"
+    condition     = output.ansible_inventory.node_storage["pve1"].pools["rpool"].protected == true
+    error_message = "node_storage.pve1.rpool must default to protected=true"
   }
 }
 

--- a/tests/ansible_inventory_contract.tftest.hcl
+++ b/tests/ansible_inventory_contract.tftest.hcl
@@ -222,7 +222,7 @@ run "ansible_inventory_docker_vms_exists" {
   }
 }
 
-# --- per-container node placement (media stack pins to pve2) ---
+# --- per-container node placement (media stack pins to pve1 in v1; v2 = pve2 per JAC-69) ---
 
 run "ansible_inventory_container_node_override_propagated" {
   command = plan
@@ -241,7 +241,7 @@ run "ansible_inventory_container_node_override_propagated" {
           { path = "/dev/net/tun", mode = "0666" }
         ]
         mount_points = [
-          { volume = "/tank/downloads", path = "/mnt/downloads" }
+          { volume = "/rpool/data/downloads", path = "/mnt/downloads" }
         ]
       }
       "lan-default-node" = {
@@ -463,6 +463,50 @@ run "ansible_inventory_node_storage_propagated" {
   assert {
     condition     = output.ansible_inventory.node_storage["pve2"].pools["tank"].protected == true
     error_message = "node_storage pool protected must default to true (storage-safety)"
+  }
+}
+
+# JAC-69 v1: pve carries rpool/data datasets for the media stack. register=false
+# because rpool is already PVE-registered as `local-zfs`; ansible-proxmox just
+# creates the datasets, not a duplicate `pvesm add`.
+run "ansible_inventory_node_storage_pve_media_datasets" {
+  command = plan
+
+  variables {
+    node_storage = {
+      pve = {
+        pools = {
+          rpool = {
+            raid     = "mirror"
+            register = false
+            datasets = {
+              "data/downloads" = { quota = "500G", mountpoint = "/rpool/data/downloads" }
+              "data/media"     = { quota = "1.5T", mountpoint = "/rpool/data/media" }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  assert {
+    condition     = output.ansible_inventory.node_storage["pve"].pools["rpool"].datasets["data/downloads"].quota == "500G"
+    error_message = "node_storage.pve.rpool must declare data/downloads with quota 500G for the media stack"
+  }
+
+  assert {
+    condition     = output.ansible_inventory.node_storage["pve"].pools["rpool"].datasets["data/media"].quota == "1.5T"
+    error_message = "node_storage.pve.rpool must declare data/media with quota 1.5T for the media stack"
+  }
+
+  assert {
+    condition     = output.ansible_inventory.node_storage["pve"].pools["rpool"].register == false
+    error_message = "node_storage.pve.rpool must set register=false (rpool is already PVE-registered as local-zfs)"
+  }
+
+  assert {
+    condition     = output.ansible_inventory.node_storage["pve"].pools["rpool"].protected == true
+    error_message = "node_storage.pve.rpool must default to protected=true"
   }
 }
 


### PR DESCRIPTION
## Summary

Redirects the media stack (LXCs 210-214: `download-vpn`, `sonarr`, `radarr`, `plex`, `jellyseerr`) from `pve2` to `pve` (= pve1), and declares the `rpool/data/downloads` and `rpool/data/media` ZFS datasets that the downstream `ansible-proxmox` `zfs_pools` role will provision ahead of LXC creation.

**DO NOT MERGE** until the sibling `ansible-proxmox` `zfs_pools` role PR is reviewed and an apply window is scheduled.

## Why (per Linear JAC-69)

Ground-truth recon on 2026-05-31 found four hard blockers on `pve2`:

1. Not yet clustered with `pve`.
2. No `/tank/downloads` or `/tank/media` ZFS datasets.
3. `vmbr0` is not VLAN-aware.
4. Remote migration with the above is risky.

`pve` (the `pve1` node) is already VLAN-aware, IS the always-on host, and has ~3.1 TB free on `rpool` today. Decision recorded in JAC-69:

- **v1 (this PR)** ships the media stack on `pve` NOW.
- **v2** migrates to `pve2` in a future maintenance window once `pve2` is fully prepared (clustering, VLAN bridge, tank datasets). The existing `node_storage.pve2.tank.*` and `pve2` node entry stay in place untouched as the v2 target.

## Changes

### `deployment.json`

- Redirect `download-vpn` (210), `sonarr` (211), `radarr` (212), `plex` (213), and `jellyseerr` (214 from PR #336) from `node_name: "pve2"` -> `node_name: "pve"`.
- Rewrite bind-mounts on the four LXCs that carry them: `/tank/downloads` -> `/rpool/data/downloads`, `/tank/media` -> `/rpool/data/media`. (Jellyseerr has none.)
- Add `node_storage.pve.pools.rpool` with two new datasets:
  - `data/downloads` quota `500G`, mountpoint `/rpool/data/downloads`
  - `data/media` quota `1.5T`, mountpoint `/rpool/data/media`
  - `register: false` because `rpool` is already PVE-registered as `local-zfs`; the `zfs_pools` role only needs to create the datasets, not a duplicate `pvesm add`.
  - `protected: true` (schema default) — no destroy path.
- Update the `media` pool comment and per-LXC `description` strings to reflect the v1-on-pve1 / v2-on-pve2 split.

### `tests/ansible_inventory_contract.tftest.hcl`

- Update the bind-mount fixture in `ansible_inventory_container_node_override_propagated` from `/tank/downloads` to `/rpool/data/downloads`. The override target stays `pve2` because the test asserts the override mechanic itself, independent of v1 placement.
- Add new run-block `ansible_inventory_node_storage_pve_media_datasets` asserting `node_storage.pve.rpool.datasets` carries `data/downloads` (500G) and `data/media` (1.5T), `register=false`, `protected=true`.

### `docs/ARCHITECTURE.md`

- Reflect the v1 placement and `rpool/data/*` bind-mount paths in the media-pool summary and the per-container facts.

## Static checks

- `tofu fmt -check -recursive`: clean.
- `tofu validate`: success (one pre-existing deprecation warning on `proxmox_virtual_environment_datastores`, unrelated to this PR).
- `tofu test`: **89 passed, 0 failed**, including the new `ansible_inventory_node_storage_pve_media_datasets` assertion.
- pre-commit: all hooks pass on commit (`tofu test`, `trim trailing whitespace`, `end of files`).

## Downstream / sibling PR

This PR is paired with a `dryvist/ansible-proxmox` PR introducing a `zfs_pools` role that consumes the `node_storage.pve` entry and creates the two datasets on `pve` before LXC apply.

## Test plan

- [x] `tofu fmt -check -recursive` clean
- [x] `tofu validate` (one pre-existing unrelated warning)
- [x] `tofu test` 89 passed, 0 failed
- [ ] `terragrunt plan` (credentialed, in a follow-up task — see JAC-69)
- [ ] Snapshot `pve` before applying (rollback safety)
- [ ] `ansible-proxmox` `zfs_pools` role converges `data/downloads` + `data/media` ahead of `terragrunt apply`
- [ ] `terragrunt apply` creates LXCs 210-214 on `pve`
- [ ] `ansible-proxmox-apps` media roles converge end-to-end

Refs: JAC-69
Refs: #336 (jellyseerr LXC 214, redirected here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)