### PR TITLE
feat(ingress): single inventory-derived ingress route table (DRY)

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -140,6 +140,15 @@ locals {
       ntp               = 123
       idrac_kvm_r410    = 5410
       idrac_kvm_r710    = 5710
+      # Web UIs fronted by Traefik that have no other constant home. Kept here so
+      # every port lives in one place and the ingress table (below) references
+      # constants, never literals.
+      technitium_web    = 5380
+      pihole_web        = 80
+      phpipam_web       = 80
+      homeassistant_web = 8123
+      openproject_web   = 80
+      prometheus_web    = 9090
     }
     syslog_ports = {
       default   = 514
@@ -174,4 +183,47 @@ locals {
       jellyseerr_web  = 5055
     }
   }
+}
+
+# Traefik HTTPS ingress route table — the SINGLE source for every service the
+# reverse proxy fronts. The ansible-proxmox-apps `traefik` and `technitium_dns`
+# roles consume `ansible_inventory.ingress` instead of each hand-listing hosts
+# (the previous DRY violation). Add/remove a fronted service in ONE place here.
+locals {
+  # name = the hostname label -> https://<name>.<domain>.
+  # backend = the container key whose IP is resolved from the inventory.
+  # port = a pipeline_constants reference (never a literal, so ports stay DRY).
+  ingress_services = {
+    plex            = { backend = "plex", port = local.pipeline_constants.media_ports.plex_web }
+    seerr           = { backend = "jellyseerr", port = local.pipeline_constants.media_ports.jellyseerr_web }
+    sonarr          = { backend = "sonarr", port = local.pipeline_constants.media_ports.sonarr_web }
+    radarr          = { backend = "radarr", port = local.pipeline_constants.media_ports.radarr_web }
+    qbittorrent     = { backend = "download-vpn", port = local.pipeline_constants.media_ports.qbittorrent_web }
+    prowlarr        = { backend = "download-vpn", port = local.pipeline_constants.media_ports.prowlarr_web }
+    technitium      = { backend = "technitium-dns", port = local.pipeline_constants.service_ports.technitium_web }
+    pihole          = { backend = "pi-hole", port = local.pipeline_constants.service_ports.pihole_web }
+    phpipam         = { backend = "phpipam", port = local.pipeline_constants.service_ports.phpipam_web }
+    minio           = { backend = "minio", port = local.pipeline_constants.service_ports.minio_console }
+    infisical       = { backend = "infisical", port = local.pipeline_constants.service_ports.infisical_api }
+    mailpit         = { backend = "mailpit", port = local.pipeline_constants.notification_ports.mailpit_web }
+    ntfy            = { backend = "ntfy", port = local.pipeline_constants.notification_ports.ntfy_http }
+    homeassistant   = { backend = "homeassistant", port = local.pipeline_constants.service_ports.homeassistant_web }
+    openproject     = { backend = "openproject", port = local.pipeline_constants.service_ports.openproject_web }
+    prometheus      = { backend = "prometheus", port = local.pipeline_constants.service_ports.prometheus_web }
+    qdrant          = { backend = "qdrant", port = local.pipeline_constants.vector_db_ports.qdrant_http }
+    "haproxy-stats" = { backend = "haproxy", port = local.pipeline_constants.service_ports.haproxy_stats }
+  }
+
+  # Assembled routes: one {name, ip, port} per fronted service whose backend
+  # container is actually defined (others are skipped, so a partial deployment
+  # never emits a dangling route). IP resolves via container_ipv4 (cidrhost),
+  # already nonsensitive; strip the CIDR mask for the proxy backend URL.
+  ingress = [
+    for name, svc in local.ingress_services : {
+      name = name
+      ip   = split("/", local.container_ipv4[svc.backend])[0]
+      port = svc.port
+    }
+    if contains(keys(var.containers), svc.backend)
+  ]
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -124,6 +124,10 @@ output "ansible_inventory" {
     }
     # Pipeline constants - service and syslog port definitions
     constants = local.pipeline_constants
+    # Traefik ingress route table - one {name, ip, port} per fronted service UI.
+    # The ansible-proxmox-apps traefik + technitium_dns roles derive their routers
+    # and DNS aliases from this single source instead of hand-listing hosts.
+    ingress = local.ingress
     # Host-level NAS service config - consumed by ansible-proxmox to provision ZFS dataset + Samba
     host_services = var.host_services
     # Cluster node inventory (non-secret identity) - ansible-proxmox targets hosts and

--- a/tests/ansible_inventory_contract.tftest.hcl
+++ b/tests/ansible_inventory_contract.tftest.hcl
@@ -253,42 +253,56 @@ run "ansible_inventory_container_node_override_propagated" {
   }
 }
 
-# --- ingress: traefik reverse-proxy container contract ---
+# --- ingress: Traefik route table contract ---
 #
-# The ansible-proxmox-apps `traefik` role auto-generates its routers/services
-# from this inventory: it needs the ingress LXC to surface with a derived IP,
-# its node, and the "ingress" tag so the role can find it. Pin that contract.
+# `ansible_inventory.ingress` is the SINGLE source the ansible-proxmox-apps
+# `traefik` (routers) and `technitium_dns` (aliases) roles consume instead of
+# hand-listing hosts/ports. Pin: each fronted service surfaces as {name, ip,
+# port} with the IP derived via cidrhost + the port from pipeline_constants, and
+# a service whose backend container isn't deployed is skipped (no dangling route).
 
-run "ansible_inventory_traefik_ingress_container" {
+run "ansible_inventory_ingress_route_table" {
   command = plan
 
   variables {
+    # Only two of the fronted backends are deployed in this fixture; the rest of
+    # the ingress_services map must be filtered out.
     containers = {
-      "traefik" = {
-        vm_id     = 215
-        hostname  = "traefik"
-        vlan      = "media_svc"
-        node_name = "proxmox-2"
-        pool_id   = "media"
-        tags      = ["terraform", "container", "ingress", "traefik"]
+      "plex" = {
+        vm_id    = 210
+        hostname = "plex"
+        vlan     = "media_svc"
+      }
+      "jellyseerr" = {
+        vm_id    = 211
+        hostname = "jellyseerr"
+        vlan     = "media_svc"
       }
     }
   }
 
-  # IP derives from the media_svc CIDR (192.168.55.0/24) + vm_id last octet.
+  # plex: backend "plex" (192.168.55.210) on media_ports.plex_web (32400).
   assert {
-    condition     = output.ansible_inventory.containers["traefik"].ip == "192.168.55.215"
-    error_message = "traefik ingress IP must derive to 192.168.55.215 (cidrhost(media_svc, 215))"
+    condition = length([
+      for r in output.ansible_inventory.ingress :
+      r if r.name == "plex" && r.ip == "192.168.55.210" && r.port == 32400
+    ]) == 1
+    error_message = "ingress must front plex at 192.168.55.210:32400 (derived IP + constant port)"
   }
 
+  # seerr: route name != backend container ("jellyseerr") -> 192.168.55.211:5055.
   assert {
-    condition     = output.ansible_inventory.containers["traefik"].node == "proxmox-2"
-    error_message = "traefik must land on its declared media node"
+    condition = length([
+      for r in output.ansible_inventory.ingress :
+      r if r.name == "seerr" && r.ip == "192.168.55.211" && r.port == 5055
+    ]) == 1
+    error_message = "ingress must front seerr via the jellyseerr backend at 192.168.55.211:5055"
   }
 
+  # Services whose backend container is absent are skipped (sonarr not deployed).
   assert {
-    condition     = contains(output.ansible_inventory.containers["traefik"].tags, "ingress")
-    error_message = "traefik must carry the 'ingress' tag the traefik role selects on"
+    condition     = length([for r in output.ansible_inventory.ingress : r if r.name == "sonarr"]) == 0
+    error_message = "ingress must skip services whose backend container is not defined"
   }
 }
 


### PR DESCRIPTION
## What

Adds `ansible_inventory.ingress` — **one** source of truth for every service the Traefik reverse proxy fronts — so the downstream `traefik` (routers) and `technitium_dns` (aliases) roles stop **hand-listing the same ~18 hosts/ports in each role's defaults** (the DRY violation flagged in review).

- **`locals.tf`**: an `ingress_services` map (`name -> {backend container key, port}`) that references the existing `pipeline_constants` (no literal ports), and an assembled `ingress` list of `{name, ip, port}` resolving the IP via the existing `container_ipv4`/`cidrhost` logic. Services whose backend container isn't deployed are **skipped**, so a partial deployment never emits a dangling route.
- **`pipeline_constants.service_ports`**: add the handful of UI ports that had no constant home (technitium/pihole/phpipam/homeassistant/openproject/prometheus) so *all* ports live in one place.
- **`outputs.tf`**: surface `ingress` in `ansible_inventory`.
- **tests**: replace the prior container-render run with an `ingress` route-table contract test — derived IP + constant port, `name != backend` for seerr, and undefined backends skipped.

## Why

Both the `traefik` and `technitium_dns` roles previously hard-coded the full fronted-service list (a per-role copy). Deriving both from one tofu-owned table means **add/remove a fronted service in exactly one place** (`ingress_services`), and both the proxy routers and the DNS aliases follow. The companion ansible-proxmox-apps PR deletes the two hard-coded lists in favor of `terraform_data.ingress`.

## Test plan

- `tofu test` — 27/27 pass incl. `ansible_inventory_ingress_route_table`.
- `tofu fmt -check -recursive`, `tofu validate`, `tflint`, checkov, secret-scan — green via pre-commit/pre-push.

Refs: dryvist/ansible-proxmox-apps#247

🤖 Generated with [Claude Code](https://claude.com/claude-code)