### PR TITLE
fix(terragrunt): resolve inventory sync to public worktree layout

### DIFF
--- a/terragrunt.hcl
+++ b/terragrunt.hcl
@@ -69,7 +69,7 @@ terraform {
   # Writes terraform_inventory.json to ansible-proxmox, ansible-proxmox-apps, and ansible-splunk.
   after_hook "sync_inventory" {
     commands     = ["apply"]
-    execute      = ["bash", "-c", "INV=$(tofu output -json ansible_inventory) && for repo in ansible-proxmox ansible-proxmox-apps ansible-splunk; do TARGET=\"$HOME/git/$repo/main/inventory/terraform_inventory.json\"; if [ -d \"$(dirname \"$TARGET\")\" ]; then printf \"%s\\n\" \"$INV\" > \"$TARGET\" && echo \"Synced inventory -> $repo\" >&2; else echo \"Skipped $repo (not cloned at ~/git/$repo/main)\" >&2; fi; done"]
+    execute      = ["bash", "-c", "INV=$(tofu output -json ansible_inventory) && for repo in ansible-proxmox ansible-proxmox-apps ansible-splunk; do TARGET=\"\"; for root in \"$GIT_HOME_PUBLIC\" \"$GIT_HOME\"; do [ -n \"$root\" ] && [ -d \"$root/$repo/main/inventory\" ] && TARGET=\"$root/$repo/main/inventory/terraform_inventory.json\" && break; done; if [ -n \"$TARGET\" ]; then printf \"%s\\n\" \"$INV\" > \"$TARGET\" && echo \"Synced inventory -> $TARGET\" >&2; else echo \"Skipped $repo (no main worktree found)\" >&2; fi; done"]
     run_on_error = false
   }
 }


### PR DESCRIPTION
## Problem

The post-apply `sync_inventory` `after_hook` resolved its target path under the non-public `$GIT_HOME/<repo>/main` layout. Every downstream clone in this workspace lives under `$GIT_HOME_PUBLIC` instead, so the hook's `[ -d ... ]` guard never matched and it **silently skipped all three** downstream repos (`ansible-proxmox`, `ansible-proxmox-apps`, `ansible-splunk`). They never received the freshly-applied `terraform_inventory.json` — the only cross-repo reference in this stack.

## Fix

Resolve each repo's inventory dir by preferring `$GIT_HOME_PUBLIC` and falling back to `$GIT_HOME`, mirroring the workspace "Finding a repo" convention. Writes to the first `main/inventory` that exists; otherwise prints a skip notice.

- Remains a single-line inline hook — no new script file.
- No `.tf` changed; `terraform validate`, `tflint`, `tofu test`, and gitleaks all pass locally.
- Verified the resolver targets all three public clones via dry-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)