### PR TITLE
feat(media): declare Traefik TLS ingress LXC (215) on media VLAN

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -179,7 +179,7 @@ Authoritative list lives in `deployment.json` `containers.*`. Summary by pool:
   `node_storage`, and ansible inventory label all aligned on that node;
   v2 lives on the secondary media node) — `download-vpn` (qBittorrent +
   Prowlarr behind Proton WireGuard with an nftables killswitch), `sonarr`,
-  `radarr`, `plex`, `jellyseerr`
+  `radarr`, `plex`, `jellyseerr`, `traefik` (HTTPS/TLS ingress)
 
 Notable per-container facts:
 
@@ -204,6 +204,14 @@ Notable per-container facts:
 - `sonarr`, `radarr`, `plex` are LAN-only (no VPN); they reach Prowlarr +
   qBittorrent on `download-vpn` over the LAN and read/write the same
   bind-mounted `rpool/data/*` datasets.
+- `traefik` (VMID 215) is the HTTPS reverse-proxy / TLS ingress, on the media
+  VLAN so it reaches the media UIs at layer 2 (other VLANs' UIs route in). It
+  fronts every service web UI at `https://<name>.pve.<domain>` (no ports) and
+  fetches + auto-renews a wildcard `*.pve.<domain>` Let's Encrypt certificate
+  itself via the Route53 DNS-01 challenge (lego) — no inbound internet required.
+  Install, dynamic routers (generated from this inventory), and the cert
+  lifecycle are owned by the `ansible-proxmox-apps` `traefik` role; it
+  supersedes the legacy `nginx-proxy-manager` LXC.
 
 #### Notification Services
 

--- a/tests/ansible_inventory_contract.tftest.hcl
+++ b/tests/ansible_inventory_contract.tftest.hcl
@@ -253,6 +253,45 @@ run "ansible_inventory_container_node_override_propagated" {
   }
 }
 
+# --- ingress: traefik reverse-proxy container contract ---
+#
+# The ansible-proxmox-apps `traefik` role auto-generates its routers/services
+# from this inventory: it needs the ingress LXC to surface with a derived IP,
+# its node, and the "ingress" tag so the role can find it. Pin that contract.
+
+run "ansible_inventory_traefik_ingress_container" {
+  command = plan
+
+  variables {
+    containers = {
+      "traefik" = {
+        vm_id     = 215
+        hostname  = "traefik"
+        vlan      = "media_svc"
+        node_name = "proxmox-2"
+        pool_id   = "media"
+        tags      = ["terraform", "container", "ingress", "traefik"]
+      }
+    }
+  }
+
+  # IP derives from the media_svc CIDR (192.168.55.0/24) + vm_id last octet.
+  assert {
+    condition     = output.ansible_inventory.containers["traefik"].ip == "192.168.55.215"
+    error_message = "traefik ingress IP must derive to 192.168.55.215 (cidrhost(media_svc, 215))"
+  }
+
+  assert {
+    condition     = output.ansible_inventory.containers["traefik"].node == "proxmox-2"
+    error_message = "traefik must land on its declared media node"
+  }
+
+  assert {
+    condition     = contains(output.ansible_inventory.containers["traefik"].tags, "ingress")
+    error_message = "traefik must carry the 'ingress' tag the traefik role selects on"
+  }
+}
+
 # --- host_services structure tests ---
 
 run "ansible_inventory_host_services_exists" {


### PR DESCRIPTION
## What

Declares **Traefik** as the media-stack HTTPS reverse-proxy / TLS ingress (LXC vmid 215, `media_svc` VLAN, `media` pool). Traefik will front every service web UI at `https://<name>.pve.<domain>` (no ports) with a wildcard `*.pve.<domain>` Let's Encrypt certificate it fetches and auto-renews itself via the **Route53 DNS-01 challenge** (lego) — no inbound internet required. It supersedes the legacy `nginx-proxy-manager` LXC.

The live container definition lives in the **gitignored** `deployment.json` (per the repo's public/private split from #335). This PR is the **public, tracked surface**:

- **Contract test** (`tests/ansible_inventory_contract.tftest.hcl`) — pins the ingress container's derived IP (`cidrhost(media_svc, 215)` → `192.168.55.215`), its node, and the `ingress` tag. These are exactly the inventory inputs the downstream `traefik` role selects on, so a regression in the inventory contract fails CI here.
- **`docs/ARCHITECTURE.md`** — adds `traefik` to the media-stack list and a notable-fact entry describing the ingress + cert model.

## Why

Services are currently reachable only by raw `IP:port` with no TLS, which breaks Plex "secure connections" and is unusable for clean access. Traefik-native ACME (decided over the Proxmox/Terraform acme module) keeps cert renewal self-healing and decoupled from `terragrunt apply`.

## Cert scope

Wildcard scoped to **`*.pve.jacobpevans.com`** (the `pve` Route53 zone + Technitium internal zone already exist and already validate), not the public apex — smallest blast radius for both the cert key and the AWS IAM policy.

## Out of scope (follow-ups)

- The Ansible `traefik` role (install, dynamic routers, ACME) + Technitium CNAMEs + Plex/Seerr URL settings — separate PR in `ansible-proxmox-apps`, **closes #247**.
- The least-privilege Route53 IAM policy for the dedicated `acme` AWS user — documented in the role README.
- Live apply of LXC 215 — targeted apply in the credentialed session (legacy `pve`→`pve1` state drift means full-repo apply is avoided).

## Test plan

- `tofu test` (mock providers) — 27/27 pass, incl. `ansible_inventory_traefik_ingress_container`.
- `tofu fmt -check -recursive`, `tofu validate`, `tflint`, secret detection — all green via pre-commit.

Refs: dryvist/ansible-proxmox-apps#247

🤖 Generated with [Claude Code](https://claude.com/claude-code)