### PR TITLE
fix(dev): point nix-devenv flake ref at dryvist owner + bump bpg lock

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,4 +1,4 @@
-use flake "github:JacobPEvans/nix-devenv?dir=shells/terraform"
+use flake "github:dryvist/nix-devenv?dir=shells/terraform"
 
 # This is an OpenTofu repo. Point pre-commit-terraform hooks (validate/fmt/docs)
 # at tofu instead of the HashiCorp terraform binary, which cannot read the

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -2,36 +2,24 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.opentofu.org/bpg/proxmox" {
-  version     = "0.106.0"
+  version     = "0.108.0"
   constraints = "~> 0.106"
   hashes = [
-    "h1:2lziY2aIqrpjAKAtYnDJ2Q06MlTaa512webPRs/yk4Y=",
-    "h1:CnUVTBB9ZlJRH9xhyxPIAY++4gSRqMeLMZokzgN1V2A=",
-    "h1:EOids9iCKPHt5Rm1zliMIybn36D5dRXkK9XjinmzlYk=",
-    "h1:Oh710k1dlYP0N+ttSRLlPBxw30AtgFPML7y50Hs311M=",
-    "h1:OpR5VcLyMmcLO/f04PlYph9wuipPTY5OxDPwSZyYYmo=",
-    "h1:XdZ9KMSldapSyJjut/DmT+CKYNrTMu9ZsYNSne8EBnI=",
-    "h1:diiF3KxyBX6HGIKsR98Y8TbN6RKzR51Tvn+NmJQ3gzE=",
-    "h1:ez7B4GCruD8Lk5Xdnq924jJvfu6/mCTMnYJtgHXOO5Y=",
-    "h1:jbKUrw6M3n7Y4U3kCmmq9XBYq2LPUz/kJ9A2bCzM4i0=",
-    "h1:t57Ykyd3/dNGEQ7pW12I70tA2U0Bqecv8f2/RqOeAaA=",
-    "h1:uJRko0x/UTr1yhVyNxSh7A7ZjLifc0UdAFdn2psLANk=",
-    "h1:uo/eZ4OHAJpdr5a2GyuXVKoLlkVwSspT1akZgAuEIbA=",
-    "h1:xktdHei+MqUgk6Lh3mYJlNY8R1tm2dBaBsSySTAKdn0=",
-    "zh:1a8d717dada526bf0aab51683352390e194bf5c05c8c69464e00befd113121d6",
-    "zh:31db845b45df5839b442104e31aa41f832eb1f363f5278df290f1a906b731150",
-    "zh:36af78f4395ac64e5a997fad6cfb18f369e5cae7e4895086ef7d39c65e3d6324",
-    "zh:526e87482db9a0f8c7a22b430214886a3df4fd08c6949b7235d9a088850fd736",
-    "zh:6c99f833606527b86fed0ef74bf8723e118b98a8067ff9f3745e90b095a4bc2b",
-    "zh:7aa85292c4891e85a817821dd31d736e977eabe3a04d29913d1cb5dfca2020ef",
-    "zh:879dc2b315093c2818c8ff289fcb20d6925dab57e7d758b5e646c6b35860ac37",
-    "zh:955eb04b8df5438a717af9766f02b48e919c0a33c97590905ee04f3106adb299",
-    "zh:981eb203d9cfbc735bd792a7654319a5a9b8d68a485d0399b4f018557550f0ce",
-    "zh:a0e3b74af3976aa4f9e68a7c8bde620abda2d4f0d29859032f9d6d2df3e4c200",
-    "zh:b767b70e56dc47238ef9f541c29a16e97e7f19b63b303d551593b620d0c9f609",
-    "zh:edf48f3699cf8597d07d7ab8923e5353da4337dfa9462c07c289643309bf7494",
+    "h1:5rjI1oYVsT/1wHe/60zpcCVPvDJrGkbBGPxvld9l+ro=",
+    "zh:059672baca1261158c0b5a503545010e2a407d64fb71dc4a205628cc327b1529",
+    "zh:13060adb3f4a5c4cdee898389b5e4773db4580747e4e03aad1f93879923745ba",
+    "zh:280f5b12d21b7112dcd4a0112e15438cb1cce939a51f17a5b57e8fa965e94bdf",
+    "zh:3aa78cbd3c7ffad675622a5879779262ef21db5f261667ffa4ff8bf61c568a94",
+    "zh:443171c407149012cd2eb293defb37973cfddd8481933d81c1dcca49234929cb",
+    "zh:5272ef8f3973b1a6ba8afc9fbb1a4e1f738aa9a1bba4c95d9b568a150da1c30d",
+    "zh:5d05fd0a5acb9dd3ae13df207adc48f0d06c73ee1ddd8ea35946780c987f5e6b",
+    "zh:609ec7c300775410c6968fc35a07157ce1de907b5482ac3e0e8672eff80dec31",
+    "zh:afabe17c49610aa3fe3c8aacb29be179d7011145fa78ab272b7c28f51a4692e6",
+    "zh:b5425be7f92202a8bf2f09dc9027af6d1d3bb201b05f167c2afa19c4cc48d039",
+    "zh:ebcc9f6747b77a6e56229a91c378d50dbe40be2fdbace1a08cee76067b9e32a0",
+    "zh:f023870ad5452ebf140abace0fafd5902dba2e9cd61c2eecf123aae36249e6c4",
     "zh:f26e0763dbe6a6b2195c94b44696f2110f7f55433dc142839be16b9697fa5597",
-    "zh:faf3b240bce18a4cf91359b0bdb017f9b2a8f4c38202c4c959c3149f69bf321e",
+    "zh:fefe8c99e83a94d0d3d4fe4897af1bc34b9142e435d7dcd904dd5a36c8428be4",
   ]
 }
 


### PR DESCRIPTION
## Why

The dev shell's pre-commit `tofu test` was failing locally on OpenTofu **1.10.9**, which rejects a `merge()`/`for` call in a `run` block that #374 added (CI's `setup-opentofu` floats on latest and accepts it). Root cause: `.envrc` referenced `github:JacobPEvans/nix-devenv` — the **old owner** (repo moved to the `dryvist` org). nix's flake-ref cache resolves the redirected old owner to a **stale pre-transfer rev (1.10.9)** unless `--refresh` is passed; `github:dryvist/nix-devenv` resolves cleanly to **1.11.8**.

## What

- `.envrc`: `github:JacobPEvans/nix-devenv` → `github:dryvist/nix-devenv` so the dev shell tracks the published toolchain (1.11.8) without manual `--refresh`.
- `.terraform.lock.hcl`: incidental `bpg/proxmox` lock bump `0.106.0 → 0.108.0` (satisfies `~> 0.106`; all applies this session ran against it).

## Related

- `dryvist/nix-devenv#42` fixes the Renovate `shells/**` disable that let per-shell locks drift behind the channel (the upstream half of the same skew).

🤖 Generated with [Claude Code](https://claude.com/claude-code)