### PR TITLE
fix(storage): bump PBS ISO to 4.2-1, track via Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,28 @@
   "extends": [
     "config:recommended",
     "local>dryvist/.github"
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["variables-storage\\.tf$"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s+default\\s*=\\s*\"(?<currentValue>[^\"]+)\""
+      ],
+      "extractVersionTemplate": "^proxmox-backup-server_(?<version>.+)\\.iso$",
+      "versioningTemplate": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)-(?<build>\\d+)$"
+    }
+  ],
+  "customDatasources": {
+    "proxmox-iso": {
+      "defaultRegistryUrlTemplate": "http://download.proxmox.com/iso/",
+      "format": "html"
+    }
+  },
+  "packageRules": [
+    {
+      "matchDatasources": ["custom.proxmox-iso"],
+      "minimumReleaseAge": "30 days"
+    }
   ]
 }

--- a/variables-storage.tf
+++ b/variables-storage.tf
@@ -54,7 +54,8 @@ variable "proxmox_iso_debian" {
 variable "proxmox_iso_pbs" {
   description = "Proxmox Backup Server ISO filename (upload to datastore_iso; reference it as <datastore_iso>:iso/<filename> in a VM's cdrom_file_id)."
   type        = string
-  default     = "proxmox-backup-server_4.0-1.iso"
+  # renovate: datasource=custom.proxmox-iso depName=proxmox-backup-server
+  default = "proxmox-backup-server_4.2-1.iso"
 }
 
 variable "template_id" {


### PR DESCRIPTION
## What

- Bump `proxmox_iso_pbs` default `proxmox-backup-server_4.0-1.iso` → `proxmox-backup-server_4.2-1.iso` (latest on download.proxmox.com; SHA256 verified against the published SHA256SUMS when the ISO was downloaded to pve1).
- Add a Renovate **custom manager + custom datasource** so the PBS ISO filename auto-bumps when Proxmox publishes a newer one. An inline `# renovate:` annotation on the variable ties the value to the datasource.

## Why html datasource (not deb / json)

The variable stores the **ISO filename**, so the datasource must emit the exact `proxmox-backup-server_X.Y-Z.iso` strings:

| Option | Verdict |
|---|---|
| **html** dir index of `/iso/` | ✅ emits the exact ISO filenames; Renovate's documented pattern for directory listings |
| native `deb` datasource | ❌ tracks the *package* version (`4.2.x-1`), not the ISO filename — would produce an invalid filename |
| `json` custom (e.g. endoflife.date) | ❌ cycle-granular (`4.2`), no `-1` build, date is the cycle's, not the ISO's |
| JSON manifest on the server | ❌ none exists (`iso/releases.json` → 404; `SHA256SUMS` is hash+filename) |

## Two caveats (read before merging)

1. **Registry is `http://` on purpose.** `download.proxmox.com` presents a TLS cert that does not match the hostname (verified via curl + node fetch), so `https://` fails TLS verification at Renovate runtime. The index is read **only for version strings**; ISO integrity is verified separately against SHA256SUMS at download time. Do not switch this to https.
2. **`minimumReleaseAge: 30 days` is declared but cannot self-enforce on this datasource.** The html format exposes no per-file timestamps, so Renovate has nothing to age against — the bump PR will appear when the new ISO is published. Because `config:recommended` does **not** auto-merge, the 30-day wait is applied at **merge time** (human merges later). The setting auto-activates if a dated datasource is ever wired in.

## Validation

- `renovate-config-validator`: **Config validated successfully**.
- `tofu fmt`/`validate`: handled by pre-commit + CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)