### PR TITLE
feat(network): untagged-native NIC support, static IP override, mgmt_native key

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -21,9 +21,14 @@ locals {
 
   # Per-guest IPv4 (CIDR notation) and gateway, keyed by resource name. IP is
   # cidrhost(<guest VLAN CIDR>, vm_id); gateway is the .1 of that subnet.
+  # A container MAY pin a static ipv4_address (CIDR form, e.g. "192.168.5.10/24") to
+  # override the vm_id-derived address — for fixed low-number hosts (e.g. a DNS server
+  # at .10) whose address must not follow the vm_id. Otherwise derived as usual.
   container_ipv4 = {
-    for k, v in var.containers : k =>
-    nonsensitive("${cidrhost(var.network_cidrs[v.vlan], v.vm_id)}/${split("/", var.network_cidrs[v.vlan])[1]}")
+    for k, v in var.containers : k => nonsensitive(coalesce(
+      try(v.ip_config.ipv4_address, null),
+      "${cidrhost(var.network_cidrs[v.vlan], v.vm_id)}/${split("/", var.network_cidrs[v.vlan])[1]}"
+    ))
   }
   container_gateway = {
     for k, v in var.containers : k => nonsensitive(cidrhost(var.network_cidrs[v.vlan], 1))

--- a/main.tf
+++ b/main.tf
@@ -68,7 +68,7 @@ module "vms" {
       }
       # Tag every NIC onto the VM's service VLAN (802.1Q id from var.vlan_ids).
       network_interfaces = [
-        for ni in v.network_interfaces : merge(ni, { vlan_id = var.vlan_ids[v.vlan] })
+        for ni in v.network_interfaces : merge(ni, { vlan_id = lookup(var.vlan_ids, v.vlan, null) })
       ]
       user_account = {
         username = v.user_account.username
@@ -103,13 +103,14 @@ module "containers" {
       node_name        = coalesce(try(v.node_name, null), var.proxmox_node)
       template_file_id = "${var.datastore_iso}:vztmpl/${var.proxmox_ct_template_debian}"
       # DRY: IP/gateway derived from the LXC's VLAN CIDR + vm_id (see locals.tf).
+      # local.container_ipv4 already honors a per-container static ipv4_address override.
       ip_config = {
         ipv4_address = local.container_ipv4[k]
         ipv4_gateway = local.container_gateway[k]
       }
       # Tag every NIC onto the LXC's service VLAN (802.1Q id from var.vlan_ids).
       network_interfaces = [
-        for ni in v.network_interfaces : merge(ni, { vlan_id = var.vlan_ids[v.vlan] })
+        for ni in v.network_interfaces : merge(ni, { vlan_id = lookup(var.vlan_ids, v.vlan, null) })
       ]
       # DRY: Always inject SSH key for Ansible access
       # Uses container's password/keys if specified, otherwise empty password with SSH key only

--- a/terragrunt.hcl
+++ b/terragrunt.hcl
@@ -32,6 +32,9 @@ locals {
   network_cidrs = {
     lan_main  = get_env("NETWORK_CIDR_LAN_MAIN")
     mgmt      = get_env("NETWORK_CIDR_MGMT")
+    # Native/untagged Management subnet (gateway + DNS servers). No vlan_ids entry
+    # => NICs on this key are untagged (native VLAN), matching haproxy/Technitium.
+    mgmt_native = get_env("NETWORK_CIDR_LAN_MGMT")
     dns       = get_env("NETWORK_CIDR_DNS")
     bmc       = get_env("NETWORK_CIDR_BMC")
     compute   = get_env("NETWORK_CIDR_COMPUTE")

--- a/tests/ansible_inventory_contract.tftest.hcl
+++ b/tests/ansible_inventory_contract.tftest.hcl
@@ -337,6 +337,50 @@ run "ansible_inventory_domain_field_exists" {
   }
 }
 
+# --- untagged-native vlan key + static IP override ---
+#
+# A vlan key present in network_cidrs but ABSENT from vlan_ids yields an untagged NIC
+# (native VLAN). A container MAY also pin a static ipv4_address overriding the
+# vm_id-derived address (e.g. a fixed DNS server at .10). Both feed the inventory.
+
+run "ansible_inventory_untagged_native_and_static_ip" {
+  command = plan
+
+  variables {
+    # Add an untagged native-Management key (intentionally NOT in vlan_ids).
+    network_cidrs = merge(
+      { for name, id in var.vlan_ids : name => "192.168.${id}.0/24" },
+      { mgmt_native = "192.168.5.0/24" }
+    )
+    containers = {
+      # On an untagged key; planning at all proves lookup(var.vlan_ids, vlan, null)
+      # avoids the missing-key error. IP derives from vm_id.
+      "dns-derived" = {
+        vm_id    = 110
+        hostname = "dns-derived"
+        vlan     = "mgmt_native"
+      }
+      # Static ipv4_address must override the vm_id-derived address.
+      "dns-static" = {
+        vm_id     = 111
+        hostname  = "dns-static"
+        vlan      = "mgmt_native"
+        ip_config = { ipv4_address = "192.168.5.10/24" }
+      }
+    }
+  }
+
+  assert {
+    condition     = output.ansible_inventory.containers["dns-derived"].ip == "192.168.5.110"
+    error_message = "container on a vlan key absent from vlan_ids must plan (untagged) and derive ip from vm_id"
+  }
+
+  assert {
+    condition     = output.ansible_inventory.containers["dns-static"].ip == "192.168.5.10"
+    error_message = "ip_config.ipv4_address must override the vm_id-derived address in the inventory"
+  }
+}
+
 run "ansible_inventory_domain_default_empty" {
   command = plan
 

--- a/variables-containers.tf
+++ b/variables-containers.tf
@@ -10,8 +10,9 @@ variable "containers" {
     pool_id     = optional(string)
 
     # Service VLAN name (required). Selects the guest's subnet + 802.1Q tag:
-    # IP = cidrhost(network_cidrs[vlan], vm_id), NIC vlan_id = vlan_ids[vlan].
-    # Must be a key in both var.network_cidrs and var.vlan_ids.
+    # IP = cidrhost(network_cidrs[vlan], vm_id) (unless ip_config.ipv4_address pins a
+    # static address); NIC vlan_id = vlan_ids[vlan]. Must be a key in network_cidrs;
+    # a key ABSENT from vlan_ids yields an UNTAGGED NIC (native VLAN, e.g. mgmt_native).
     vlan = string
 
     # Node placement (optional). When unset, main.tf defaults to var.proxmox_node


### PR DESCRIPTION
## Summary

Two small, composable module capabilities needed to place DNS servers on the **native (untagged) Management subnet at fixed low addresses** — the foundation for 3-node Technitium HA. No live resources change in this PR (module/test only).

### 1. Untagged-native NIC
`main.tf` builds each NIC's `vlan_id` via `lookup(var.vlan_ids, v.vlan, null)`. A vlan key that exists in `network_cidrs` but is **absent from `vlan_ids`** now yields an **untagged** NIC (native VLAN) — matching how the bridge's native-VLAN guests (e.g. haproxy) attach. Previously a missing key errored.

### 2. Per-container static IP override
`locals.tf` `container_ipv4` honors an optional `ip_config.ipv4_address` (CIDR form) that **overrides the `vm_id`-derived address** and propagates consistently to the `ansible_inventory` output and the ingress table. Gateway stays derived. This lets a fixed-role host (e.g. a DNS server at `.10`) keep a valid Proxmox VMID (≥100) while pinning a low address that doesn't follow the VMID.

### 3. `mgmt_native` key
`terragrunt.hcl` adds `mgmt_native` to `network_cidrs` (native Management subnet, sourced from the existing env var), intentionally **omitted from `vlan_ids`** so its NICs are untagged.

## Verification
- New test `ansible_inventory_untagged_native_and_static_ip`: a container on an untagged-native key plans and derives its IP; a container with a static `ipv4_address` shows that address (not the VMID-derived one) in the inventory.
- Full suite: **all tofu tests pass**; pre-commit (fmt, validate, tflint, checkov, secret-scan) green. No committed IP/domain literals — examples use `192.168.x` fixtures.

## Follow-up (not in this PR)
The 3 Technitium LXC declarations (`technitium-1/2/3` on `mgmt_native` at `.10/.11/.12`, node-pinned) land in the gitignored `deployment.json` + a credentialed apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)