### PR TITLE
feat(storage): Time Machine fields on host_services.nas.shares

### DIFF
--- a/tests/ansible_inventory_contract.tftest.hcl
+++ b/tests/ansible_inventory_contract.tftest.hcl
@@ -446,6 +446,7 @@ run "ansible_inventory_host_services_nas_propagated" {
             create_mask    = "0664"
             directory_mask = "0775"
             comment        = "Home Assistant backup storage"
+            time_machine   = true
           }
         ]
       }
@@ -475,6 +476,11 @@ run "ansible_inventory_host_services_nas_propagated" {
   assert {
     condition     = output.ansible_inventory.host_services.nas.shares[1].name == "ha-backups"
     error_message = "host_services.nas.shares must propagate to ansible_inventory output"
+  }
+
+  assert {
+    condition     = output.ansible_inventory.host_services.nas.shares[1].time_machine == true
+    error_message = "host_services.nas.shares time_machine must propagate to ansible_inventory output"
   }
 }
 

--- a/variables-storage.tf
+++ b/variables-storage.tf
@@ -90,6 +90,9 @@ variable "host_services" {
         create_mask    = optional(string)
         directory_mask = optional(string)
         comment        = optional(string)
+        # macOS Time Machine target (consumed by the nas_storage vfs_fruit role).
+        time_machine          = optional(bool)
+        time_machine_max_size = optional(string)
       })))
       description = optional(string)
     }))


### PR DESCRIPTION
## Summary

Adds optional `time_machine` (bool) + `time_machine_max_size` (string) to the
`host_services.nas.shares` contract so a NAS share can be declared a macOS
**Time Machine** target.

## What

- `variables-storage.tf`: two optional fields on the shares object; surfaces via
  the existing `ansible_inventory` pass-through (no extra wiring).
- contract test: asserts `time_machine` propagates.

## Verification

- `tofu validate` ✓; `tofu fmt` ✓ (comment line kept the diff to +3, no field churn).
- `tofu test` (mock providers) ✓ — **28 passed, 0 failed**, incl. the new assertion.
- Backward-compatible.

Consumed by the `nas_storage` vfs_fruit support in dryvist/ansible-proxmox#234.

Refs: dryvist/ansible-proxmox#234

🤖 Generated with [Claude Code](https://claude.com/claude-code)