### PR TITLE
feat(inventory): validate before sync; version inventory in int_homelab

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,10 +100,12 @@ containers, IPs, ports, and firewall rules.
 
 ### Inventory sync (automatic)
 
-`terragrunt.hcl` runs an `after_hook` post-apply that writes
-`terraform_inventory.json` to each downstream repo's `inventory/`
-directory under `~/git/<repo>/main/`. Repos not cloned locally are
-skipped with a stderr warning.
+`terragrunt.hcl` runs an `after_hook` post-apply (`scripts/sync-inventory.sh`)
+that validates the `ansible_inventory` output against the schema, then commits a
+versioned copy to the private `int_homelab` repo and writes `tofu_inventory.json`
+to each downstream repo's `inventory/` directory under `$GIT_HOME/<repo>/main/`.
+A partial/invalid output is rejected (nothing written). Repos not cloned locally
+are skipped with a stderr warning.
 
 To sync manually after importing state without applying, see
 `docs/ARCHITECTURE.md`.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -247,12 +247,9 @@ Both containers run Docker-in-LXC (`nesting: true`, `keyctl: true`) and are tagg
 terraform-proxmox produces `ansible_inventory` output consumed by Ansible repos:
 
 ```bash
-# Regenerate after terragrunt apply
-terragrunt output -json ansible_inventory > \
-  ~/git/ansible-proxmox-apps/main/inventory/terraform_inventory.json
-
-terragrunt output -json ansible_inventory > \
-  ~/git/ansible-splunk/main/inventory/terraform_inventory.json
+# Regenerate, validate, and distribute (writes tofu_inventory.json to each
+# downstream repo + a versioned commit to int_homelab; rejects a partial output)
+./scripts/sync-inventory.sh
 ```
 
 The inventory includes:

--- a/scripts/sync-inventory.sh
+++ b/scripts/sync-inventory.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Render the ansible_inventory output from OpenTofu, validate it against the
+# inventory schema (the CONTRACT — what "complete" means is declared there, not
+# here), and on success distribute it UNCHANGED: a versioned commit into the
+# private int_homelab repo, plus the gitignored copy each Ansible repo reads.
+#
+# The sync deliberately adds no interpretation of its own — shape comes from the
+# tofu output declarations, meaning comes from the consuming Ansible repos, and
+# "is this complete" comes from the schema. A partial output (e.g. from a
+# `-target` apply) fails the schema, so nothing is written — the guard the old
+# inline after_hook lacked.
+#
+# Manual run: aws-vault exec tf-proxmox -- doppler run -- ./scripts/sync-inventory.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "$REPO_ROOT"
+
+GIT_HOME="${GIT_HOME:?GIT_HOME must be set}"
+# The contract schema. Defaults to the interim schema; Phase 2 points this at the
+# homelab-schemas repo via TOFU_INVENTORY_SCHEMA.
+SCHEMA="${TOFU_INVENTORY_SCHEMA:-${GIT_HOME_PUBLIC:-$GIT_HOME/public}/ansible-proxmox-apps/main/tests/inventory_load/tofu_inventory.schema.json}"
+
+# Locate the private int_homelab data repo (bare+worktree or plain clone).
+INT_HOMELAB="${INT_HOMELAB_DIR:-}"
+if [[ -z "$INT_HOMELAB" ]]; then
+  for c in "$GIT_HOME/int_homelab/main" "$GIT_HOME/int_homelab"; do
+    if git -C "$c" rev-parse --git-dir &>/dev/null; then INT_HOMELAB="$c"; break; fi
+  done
+fi
+
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+terragrunt output -json ansible_inventory > "$tmp"
+
+# Gate: valid against the contract or abort, writing nothing. A partial output
+# that drops schema-required keys fails here.
+nix run nixpkgs#check-jsonschema -- --schemafile "$SCHEMA" "$tmp"
+
+# Versioned commit into the private int_homelab data repo (terraform-proxmox is
+# the source repo name, not yet renamed).
+dest="tofu/terraform-proxmox/ansible_inventory.json"
+if [[ -n "$INT_HOMELAB" ]]; then
+  install -Dm644 "$tmp" "$INT_HOMELAB/$dest"
+  if ! git -C "$INT_HOMELAB" diff --quiet -- "$dest" 2>/dev/null; then
+    git -C "$INT_HOMELAB" add "$dest"
+    git -C "$INT_HOMELAB" -c commit.gpgsign=true commit -qm "chore(inventory): sync ansible_inventory from tofu"
+    git -C "$INT_HOMELAB" push -q || echo "sync-inventory: committed to int_homelab but push failed" >&2
+  fi
+else
+  echo "sync-inventory: int_homelab clone not found under $GIT_HOME — skipped versioned commit" >&2
+fi
+
+# Transitional: the gitignored copy each Ansible repo reads until Phase 2 points
+# them at int_homelab.
+for repo in ansible-proxmox ansible-proxmox-apps ansible-splunk; do
+  for root in "${GIT_HOME_PUBLIC:-}" "$GIT_HOME"; do
+    if [[ -n "$root" && -d "$root/$repo/main/inventory" ]]; then
+      install -m644 "$tmp" "$root/$repo/main/inventory/tofu_inventory.json"
+      break
+    fi
+  done
+done

--- a/terragrunt.hcl
+++ b/terragrunt.hcl
@@ -65,11 +65,15 @@ locals {
 terraform {
   source = "."
 
-  # Automatically sync ansible_inventory to downstream Ansible repos after every apply.
-  # Writes terraform_inventory.json to ansible-proxmox, ansible-proxmox-apps, and ansible-splunk.
+  # Render, VALIDATE, then distribute ansible_inventory after every apply: a
+  # versioned commit into the private int_homelab repo, plus the transitional
+  # gitignored copy each Ansible repo reads today. A partial/invalid output (e.g.
+  # from a `-target` apply, where replace-pending media containers drop whole
+  # sections) is REJECTED and nothing is written — the guard the previous inline
+  # one-liner lacked. Logic lives in scripts/sync-inventory.sh (no-scripts rule).
   after_hook "sync_inventory" {
     commands     = ["apply"]
-    execute      = ["bash", "-c", "INV=$(tofu output -json ansible_inventory) && for repo in ansible-proxmox ansible-proxmox-apps ansible-splunk; do TARGET=\"\"; for root in \"$GIT_HOME_PUBLIC\" \"$GIT_HOME\"; do [ -n \"$root\" ] && [ -d \"$root/$repo/main/inventory\" ] && TARGET=\"$root/$repo/main/inventory/terraform_inventory.json\" && break; done; if [ -n \"$TARGET\" ]; then printf \"%s\\n\" \"$INV\" > \"$TARGET\" && echo \"Synced inventory -> $TARGET\" >&2; else echo \"Skipped $repo (no main worktree found)\" >&2; fi; done"]
+    execute      = ["bash", "${get_terragrunt_dir()}/scripts/sync-inventory.sh"]
     run_on_error = false
   }
 }

--- a/tests/splunk_protection.tftest.hcl
+++ b/tests/splunk_protection.tftest.hcl
@@ -81,7 +81,7 @@ run "plan_succeeds_without_splunk_credentials" {
 }
 
 # --- Test: ansible_inventory output contains splunk_vm at root level ---
-# Downstream Ansible repos load this output and access terraform_data.splunk_vm.
+# Downstream Ansible repos load this output and access tofu_data.splunk_vm.
 # Any nesting change here breaks ansible-splunk inventory loading.
 
 run "ansible_inventory_splunk_vm_at_root" {


### PR DESCRIPTION
Producer end of the coordinated **tofu inventory pipeline** (design: `int_homelab/docs/designs/2026-06-03-inventory-pipeline.md`).

## Problem
The Terragrunt `after_hook` piped `tofu output -json ansible_inventory` straight to a gitignored file in three repos with **zero validation**. On 2026-06-03 a `terragrunt apply -target=…` produced a *partial* output (replace-pending media containers evaluate to unknown under `-target`, dropping media + `media_ports` + `ingress` + `nodes` + `node_storage`); the hook synced that partial to all three repos, clobbering the good inventory. No history to roll back to either.

## Change (minimal, schema-driven)
Replace the inline one-liner with `scripts/sync-inventory.sh`:
- **Validate against the schema (the contract)** with `check-jsonschema`, then distribute the output **unchanged** only if valid: a versioned commit into the private `int_homelab` repo (`tofu/terraform-proxmox/ansible_inventory.json`) + the gitignored `tofu_inventory.json` each Ansible repo reads. The sync adds **no interpretation** — completeness is declared in the schema, not hand-coded here. A partial fails the schema → nothing is written.
- `tofu`/OpenTofu terminology; synced file is `tofu_inventory.json`.
- Moving logic into `scripts/` resolves the no-scripts-rule violation in the old inline hook.

## Verification
- `shellcheck` clean; repo pre-commit green (tofu validate, tflint, tofu test, secret scan).
- The strengthened schema (in #317) + `check-jsonschema` accept a complete inventory and reject a partial (proven against live state: partial → refused).

## Coordinated set (land together)
- dryvist/ansible-proxmox-apps#317 — strict schema (the contract) + tofu rename
- dryvist/ansible-proxmox#227 + dryvist/ansible-splunk#241 — tofu rename in consumers

The sync points `TOFU_INVENTORY_SCHEMA` at the strengthened schema from #317; the consumers read `tofu_inventory.json`. Don't apply/converge between merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)