### PR TITLE
feat(splunk): tag splunk NIC onto siem VLAN + front via Traefik

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -227,12 +227,23 @@ locals {
   # container is actually defined (others are skipped, so a partial deployment
   # never emits a dangling route). IP resolves via container_ipv4 (cidrhost),
   # already nonsensitive; strip the CIDR mask for the proxy backend URL.
-  ingress = [
-    for name, svc in local.ingress_services : {
-      name = name
-      ip   = split("/", local.container_ipv4[svc.backend])[0]
-      port = svc.port
-    }
-    if contains(keys(var.containers), svc.backend)
-  ]
+  # The Splunk VM is appended separately: it is a VM (not in var.containers), so
+  # its IP comes from splunk_derived_ip (siem VLAN) rather than container_ipv4.
+  ingress = concat(
+    [
+      for name, svc in local.ingress_services : {
+        name = name
+        ip   = split("/", local.container_ipv4[svc.backend])[0]
+        port = svc.port
+      }
+      if contains(keys(var.containers), svc.backend)
+    ],
+    [
+      {
+        name = "splunk"
+        ip   = split("/", local.splunk_derived_ip)[0]
+        port = local.pipeline_constants.service_ports.splunk_web
+      }
+    ]
+  )
 }

--- a/main.tf
+++ b/main.tf
@@ -146,6 +146,7 @@ module "splunk_vm" {
   template_id    = var.template_id
   datastore_id   = var.datastore_id
   bridge         = var.bridge
+  vlan_id        = lookup(var.vlan_ids, "siem", null) # tag the NIC onto siem; DRY with container pattern
   ssh_public_key = var.ssh_public_key != "" ? var.ssh_public_key : trimspace(data.local_file.vm_ssh_public_key.content)
   boot_disk_size = var.splunk_boot_disk_size
   data_disk_size = var.splunk_data_disk_size

--- a/modules/splunk-vm/main.tf
+++ b/modules/splunk-vm/main.tf
@@ -84,6 +84,10 @@ resource "proxmox_virtual_environment_vm" "splunk_vm" {
     bridge   = var.bridge
     model    = "virtio"
     firewall = true
+    # 802.1Q tag onto the service VLAN (siem). Null/0 = untagged native.
+    # Mirrors the container NIC pattern (vlan_id = vlan_ids[guest.vlan]); without
+    # this the VM sits on vmbr0's untagged native instead of its own VLAN.
+    vlan_id = var.vlan_id
   }
 
   clone {

--- a/modules/splunk-vm/variables.tf
+++ b/modules/splunk-vm/variables.tf
@@ -104,6 +104,12 @@ variable "bridge" {
   }
 }
 
+variable "vlan_id" {
+  description = "802.1Q VLAN tag for the VM NIC. Null = untagged native VLAN."
+  type        = number
+  default     = null
+}
+
 variable "ssh_public_key" {
   description = "SSH public key content for VM access (optional)"
   type        = string


### PR DESCRIPTION
## Why

The `splunk-vm` module never set `vlan_id` on its NIC, so the Splunk VM sat on vmbr0's **untagged native VLAN** (the retiring flat segment) instead of the siem VLAN like every other guest. Result: the VM was unreachable from clients that no longer route to the flat segment, and accessible only by raw IP.

## What

- Add a `vlan_id` variable to `modules/splunk-vm` and wire it into `network_device` (null = untagged native).
- Pass `lookup(var.vlan_ids, "siem")` from the root module call (DRY with the container NIC pattern).
- Append a `splunk` Traefik ingress route. Splunk is a VM (not in `var.containers`), so its IP resolves via `splunk_derived_ip` (siem) rather than the container path — fronted at `https://splunk.<domain>` on `service_ports.splunk_web`.

## Safety

Splunk indexer data is **not backed up**. This change touches only the NIC VLAN tag and the ingress table — no disk, no `initialization`/cloud-init drive, `prevent_destroy=true` retained. Guest-OS IP reconvergence to the siem address is handled out-of-band (Ansible/manual) since `initialization[0].ip_config` is in `ignore_changes`.

## Validation

`tofu fmt`, `validate`, `tflint`, and `tofu test` pass (pre-commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)