### PR TITLE
feat(storage): per-dataset ZFS properties in node_storage

### DIFF
--- a/deployment.json.example
+++ b/deployment.json.example
@@ -40,7 +40,20 @@
           "register": true,
           "content": ["images", "rootdir"],
           "datasets": {
-            "backups": { "quota": "1T" }
+            "backups": { "quota": "1T", "properties": { "compression": "zstd" } },
+            "media/tv": { "quota": "2T", "properties": { "recordsize": "1M", "compression": "zstd" } },
+            "media/movies": { "quota": "2T", "properties": { "recordsize": "1M", "compression": "zstd" } }
+          }
+        },
+        "example-nvme": {
+          "type": "zfspool",
+          "raid": "mirror",
+          "protected": true,
+          "register": false,
+          "content": ["images", "rootdir"],
+          "datasets": {
+            "siem/splunk-hot": { "quota": "300G", "properties": { "recordsize": "128K", "compression": "lz4" } },
+            "siem/cribl-pq": { "quota": "50G", "properties": { "compression": "lz4", "com.sun:auto-snapshot": "false" } }
           }
         }
       }

--- a/tests/ansible_inventory_contract.tftest.hcl
+++ b/tests/ansible_inventory_contract.tftest.hcl
@@ -528,7 +528,7 @@ run "ansible_inventory_node_storage_propagated" {
         pools = {
           example-pool = {
             raid     = "raidz1"
-            datasets = { backups = { quota = "1T" } }
+            datasets = { backups = { quota = "1T", properties = { recordsize = "1M", compression = "zstd" } } }
           }
         }
       }
@@ -538,6 +538,11 @@ run "ansible_inventory_node_storage_propagated" {
   assert {
     condition     = output.ansible_inventory.node_storage["proxmox-2"].pools["example-pool"].datasets["backups"].quota == "1T"
     error_message = "node_storage pool/dataset/quota must propagate to ansible_inventory for ansible-proxmox"
+  }
+
+  assert {
+    condition     = output.ansible_inventory.node_storage["proxmox-2"].pools["example-pool"].datasets["backups"].properties["recordsize"] == "1M"
+    error_message = "node_storage dataset properties must propagate to ansible_inventory for ansible-proxmox"
   }
 
   assert {

--- a/variables-storage.tf
+++ b/variables-storage.tf
@@ -119,6 +119,10 @@ variable "node_storage" {
         quota      = optional(string)
         mountpoint = optional(string)
         nfs_export = optional(string)
+        # Arbitrary ZFS properties (recordsize, compression, readonly,
+        # com.sun:auto-snapshot, …) applied idempotently by ansible-proxmox.
+        # Use ZFS canonical forms as strings (e.g. "1M", "zstd", "false").
+        properties = optional(map(string), {})
       })), {})
     }))
   }))


### PR DESCRIPTION
## Summary

Adds an optional `datasets.<name>.properties` map (`map(string)`) to the
`node_storage` variable, so the storage contract can carry per-dataset ZFS
tuning — `recordsize`, `compression`, `com.sun:auto-snapshot`, `readonly`, etc.
— for **ansible-proxmox** to apply idempotently.

## Why

Foundation (WS1) for the ZFS storage architecture (SIEM tiering, media datasets,
snapshot/replication targets). Each dataset "chunk" needs workload-appropriate
properties; quota alone isn't enough.

## What

- `variables-storage.tf`: `properties = optional(map(string), {})` on the
  datasets object. Surfaces via the existing pass-through
  `ansible_inventory` output (`outputs.tf:138`) — no extra wiring.
- `deployment.json.example`: documents the field with an NVMe SIEM tier
  (`siem/splunk-hot` 300G @ recordsize=128K/lz4, `siem/cribl-pq` 50G @
  com.sun:auto-snapshot=false) and a media tv/movies pattern (recordsize=1M/zstd).
- contract test: asserts `properties` propagates to `ansible_inventory`.

## Verification

- `tofu validate` ✓ (only a pre-existing proxmox-provider deprecation warning).
- `tofu fmt` ✓, `deployment.json.example` valid JSON ✓.
- `tofu test` (mock providers) ✓ — **28 passed, 0 failed**, including the new
  properties-propagation assertion.
- Backward-compatible: datasets without `properties` are unaffected.

## Scope / follow-up

Declaration/schema only — Terraform never creates pools. The live `nvme1` pool
declaration in the real (gitignored) `deployment.json` + `tofu apply` is the
credentialed apply step after merge. Pairs with the consumer role in
dryvist/ansible-proxmox#228.

Refs: dryvist/ansible-proxmox#228

🤖 Generated with [Claude Code](https://claude.com/claude-code)