### PR TITLE
refactor(media): renumber media VMIDs — plex=210, download-vpn=214

### DIFF
--- a/deployment.json
+++ b/deployment.json
@@ -533,7 +533,7 @@
       "root_disk": { "size": 100 }
     },
     "download-vpn": {
-      "vm_id": 210,
+      "vm_id": 214,
       "vlan": "media_svc",
       "hostname": "download-vpn",
       "description": "VPN-locked downloader: qBittorrent-nox + Prowlarr behind Proton WireGuard with an nftables killswitch (wg0 down => no egress). Configured by ansible-proxmox-apps download_vpn role. Pinned to pve1 (always-on; v1 placement per JAC-69; v2 = pve2). Shell only: bind-mounts (/rpool/data/{downloads,media}), keyctl, and /dev/net/tun are applied by ansible-proxmox (root@pam) — see _media_comment.",
@@ -548,7 +548,7 @@
       "features": { "nesting": true }
     },
     "sonarr": {
-      "vm_id": 211,
+      "vm_id": 212,
       "vlan": "media_svc",
       "hostname": "sonarr",
       "description": "Sonarr TV series PVR/management. LAN-only (no VPN); reaches Prowlarr+qBittorrent on download-vpn over the LAN. Configured by ansible-proxmox-apps sonarr role. Pinned to pve1 (always-on; v1 placement per JAC-69; v2 = pve2). Shell only: bind-mounts (/rpool/data/{downloads,media}) are applied by ansible-proxmox (root@pam) — see _media_comment.",
@@ -562,7 +562,7 @@
       "root_disk": { "size": 16 }
     },
     "radarr": {
-      "vm_id": 212,
+      "vm_id": 213,
       "vlan": "media_svc",
       "hostname": "radarr",
       "description": "Radarr movie PVR/management. LAN-only (no VPN); reaches Prowlarr+qBittorrent on download-vpn over the LAN. Configured by ansible-proxmox-apps radarr role. Pinned to pve1 (always-on; v1 placement per JAC-69; v2 = pve2). Shell only: bind-mounts (/rpool/data/{downloads,media}) are applied by ansible-proxmox (root@pam) — see _media_comment.",
@@ -576,7 +576,7 @@
       "root_disk": { "size": 16 }
     },
     "plex": {
-      "vm_id": 213,
+      "vm_id": 210,
       "vlan": "media_svc",
       "hostname": "plex",
       "description": "Plex Media Server. LAN-only (no VPN); streams from rpool/data/media. Configured by ansible-proxmox-apps plex role. Pinned to pve1 (always-on; v1 placement per JAC-69; v2 = pve2). Shell only: the /rpool/data/media bind-mount is applied by ansible-proxmox (root@pam) — see _media_comment.",
@@ -590,7 +590,7 @@
       "root_disk": { "size": 16 }
     },
     "jellyseerr": {
-      "vm_id": 214,
+      "vm_id": 211,
       "vlan": "media_svc",
       "hostname": "jellyseerr",
       "description": "Jellyseerr request UI (Docker in LXC). Self-service movie/TV request front-end that wires to Sonarr, Radarr, and Plex. Config-only: no bind-mounts (reaches *arr + Plex over the LAN). Configured by ansible-proxmox-apps jellyseerr role. Pinned to pve1 (always-on; v1 placement per JAC-69; v2 = pve2). Shell only: keyctl is applied by ansible-proxmox (root@pam) — see _media_comment.",


### PR DESCRIPTION
## What

Remap the 5 media container VMIDs in `deployment.json` so the stack reads in service order (VMID = IP last octet).

| Container | Old | New |
| --- | --- | --- |
| plex | 213 | **210** |
| jellyseerr | 214 | **211** |
| sonarr | 211 | **212** |
| radarr | 212 | **213** |
| download-vpn | 210 | **214** |

Only the `vm_id` fields change. Bind-mounts, features, `pool_id`, `node_name` (pve1), VLAN, and the `network_prefix.vm_id` IP-derivation contract are all untouched.

## Why

Cleaner numbering: Plex (the primary user-facing service) anchors at 210; the VPN downloader moves to the end at 214.

## Blast radius

`vm_id` is `ForceNew` in the bpg/proxmox provider, so applying this **replaces** the 5 media LXCs (destroy + recreate). No other guests, pools, ZFS datasets, or firewall rules are affected. Host-level ZFS datasets (`/rpool/data/{downloads,media}`) are managed by ansible-proxmox and are not in scope.

## Verification

- `tofu fmt -check` clean
- `tofu validate` Success (pre-existing datastore deprecation warning only)
- `tofu test`: same 86 pass / 3 fail as pristine `main` — the 3 failures (`host_services_default_no_nas`, `domain_default_empty`, `vm_node_placement_defaults_to_primary`) are pre-existing and unrelated to this change (verified against `origin/main`).
- No contract test asserts the real `deployment.json` VMID↔service mapping, so no test updates were required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)