### PR TITLE
feat(splunk): mark splunk ingress as https backend

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -243,6 +243,11 @@ locals {
         name = "splunk"
         ip   = split("/", local.splunk_derived_ip)[0]
         port = local.pipeline_constants.service_ports.splunk_web
+        # Splunk Web serves HTTPS with a self-signed cert, unlike the HTTP
+        # container backends. Traefik must speak https to it and skip verify.
+        # Consumers default scheme=http / insecure_tls=false when absent.
+        scheme       = "https"
+        insecure_tls = true
       }
     ]
   )


### PR DESCRIPTION
## Why

Splunk Web serves **HTTPS** with a self-signed cert, unlike the HTTP container backends. The Traefik route for it must speak https and skip self-signed verification, or it 502s.

## What

Tag the `splunk` ingress entry with `scheme = "https"` + `insecure_tls = true`. The downstream Traefik role (dryvist/ansible-proxmox-apps#337) reads these — building an `https://` backend and attaching an `insecureSkipVerify` serversTransport. HTTP container backends are unaffected (both keys default to `http`/`false` when absent).

## Validation

`tofu fmt`, `validate`, `tflint`, `tofu test` pass (pre-commit). Pairs with the migration in #369 (splunk NIC → siem VLAN).

Refs: dryvist/ansible-proxmox-apps#337

🤖 Generated with [Claude Code](https://claude.com/claude-code)