### PR TITLE
feat(backup): PBS appliance VM (ISO) declaration + ISO var

### DIFF
--- a/deployment.json.example
+++ b/deployment.json.example
@@ -87,6 +87,22 @@
       "boot_disk": { "datastore_id": "local-zfs", "size": 32 },
       "clone_template": { "template_id": 9000 },
       "user_account": { "username": "debian", "password": "", "keys": [] }
+    },
+    "pbs": {
+      "vm_id": 240,
+      "vlan": "nonprod",
+      "name": "pbs",
+      "description": "Proxmox Backup Server appliance (ISO install). Boot the PBS ISO, install to the boot disk, then create a datastore on the additional disk (backup ZFS pool). Add a remote+sync job to a second PBS on the max-storage node once it is commissioned.",
+      "node_name": "proxmox-2",
+      "cpu_cores": 2,
+      "memory_dedicated": 4096,
+      "tags": ["terraform", "backup", "pbs"],
+      "boot_disk": { "datastore_id": "local-zfs", "size": 32 },
+      "additional_disks": [
+        { "interface": "scsi1", "datastore_id": "example-pool", "size": 1024 }
+      ],
+      "cdrom_file_id": "local:iso/proxmox-backup-server.iso",
+      "protection": true
     }
   },
 

--- a/tests/ansible_inventory_contract.tftest.hcl
+++ b/tests/ansible_inventory_contract.tftest.hcl
@@ -596,3 +596,30 @@ run "vm_node_placement_override" {
     error_message = "a VM with node_name set must be placed on that node"
   }
 }
+
+# An ISO-appliance VM (cdrom_file_id, an extra datastore disk, and no
+# clone_template) must plan — this is the shape the PBS backup appliance uses.
+run "vm_iso_appliance_plans" {
+  command = plan
+
+  variables {
+    vms = {
+      pbs = {
+        vm_id            = 240
+        name             = "pbs"
+        vlan             = "compute"
+        node_name        = "proxmox-2"
+        cdrom_file_id    = "local:iso/proxmox-backup-server.iso"
+        boot_disk        = { datastore_id = "local-zfs", size = 32 }
+        additional_disks = [{ interface = "scsi1", datastore_id = "local-zfs", size = 1024 }]
+        protection       = true
+        tags             = ["terraform", "backup", "pbs"]
+      }
+    }
+  }
+
+  assert {
+    condition     = output.ansible_inventory.vms["pbs"].node == "proxmox-2"
+    error_message = "ISO-appliance VM (cdrom_file_id, extra disk, no clone_template) must plan and land on its node"
+  }
+}

--- a/variables-storage.tf
+++ b/variables-storage.tf
@@ -51,6 +51,12 @@ variable "proxmox_iso_debian" {
   default     = "debian-13.2.0-amd64-netinst.iso"
 }
 
+variable "proxmox_iso_pbs" {
+  description = "Proxmox Backup Server ISO filename (upload to datastore_iso; reference it as <datastore_iso>:iso/<filename> in a VM's cdrom_file_id)."
+  type        = string
+  default     = "proxmox-backup-server_4.0-1.iso"
+}
+
 variable "template_id" {
   description = "VM ID of the Packer-built Splunk Docker template to clone from (default: splunk-docker-template ID 9201)"
   type        = number


### PR DESCRIPTION
## Summary

Declares a **Proxmox Backup Server** appliance VM (ISO install) so guest backups
can protect the VM/LXC fleet — most urgently the **explicitly-unprotected Splunk
indexer** (VM 200, whose module banner warns its data has no backup).

Decisions: **ISO-appliance VM**; datastore on **pve2 now, synced to pve3** later.

## What (this PR — declarative IaC only)

- `proxmox_iso_pbs` variable (the PBS ISO filename).
- An example `pbs` VM: ISO-boot (`cdrom_file_id`, no `clone_template`), 32G boot
  disk + a 1T datastore disk on the backup pool, `protection: true`.
- Contract-test run `vm_iso_appliance_plans` proving the ISO-appliance shape
  plans and lands on its node.

## Verification

- `tofu validate` ✓; `tofu fmt` ✓; `deployment.json.example` valid JSON ✓.
- `tofu test` (mock providers) ✓ — **29 passed, 0 failed** (incl. the new run).

## Apply-time runbook (credentialed / prod-touching — NOT in this PR)

1. Upload the PBS ISO to `datastore_iso`; add the `pbs` VM to the real
   `deployment.json` (datastore disk on pve2 `tank`); `tofu apply`.
2. Boot the VM, install PBS to the boot disk, set its IP/DNS.
3. On PBS: create a datastore on the 1T data disk; set GC + prune retention.
4. Add the PBS storage to the PVE cluster; create **vzdump → PBS** backup jobs,
   **starting with Splunk VM 200**, then mssql/qdrant/minio/infisical/openproject.
5. Verify a real Splunk backup completes **and a test restore succeeds** before
   relying on it.
6. When pve3 is commissioned: stand up a second PBS datastore there and add a
   PBS **remote + sync job** (pve2 → pve3) for the offline/DR copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)