### PR TITLE
feat(ingress): expose Open WebUI (llm) via Traefik + add LLM service ports

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -154,6 +154,9 @@ locals {
       homeassistant_web = 8123
       openproject_web   = 80
       prometheus_web    = 9090
+      # Local LLM: Ollama API (CT 167 hermes-infer) + Open WebUI (CT 168 hermes-chat)
+      ollama_api     = 11434
+      open_webui_web = 8080
     }
     syslog_ports = {
       default   = 514
@@ -215,6 +218,7 @@ locals {
     homeassistant   = { backend = "homeassistant", port = local.pipeline_constants.service_ports.homeassistant_web }
     openproject     = { backend = "openproject", port = local.pipeline_constants.service_ports.openproject_web }
     prometheus      = { backend = "prometheus", port = local.pipeline_constants.service_ports.prometheus_web }
+    llm             = { backend = "hermes-chat", port = local.pipeline_constants.service_ports.open_webui_web }
     qdrant          = { backend = "qdrant", port = local.pipeline_constants.vector_db_ports.qdrant_http }
     "haproxy-stats" = { backend = "haproxy", port = local.pipeline_constants.service_ports.haproxy_stats }
   }


### PR DESCRIPTION
## Summary
One DRY ingress entry + its port constants for the local LLM chat UI.

- `pipeline_constants.service_ports`: `ollama_api = 11434`, `open_webui_web = 8080`.
- `ingress_services`: `llm = { backend = "hermes-chat", port = …open_webui_web }` — auto-generates the Traefik router `Host(llm.<PROXMOX_SUBDOMAIN>)`, the Technitium A-record, and wildcard-cert coverage. No per-service ingress/DNS/cert config.

## Notes
- Backend `hermes-chat` (CT 168) is already in `deployment.json`; IP auto-derives via `cidrhost`.
- Consumed by `ansible-proxmox-apps` (`ollama`/`open_webui` roles + `traefik`/`technitium_dns`). The base domain fix (PROXMOX_SUBDOMAIN) is a separate ansible-proxmox-apps change.

## Test plan
- [x] `tofu fmt`
- [ ] pre-commit/CI: `tofu validate` + `tflint`
- [ ] Live: inventory carries the `llm` ingress -> `https://llm.pve.jacobpevans.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)