### PR TITLE
fix(vm): ignore cloud-init ip_config drift to avoid rebuilding the non-removable cloud-init drive

### DIFF
--- a/modules/proxmox-vm/main.tf
+++ b/modules/proxmox-vm/main.tf
@@ -161,6 +161,11 @@ resource "proxmox_virtual_environment_vm" "vms" {
     create_before_destroy = false
     ignore_changes = [
       initialization[0].user_account[0].password,
+      # Cloud-init runs only at first boot; Ansible owns post-boot networking.
+      # A VLAN change updates the qemu NIC live but also changes cloud-init
+      # ip_config — ignore it so bpg does not rebuild the cloud-init drive
+      # (which fails: the ide2 cloud-init disk is not removable on a running VM).
+      initialization[0].ip_config,
     ]
   }
 

--- a/modules/splunk-vm/main.tf
+++ b/modules/splunk-vm/main.tf
@@ -134,6 +134,10 @@ resource "proxmox_virtual_environment_vm" "splunk_vm" {
       # Ignore changes to user_data_file_id so cloud-init template updates
       # don't force VM replacement on an already-running VM.
       initialization[0].user_data_file_id,
+      # Same reason: a VLAN change alters cloud-init ip_config, which would make
+      # bpg rebuild the cloud-init drive — and that fails on the non-removable
+      # ide2 disk. Ansible owns post-boot networking, so ignore the drift.
+      initialization[0].ip_config,
     ]
   }
 }


### PR DESCRIPTION
## What
A VLAN change updates the qemu NIC live, but it also alters cloud-init `ip_config`, which makes the bpg provider try to **rebuild the cloud-init drive** — and that fails with `Device 'ide2' is not removable` on a running VM. This halted the homelab VLAN-segmentation apply before it could complete (and before the inventory-sync after-hook could run).

## Fix
Add `initialization[0].ip_config` to `ignore_changes` in both VM modules (`proxmox-vm`, `splunk-vm`). These VMs are **Ansible-managed post-boot** (cloud-init is first-boot only — already documented in the splunk-vm lifecycle), so tofu should not regenerate the cloud-init drive on an IP change. The qemu NIC VLAN tag is applied independently and persists; guest-OS networking is reconverged by Ansible.

## Why it's safe
- No resource is replaced or destroyed — purely stops a spurious cloud-init drive rebuild.
- Consistent with the existing `ignore_changes` on `initialization[0].user_data_file_id` and the in-code design note "Cloud-init runs only at first boot; Ansible handles all post-boot config."
- pre-commit green (Checkov, validate, tflint, tofu test).

Unblocks the clean completion of the VLAN-segmentation apply + the downstream inventory sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
