### PR TITLE
feat(network): rename lan_mgmt→mgmt; place Traefik ingress on mgmt VLAN

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -208,8 +208,8 @@ Notable per-container facts:
 - `traefik` (VMID 101) is the HTTPS reverse-proxy / TLS ingress on the
   management VLAN (VLAN 5), co-located with `haproxy`; backends on other VLANs
   are reached via inter-VLAN routing (UniFi allow rules per UI port). It
-  fronts every service web UI at `https://<name>.pve.<domain>` (no ports) and
-  fetches + auto-renews a wildcard `*.pve.<domain>` Let's Encrypt certificate
+  fronts every service web UI at `https://<name>.<subdomain>` (no ports) and
+  fetches + auto-renews a wildcard `*.<subdomain>` Let's Encrypt certificate
   itself via the Route53 DNS-01 challenge (lego) — no inbound internet required.
   Install, dynamic routers (generated from this inventory), and the cert
   lifecycle are owned by the `ansible-proxmox-apps` `traefik` role; it

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -171,7 +171,8 @@ Authoritative list lives in `deployment.json` `containers.*`. Summary by pool:
 
 - **`infrastructure`** — `ansible`, `pve-scripts-local`, `technitium-dns`,
   `pi-hole`, `phpipam`, `apt-cacher-ng`, `minio`, `mailpit`, `ntfy`,
-  `homeassistant`, `mssql`, `nginx-proxy-manager`, `prometheus`
+  `homeassistant`, `mssql`, `nginx-proxy-manager`, `prometheus`, `traefik`
+  (HTTPS/TLS ingress)
 - **`logging`** — `haproxy`, `cribl-edge-01/02`, `cribl-stream-01/02`,
   `splunk-mgmt` (SH + DS + LM + MC + CM)
 - **`ai`** — `claude-code-01/02`, `gemini-01/02`, `qdrant`, `llamaindex`
@@ -179,7 +180,7 @@ Authoritative list lives in `deployment.json` `containers.*`. Summary by pool:
   `node_storage`, and ansible inventory label all aligned on that node;
   v2 lives on the secondary media node) — `download-vpn` (qBittorrent +
   Prowlarr behind Proton WireGuard with an nftables killswitch), `sonarr`,
-  `radarr`, `plex`, `seerr`, `traefik` (HTTPS/TLS ingress)
+  `radarr`, `plex`, `seerr`
 
 Notable per-container facts:
 
@@ -204,8 +205,9 @@ Notable per-container facts:
 - `sonarr`, `radarr`, `plex` are LAN-only (no VPN); they reach Prowlarr +
   qBittorrent on `download-vpn` over the LAN and read/write the same
   bind-mounted `rpool/data/*` datasets.
-- `traefik` (VMID 215) is the HTTPS reverse-proxy / TLS ingress, on the media
-  VLAN so it reaches the media UIs at layer 2 (other VLANs' UIs route in). It
+- `traefik` (VMID 101) is the HTTPS reverse-proxy / TLS ingress on the
+  management VLAN (VLAN 5), co-located with `haproxy`; backends on other VLANs
+  are reached via inter-VLAN routing (UniFi allow rules per UI port). It
   fronts every service web UI at `https://<name>.pve.<domain>` (no ports) and
   fetches + auto-renews a wildcard `*.pve.<domain>` Let's Encrypt certificate
   itself via the Route53 DNS-01 challenge (lego) — no inbound internet required.

--- a/terragrunt.hcl
+++ b/terragrunt.hcl
@@ -31,7 +31,7 @@ locals {
   # shared one-way with terraform-unifi — single source, no magic numbers.
   network_cidrs = {
     lan_main  = get_env("NETWORK_CIDR_LAN_MAIN")
-    lan_mgmt  = get_env("NETWORK_CIDR_LAN_MGMT")
+    mgmt      = get_env("NETWORK_CIDR_MGMT")
     dns       = get_env("NETWORK_CIDR_DNS")
     bmc       = get_env("NETWORK_CIDR_BMC")
     compute   = get_env("NETWORK_CIDR_COMPUTE")

--- a/variables-network.tf
+++ b/variables-network.tf
@@ -39,7 +39,7 @@ variable "vlan_ids" {
   default = {
     lan_main  = 1
     dns       = 2
-    lan_mgmt  = 5
+    mgmt      = 5
     bmc       = 8
     compute   = 10
     siem      = 20


### PR DESCRIPTION
## Summary

Moves the Traefik HTTPS ingress LXC off the **dns** VLAN onto the **management (mgmt) VLAN (VLAN 5)**, co-located with haproxy, and renames the network key `lan_mgmt` → `mgmt`.

### Why
The `dns` VLAN enforces **client/device isolation** — a reverse proxy placed there cannot TCP-connect even to its own same-VLAN peers (verified: traefik→technitium/pihole failed), so it's a poor home for an ingress that must front every UI. The management VLAN (not isolated, where haproxy already lives) is the correct placement.

### Changes
- `variables-network.tf` (`vlan_ids`) + `terragrunt.hcl` (`network_cidrs`): rename `lan_mgmt` → `mgmt`. No guests referenced `lan_mgmt`, so this is a contained two-file rename. `network_cidrs["mgmt"]` is sourced from the new `NETWORK_CIDR_MGMT` env var (Doppler).
- `docs/ARCHITECTURE.md`: Traefik is now in the `infrastructure` pool on the management VLAN (co-located with haproxy); VMID note updated 215 → 101; backends on other VLANs reached via inter-VLAN routing.

### Live state (already applied)
Traefik LXC 101 was moved in-place to VLAN 5 / 10.0.x.x, serves the valid `*.<subdomain>` Let's Encrypt wildcard, and routes to reachable backends (plex→401, seerr→307). The 18 ingress DNS A-records were repointed to the new IP.

### Follow-up (not in this PR)
Inter-VLAN **UniFi allow rules** (`mgmt` → each backend UI port) in terraform-unifi. Until they land, only backends on permissive VLANs (media) route; others return 502 by design (destination-VLAN firewall). Pre-existing `deployment.json` drift (haproxy modeled as `pipeline`) is also deferred.

## Verification
- `terragrunt validate`: pass. Pre-commit: fmt, tflint, `tofu test` (mock), checkov, secret-scan all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
