### PR TITLE
fix(security): constrain PBS ISO Renovate version regex

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,7 @@
       "matchStrings": [
         "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s+default\\s*=\\s*\"(?<currentValue>[^\"]+)\""
       ],
-      "extractVersionTemplate": "^proxmox-backup-server_(?<version>.+)\\.iso$",
+      "extractVersionTemplate": "^proxmox-backup-server_(?<version>\\d+\\.\\d+-\\d+)\\.iso$",
       "versioningTemplate": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)-(?<build>\\d+)$"
     }
   ],


### PR DESCRIPTION
## What

Follow-up to #381. Narrows the `proxmox-iso` custom datasource's `extractVersionTemplate` from a permissive `.+` to a strict `\d+\.\d+-\d+` character class.

```diff
- "extractVersionTemplate": "^proxmox-backup-server_(?<version>.+)\\.iso$",
+ "extractVersionTemplate": "^proxmox-backup-server_(?<version>\\d+\\.\\d+-\\d+)\\.iso$",
```

## Why

Automated commit security review flagged the datasource's `http://` registry as a MITM/supply-chain risk. Background:

- The suggested fix (switch to `https://`) **does not work for this host** — `download.proxmox.com` presents a TLS cert that does not match the hostname (`SSL: no alternative certificate subject name matches`, confirmed via curl *and* node). Renovate's fetch would hard-fail TLS. So `http://` stays.
- The real teeth of the http risk is a tampered listing injecting an **arbitrary string** into the ISO filename. Constraining the captured version to `MAJOR.MINOR-BUILD` removes that: even a MITM'd index can only ever produce a well-formed version, never an arbitrary string.

## Defense in depth (already in place)

- ISO **integrity** is independently verified against `SHA256SUMS` at download time — the datasource is read only for version *strings*.
- Bump PRs are **not auto-merged** (`config:recommended`), so a human reviews any version change before it lands.

## Validation

- `renovate-config-validator`: **Config validated successfully**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)