### PR TITLE
chore(media): rename jellyseerr to seerr (pipeline constants + ingress)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -179,7 +179,7 @@ Authoritative list lives in `deployment.json` `containers.*`. Summary by pool:
   `node_storage`, and ansible inventory label all aligned on that node;
   v2 lives on the secondary media node) — `download-vpn` (qBittorrent +
   Prowlarr behind Proton WireGuard with an nftables killswitch), `sonarr`,
-  `radarr`, `plex`, `jellyseerr`, `traefik` (HTTPS/TLS ingress)
+  `radarr`, `plex`, `seerr`, `traefik` (HTTPS/TLS ingress)
 
 Notable per-container facts:
 

--- a/locals.tf
+++ b/locals.tf
@@ -180,7 +180,7 @@ locals {
       sonarr_web      = 8989
       radarr_web      = 7878
       plex_web        = 32400
-      jellyseerr_web  = 5055
+      seerr_web       = 5055
     }
   }
 }
@@ -195,7 +195,7 @@ locals {
   # port = a pipeline_constants reference (never a literal, so ports stay DRY).
   ingress_services = {
     plex            = { backend = "plex", port = local.pipeline_constants.media_ports.plex_web }
-    seerr           = { backend = "jellyseerr", port = local.pipeline_constants.media_ports.jellyseerr_web }
+    seerr           = { backend = "seerr", port = local.pipeline_constants.media_ports.seerr_web }
     sonarr          = { backend = "sonarr", port = local.pipeline_constants.media_ports.sonarr_web }
     radarr          = { backend = "radarr", port = local.pipeline_constants.media_ports.radarr_web }
     qbittorrent     = { backend = "download-vpn", port = local.pipeline_constants.media_ports.qbittorrent_web }

--- a/tests/ansible_inventory_contract.tftest.hcl
+++ b/tests/ansible_inventory_contract.tftest.hcl
@@ -147,8 +147,8 @@ run "ansible_inventory_constants_media_ports_exists" {
   }
 
   assert {
-    condition     = output.ansible_inventory.constants.media_ports.jellyseerr_web == 5055
-    error_message = "media_ports.jellyseerr_web must be 5055"
+    condition     = output.ansible_inventory.constants.media_ports.seerr_web == 5055
+    error_message = "media_ports.seerr_web must be 5055"
   }
 }
 
@@ -273,9 +273,9 @@ run "ansible_inventory_ingress_route_table" {
         hostname = "plex"
         vlan     = "media_svc"
       }
-      "jellyseerr" = {
+      "seerr" = {
         vm_id    = 211
-        hostname = "jellyseerr"
+        hostname = "seerr"
         vlan     = "media_svc"
       }
     }
@@ -290,13 +290,13 @@ run "ansible_inventory_ingress_route_table" {
     error_message = "ingress must front plex at 192.168.55.210:32400 (derived IP + constant port)"
   }
 
-  # seerr: route name != backend container ("jellyseerr") -> 192.168.55.211:5055.
+  # seerr: backend "seerr" (192.168.55.211) on media_ports.seerr_web (5055).
   assert {
     condition = length([
       for r in output.ansible_inventory.ingress :
       r if r.name == "seerr" && r.ip == "192.168.55.211" && r.port == 5055
     ]) == 1
-    error_message = "ingress must front seerr via the jellyseerr backend at 192.168.55.211:5055"
+    error_message = "ingress must front seerr at 192.168.55.211:5055"
   }
 
   # Services whose backend container is absent are skipped (sonarr not deployed).


### PR DESCRIPTION
Renames the request app `jellyseerr` → **`seerr`** on the infrastructure side, to match the renamed ansible role (dryvist/ansible-proxmox-apps#314) and the live app image `ghcr.io/seerr-team/seerr`.

## What changed
- `pipeline_constants.media_ports.jellyseerr_web` → `seerr_web` — the contract key surfaced in `ansible_inventory.constants` and consumed downstream
- Traefik ingress route `seerr`: `backend = "jellyseerr"` → `backend = "seerr"`
- `tests/ansible_inventory_contract.tftest.hcl` fixture + assertions
- `docs/ARCHITECTURE.md` prose

## ⚠️ Cross-repo ordering (breaking, no fallback)
`media_ports.seerr_web` and the `seerr` container/tag are consumed by **dryvist/ansible-proxmox-apps#314**, which expects the new names with no fallback. Land the two together. The live container rename (`jellyseerr` → `seerr` map key + hostname + tag) happens via the gitignored `deployment.json` at apply time (a `terraform state mv` + apply, no destroy) and re-syncs the inventory.

## Verification
- `tofu fmt -check` — clean
- `tofu validate` — success
- `tofu test` — **89 passed, 0 failed** (incl. the seerr ingress + `media_ports.seerr_web` contract assertions)
- No remaining `jellyseerr` outside the historical `CHANGELOG.md`

Refs: dryvist/ansible-proxmox-apps#314

🤖 Generated with [Claude Code](https://claude.com/claude-code)