### PR TITLE
feat(secrets): scaffold OpenBao secrets manager IaC (Raft node 1)

### DIFF
--- a/aws-infra/README.md
+++ b/aws-infra/README.md
@@ -80,9 +80,55 @@ nix develop "github:JacobPEvans/nix-devenv?dir=shells/terraform" --command bash 
 
 ## Modules
 
-| Module          | Purpose                                    |
-| --------------- | ------------------------------------------ |
-| route53-records | Manages A record for Proxmox VE UI domain  |
+| Module          | Purpose                                           |
+| --------------- | ------------------------------------------------- |
+| route53-records | Manages A record for Proxmox VE UI domain         |
+| openbao-unseal  | KMS key + scoped IAM user for OpenBao auto-unseal |
+
+## OpenBao Auto-Unseal
+
+The `openbao-unseal` module provisions an AWS KMS key and a least-privilege IAM
+user that OpenBao nodes use for AWS KMS auto-unseal. This removes the need to
+manually enter unseal keys after every OpenBao restart.
+
+> **WARNING — elevated AWS permissions required.**
+>
+> Provisioning a KMS key + IAM user requires an AWS principal that holds:
+>
+> - `kms:CreateKey`
+> - `kms:CreateAlias`
+> - `iam:CreateUser`
+> - `iam:PutUserPolicy`
+> - `iam:CreateAccessKey`
+>
+> The aws-infra provider's current Route53-scoped credentials (`AWS_ROUTE53_*`)
+> most likely **LACK** these permissions. Do **NOT** silently assume the
+> existing credentials work. Apply this unit with an admin-capable principal —
+> e.g. the `tf-proxmox` profile if it carries IAM/KMS permissions, or a
+> dedicated bootstrap user.
+
+The IAM user policy grants only `kms:Encrypt`, `kms:Decrypt`, and
+`kms:DescribeKey` on the single created key ARN — nothing more.
+
+### Loading outputs into Doppler
+
+After a successful apply, load the module outputs into Doppler so the OpenBao
+nodes can authenticate to KMS:
+
+| Terraform output                   | Doppler secret                          |
+| ---------------------------------- | --------------------------------------- |
+| `openbao_unseal_access_key_id`     | `OPENBAO_UNSEAL_AWS_ACCESS_KEY_ID`      |
+| `openbao_unseal_secret_access_key` | `OPENBAO_UNSEAL_AWS_SECRET_ACCESS_KEY`  |
+| `openbao_unseal_kms_key_id`        | `OPENBAO_KMS_KEY_ID`                    |
+| `aws_region`                       | `OPENBAO_KMS_REGION`                    |
+
+The `openbao_unseal_secret_access_key` output is marked `sensitive`; read it
+with `terragrunt output -raw openbao_unseal_secret_access_key`.
+
+### Disabling
+
+Set `enable_openbao_unseal = false` to skip provisioning the KMS key and IAM
+user (mirrors the `enable_route53_dns` toggle).
 
 ## Cross-Reference with Proxmox
 

--- a/aws-infra/main.tf
+++ b/aws-infra/main.tf
@@ -31,6 +31,35 @@ module "route53_records" {
   environment        = var.environment
 }
 
+# =============================================================================
+# OpenBao auto-unseal — KMS key + scoped IAM user
+# =============================================================================
+# WARNING: ELEVATED AWS PERMISSIONS REQUIRED TO APPLY THIS MODULE.
+#
+# Provisioning a KMS key + IAM user requires an AWS principal that holds:
+#   kms:CreateKey, kms:CreateAlias, iam:CreateUser, iam:PutUserPolicy,
+#   iam:CreateAccessKey
+#
+# The aws-infra provider's current Route53-scoped credentials (AWS_ROUTE53_*)
+# most likely LACK these permissions. Do NOT assume the existing creds work.
+# Apply this unit with an admin-capable principal — e.g. the tf-proxmox profile
+# if it carries IAM/KMS permissions, or a dedicated bootstrap user.
+#
+# After apply, load the outputs into Doppler for the OpenBao nodes:
+#   unseal_access_key_id     -> OPENBAO_UNSEAL_AWS_ACCESS_KEY_ID
+#   unseal_secret_access_key -> OPENBAO_UNSEAL_AWS_SECRET_ACCESS_KEY
+#   kms_key_id               -> OPENBAO_KMS_KEY_ID
+#   aws_region               -> OPENBAO_KMS_REGION
+#
+# See aws-infra/README.md ("OpenBao Auto-Unseal") for the full procedure.
+# =============================================================================
+module "openbao_unseal" {
+  count  = var.enable_openbao_unseal ? 1 : 0
+  source = "./modules/openbao-unseal"
+
+  environment = var.environment
+}
+
 # Future AWS resources go here:
 # - IAM users/roles for Terraform
 # - S3 buckets for backups

--- a/aws-infra/modules/openbao-unseal/main.tf
+++ b/aws-infra/modules/openbao-unseal/main.tf
@@ -1,0 +1,69 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}
+
+# NOTE: AWS Provider is configured in parent module (aws-infra/main.tf)
+# This module inherits the provider from its parent
+
+# KMS key for OpenBao auto-unseal (AWS KMS seal)
+# OpenBao nodes use this key to encrypt/decrypt the root key on startup,
+# removing the need for manual unseal-key entry after a restart.
+resource "aws_kms_key" "openbao_unseal" {
+  description             = "OpenBao auto-unseal"
+  enable_key_rotation     = true
+  deletion_window_in_days = 30
+
+  tags = {
+    Environment = var.environment
+    ManagedBy   = "terraform"
+    Purpose     = "openbao-auto-unseal"
+  }
+}
+
+resource "aws_kms_alias" "openbao_unseal" {
+  name          = "alias/openbao-unseal"
+  target_key_id = aws_kms_key.openbao_unseal.key_id
+}
+
+# Dedicated IAM user the OpenBao nodes authenticate as for the auto-unseal seal.
+resource "aws_iam_user" "openbao_unseal" {
+  name = "openbao-unseal"
+
+  tags = {
+    Environment = var.environment
+    ManagedBy   = "terraform"
+    Purpose     = "openbao-auto-unseal"
+  }
+}
+
+# Least-privilege policy: only the three KMS actions the auto-unseal seal needs,
+# scoped to this single key ARN. No wildcard resources, no key administration.
+resource "aws_iam_user_policy" "openbao_unseal" {
+  name = "openbao-unseal-kms"
+  user = aws_iam_user.openbao_unseal.name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "OpenBaoUnsealKMS"
+        Effect = "Allow"
+        Action = [
+          "kms:Encrypt",
+          "kms:Decrypt",
+          "kms:DescribeKey",
+        ]
+        Resource = aws_kms_key.openbao_unseal.arn
+      },
+    ]
+  })
+}
+
+resource "aws_iam_access_key" "openbao_unseal" {
+  user = aws_iam_user.openbao_unseal.name
+}

--- a/aws-infra/modules/openbao-unseal/outputs.tf
+++ b/aws-infra/modules/openbao-unseal/outputs.tf
@@ -1,0 +1,25 @@
+output "kms_key_id" {
+  description = "KMS key ID for OpenBao auto-unseal"
+  value       = aws_kms_key.openbao_unseal.key_id
+}
+
+output "kms_key_arn" {
+  description = "KMS key ARN for OpenBao auto-unseal"
+  value       = aws_kms_key.openbao_unseal.arn
+}
+
+output "unseal_iam_user" {
+  description = "IAM user name the OpenBao nodes authenticate as for auto-unseal"
+  value       = aws_iam_user.openbao_unseal.name
+}
+
+output "unseal_access_key_id" {
+  description = "AWS access key ID for the OpenBao auto-unseal IAM user"
+  value       = aws_iam_access_key.openbao_unseal.id
+}
+
+output "unseal_secret_access_key" {
+  description = "AWS secret access key for the OpenBao auto-unseal IAM user"
+  value       = aws_iam_access_key.openbao_unseal.secret
+  sensitive   = true
+}

--- a/aws-infra/modules/openbao-unseal/variables.tf
+++ b/aws-infra/modules/openbao-unseal/variables.tf
@@ -1,0 +1,5 @@
+variable "environment" {
+  description = "Environment name for tagging and organization"
+  type        = string
+  default     = "homelab"
+}

--- a/aws-infra/outputs.tf
+++ b/aws-infra/outputs.tf
@@ -32,3 +32,31 @@ output "acme_domain" {
   description = "Domain to use for ACME certificate requests"
   value       = var.proxmox_domain
 }
+
+# OpenBao auto-unseal outputs
+# Load these into Doppler for the OpenBao nodes (see aws-infra/README.md).
+output "openbao_unseal_kms_key_id" {
+  description = "KMS key ID for OpenBao auto-unseal"
+  value       = try(module.openbao_unseal[0].kms_key_id, "")
+}
+
+output "openbao_unseal_kms_key_arn" {
+  description = "KMS key ARN for OpenBao auto-unseal"
+  value       = try(module.openbao_unseal[0].kms_key_arn, "")
+}
+
+output "openbao_unseal_iam_user" {
+  description = "IAM user name the OpenBao nodes authenticate as for auto-unseal"
+  value       = try(module.openbao_unseal[0].unseal_iam_user, "")
+}
+
+output "openbao_unseal_access_key_id" {
+  description = "AWS access key ID for the OpenBao auto-unseal IAM user"
+  value       = try(module.openbao_unseal[0].unseal_access_key_id, "")
+}
+
+output "openbao_unseal_secret_access_key" {
+  description = "AWS secret access key for the OpenBao auto-unseal IAM user"
+  value       = try(module.openbao_unseal[0].unseal_secret_access_key, "")
+  sensitive   = true
+}

--- a/aws-infra/variables.tf
+++ b/aws-infra/variables.tf
@@ -41,6 +41,14 @@ variable "route53_zone_id" {
   }
 }
 
+# OpenBao Auto-Unseal Configuration
+
+variable "enable_openbao_unseal" {
+  description = "Enable provisioning of the KMS key + scoped IAM user for OpenBao auto-unseal"
+  type        = bool
+  default     = true
+}
+
 # Proxmox Integration (values passed from Proxmox config or Doppler)
 
 variable "proxmox_domain" {

--- a/locals.tf
+++ b/locals.tf
@@ -102,6 +102,12 @@ locals {
     if contains(coalesce(try(v.tags, null), []), "infisical")
   }
 
+  # OpenBao secrets-management containers (openbao tag)
+  openbao_container_ids = {
+    for k, v in var.containers : k => v.vm_id
+    if contains(coalesce(try(v.tags, null), []), "openbao")
+  }
+
   # HAProxy LXCs (haproxy tag) — receive delivered ACME certs for HTTPS frontends.
   # Distinct from pipeline_container_ids (which also includes Cribl Edge); this
   # local is dedicated to cert-delivery targeting.
@@ -140,6 +146,8 @@ locals {
       minio_api         = 9000
       minio_console     = 9001
       infisical_api     = 8080
+      openbao_api       = 8200
+      openbao_cluster   = 8201
       postgres_default  = 5432
       redis_default     = 6379
       ntp               = 123
@@ -213,6 +221,7 @@ locals {
     phpipam         = { backend = "phpipam", port = local.pipeline_constants.service_ports.phpipam_web }
     minio           = { backend = "minio", port = local.pipeline_constants.service_ports.minio_console }
     infisical       = { backend = "infisical", port = local.pipeline_constants.service_ports.infisical_api }
+    openbao         = { backend = "openbao1", port = local.pipeline_constants.service_ports.openbao_api }
     mailpit         = { backend = "mailpit", port = local.pipeline_constants.notification_ports.mailpit_web }
     ntfy            = { backend = "ntfy", port = local.pipeline_constants.notification_ports.ntfy_http }
     homeassistant   = { backend = "homeassistant", port = local.pipeline_constants.service_ports.homeassistant_web }

--- a/main.tf
+++ b/main.tf
@@ -204,6 +204,9 @@ module "firewall" {
   # Infisical secrets-management containers (infisical tag)
   infisical_container_ids = local.infisical_container_ids
 
+  # OpenBao secrets-management containers (openbao tag)
+  openbao_container_ids = local.openbao_container_ids
+
   # iDRAC KVM LXC: tagged "idrac" (domistyle/idrac6-based viewers, Docker-in-LXC)
   idrac_kvm_container_ids = local.idrac_kvm_container_ids
 

--- a/modules/firewall/locals.tf
+++ b/modules/firewall/locals.tf
@@ -102,6 +102,15 @@ locals {
     { proto = "tcp", dport = tostring(local.svc_ports.infisical_api), source = local.internal_src, comment = "Infisical API/Web from internal" },
   ]
 
+  # OpenBao API/UI (8200) is reached via Traefik (internal RFC1918). The Raft
+  # cluster port (8201) is peer-to-peer; Phase 1 has a single node so it stays
+  # scoped to internal RFC1918 (the apps VLAN is a subset). Tighten to the peer
+  # set when the HA cluster scales out (Phase 2).
+  openbao_services_rules = [
+    { proto = "tcp", dport = tostring(local.svc_ports.openbao_api), source = local.internal_src, comment = "OpenBao API/UI from internal" },
+    { proto = "tcp", dport = tostring(local.svc_ports.openbao_cluster), source = local.internal_src, comment = "OpenBao Raft cluster from internal" },
+  ]
+
   # Outbound to internal RFC1918 only (blocks internet egress)
   outbound_internal_rules = [
     { proto = "tcp", dest = local.internal_src, comment = "Outbound TCP to internal" },

--- a/modules/firewall/openbao_rules.tf
+++ b/modules/firewall/openbao_rules.tf
@@ -1,0 +1,45 @@
+# OpenBao secrets-management containers (native single-binary LXC: Raft node 1 of a future 3-node HA cluster)
+# Raft storage is local to each node (8201 cluster port) — Phase 1 runs a single node, so 8201 has no
+# external peers yet but the rule is in place for the HA scale-out.
+#
+# Lives in its own file (rather than container_rules.tf) to keep container_rules.tf under the
+# shared `_file-size` workflow's 12 KB error threshold. As more container types accrete, prefer
+# adding new per-domain files like this one over growing container_rules.tf further.
+
+resource "proxmox_virtual_environment_firewall_options" "openbao_container" {
+  for_each = var.openbao_container_ids
+
+  node_name     = var.node_name
+  container_id  = each.value
+  enabled       = local.firewall_defaults.enabled
+  input_policy  = local.firewall_defaults.input_policy
+  output_policy = local.firewall_defaults.output_policy
+  log_level_in  = local.firewall_defaults.log_level_in
+  log_level_out = local.firewall_defaults.log_level_out
+
+  depends_on = [proxmox_virtual_environment_cluster_firewall.main]
+}
+
+resource "proxmox_virtual_environment_firewall_rules" "openbao_container" {
+  for_each = var.openbao_container_ids
+
+  node_name    = var.node_name
+  container_id = each.value
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.internal_access.name
+    comment        = "Internal access (SSH, ICMP)"
+  }
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.openbao_services.name
+    comment        = "OpenBao API/UI + Raft cluster from internal"
+  }
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.outbound_internal.name
+    comment        = "Outbound to internal only"
+  }
+
+  depends_on = [proxmox_virtual_environment_firewall_options.openbao_container]
+}

--- a/modules/firewall/security_groups.tf
+++ b/modules/firewall/security_groups.tf
@@ -267,6 +267,23 @@ resource "proxmox_virtual_environment_cluster_firewall_security_group" "infisica
   }
 }
 
+resource "proxmox_virtual_environment_cluster_firewall_security_group" "openbao_services" {
+  name    = "openbao-svc"
+  comment = "OpenBao API/UI (8200) and Raft cluster (8201) from internal networks (Traefik front-ends TLS termination on its own ports)"
+
+  dynamic "rule" {
+    for_each = local.openbao_services_rules
+    content {
+      type    = "in"
+      action  = "ACCEPT"
+      proto   = rule.value.proto
+      dport   = rule.value.dport
+      source  = rule.value.source
+      comment = rule.value.comment
+    }
+  }
+}
+
 resource "proxmox_virtual_environment_cluster_firewall_security_group" "ntp_server" {
   name    = "ntp-server"
   comment = "NTP server (UDP 123) from internal networks — Proxmox hosts serve time to VMs/containers via chrony"

--- a/modules/firewall/variables.tf
+++ b/modules/firewall/variables.tf
@@ -63,6 +63,12 @@ variable "infisical_container_ids" {
   default     = {}
 }
 
+variable "openbao_container_ids" {
+  description = "Map of OpenBao secrets-management container names to their IDs"
+  type        = map(number)
+  default     = {}
+}
+
 variable "idrac_kvm_container_ids" {
   description = "Map of iDRAC KVM LXC names to IDs (tag-driven, set by root locals)"
   type        = map(number)

--- a/vault-secrets/README.md
+++ b/vault-secrets/README.md
@@ -1,0 +1,89 @@
+# Vault Secrets
+
+Terraform unit that proves the read+write loop against a live OpenBao
+instance. It is managed **separately** from Proxmox and `aws-infra/`, with its
+own state.
+
+## When to Apply
+
+Apply this unit **AFTER**:
+
+1. The `openbao` Ansible role brings OpenBao live and enables the KV v2 secrets
+   engine at `mount = "secret"`.
+2. `VAULT_ADDR`, `VAULT_ROLE_ID`, and `VAULT_SECRET_ID` are present in Doppler
+   (the AppRole the openbao role provisions for Terraform).
+
+If the `secret` mount is not yet enabled, or the AppRole credentials are
+missing, `terragrunt apply` will fail.
+
+## What It Does
+
+1. Reuses the shared `../modules/security` module to generate a demo password
+   and SSH key pair (`random_password` + `tls_private_key`).
+2. Writes those values into OpenBao at `secret/homelab/demo/vm`
+   (`vault_kv_secret_v2.demo`) — proves the **write** path.
+3. Reads the same path back (`data.vault_kv_secret_v2.demo_read`) — proves the
+   **read** path.
+
+Outputs expose only non-sensitive proof (`demo_secret_path`,
+`demo_secret_version`); the secret value itself is never output.
+
+## Requirements
+
+- [Nix](https://nixos.org/download/) with flakes enabled (provides Terraform/Terragrunt via nix-devenv)
+- [aws-vault](https://github.com/99designs/aws-vault) with `tf-proxmox` profile configured (for the S3 state backend)
+- [Doppler CLI](https://docs.doppler.com/docs/install-cli) configured for `iac-conf-mgmt` project
+- A live OpenBao instance with the KV v2 engine enabled at `mount = "secret"`
+- `VAULT_ADDR`, `VAULT_ROLE_ID`, and `VAULT_SECRET_ID` present in Doppler
+
+## Usage
+
+```bash
+# Validate
+nix develop "github:JacobPEvans/nix-devenv?dir=shells/terraform" --command bash -c \
+  "aws-vault exec tf-proxmox -- doppler run -- terragrunt validate"
+
+# Plan
+nix develop "github:JacobPEvans/nix-devenv?dir=shells/terraform" --command bash -c \
+  "aws-vault exec tf-proxmox -- doppler run -- terragrunt plan"
+
+# Apply
+nix develop "github:JacobPEvans/nix-devenv?dir=shells/terraform" --command bash -c \
+  "aws-vault exec tf-proxmox -- doppler run -- terragrunt apply"
+```
+
+`aws-vault` is still required because the state backend lives in S3 + DynamoDB;
+the Vault provider itself authenticates via AppRole, not AWS.
+
+## Inputs
+
+| Name            | Description                      | Type   | Sensitive |
+| --------------- | -------------------------------- | ------ | --------- |
+| vault_addr      | OpenBao API address              | string | no        |
+| vault_role_id   | AppRole role ID for Terraform    | string | yes       |
+| vault_secret_id | AppRole secret ID for Terraform  | string | yes       |
+
+## Outputs
+
+| Name                | Description                                  |
+| ------------------- | -------------------------------------------- |
+| demo_secret_path    | KV v2 path the demo secret was written to    |
+| demo_secret_version | Version number of the demo secret in OpenBao |
+
+## State Management
+
+| Root Module   | State Key                                           |
+| ------------- | --------------------------------------------------- |
+| vault-secrets | `terraform-proxmox/vault-secrets/terraform.tfstate` |
+| aws-infra     | `terraform-proxmox/aws-infra/terraform.tfstate`     |
+| Proxmox       | `terraform-proxmox/terraform.tfstate`               |
+
+All three use the same S3 bucket and DynamoDB table for state locking.
+
+## Notes
+
+- This unit has its own state and does **NOT** trigger the root module's
+  `after_hook` inventory sync — applying it never touches downstream Ansible
+  repos.
+- The `secret` KV v2 mount must already be enabled (the openbao Ansible role
+  enables it). This unit does not enable the mount.

--- a/vault-secrets/main.tf
+++ b/vault-secrets/main.tf
@@ -1,0 +1,55 @@
+terraform {
+  required_version = ">= 1.10"
+
+  required_providers {
+    vault = {
+      source  = "hashicorp/vault"
+      version = "~> 5.9"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.7"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 4.1"
+    }
+  }
+}
+
+# Vault (OpenBao) provider — authenticates via AppRole.
+# address / role_id / secret_id come from Doppler env vars (see terragrunt.hcl).
+provider "vault" {
+  address = var.vault_addr
+
+  auth_login_approle {
+    role_id   = var.vault_role_id
+    secret_id = var.vault_secret_id
+  }
+}
+
+# Reuse the existing security module to generate a demo password + SSH key pair.
+module "security" {
+  source = "../modules/security"
+}
+
+# Write the generated credentials into OpenBao to prove the write path.
+# The KV v2 mount "secret" is enabled by the openbao Ansible role.
+resource "vault_kv_secret_v2" "demo" {
+  mount = "secret"
+  name  = "homelab/demo/vm"
+
+  data_json = jsonencode({
+    password    = module.security.vm_password
+    private_key = module.security.vm_private_key
+    public_key  = module.security.vm_public_key
+  })
+}
+
+# Read the same path back to prove the read path.
+data "vault_kv_secret_v2" "demo_read" {
+  mount = "secret"
+  name  = "homelab/demo/vm"
+
+  depends_on = [vault_kv_secret_v2.demo]
+}

--- a/vault-secrets/outputs.tf
+++ b/vault-secrets/outputs.tf
@@ -1,0 +1,11 @@
+# Non-sensitive proof outputs only. The demo secret value is NEVER output.
+
+output "demo_secret_path" {
+  description = "OpenBao KV v2 path the demo secret was written to"
+  value       = "${vault_kv_secret_v2.demo.mount}/${vault_kv_secret_v2.demo.name}"
+}
+
+output "demo_secret_version" {
+  description = "Version number of the demo secret written to OpenBao"
+  value       = vault_kv_secret_v2.demo.version
+}

--- a/vault-secrets/terragrunt.hcl
+++ b/vault-secrets/terragrunt.hcl
@@ -1,0 +1,61 @@
+# Terragrunt configuration for the vault-secrets unit
+# Applied AFTER OpenBao is live; proves the Terraform read+write loop against
+# OpenBao via the AppRole-authenticated Vault provider.
+# COMPLETELY SEPARATE from Proxmox and aws-infra state.
+
+terraform {
+  source = "."
+}
+
+# Remote state backend configuration using S3 + DynamoDB
+# Uses a DIFFERENT state key than aws-infra and Proxmox to keep states isolated
+remote_state {
+  backend = "s3"
+  generate = {
+    path      = "backend.tf"
+    if_exists = "overwrite_terragrunt"
+  }
+  config = {
+    bucket         = "terraform-proxmox-state-useast2-${get_aws_account_id()}"
+    key            = "terraform-proxmox/vault-secrets/terraform.tfstate"
+    region         = "us-east-2"
+    encrypt        = true
+    dynamodb_table = "terraform-proxmox-locks-useast2"
+
+    max_retries = 5
+  }
+}
+
+# OpenBao connection + AppRole auth from Doppler environment variables.
+# VAULT_ADDR / VAULT_ROLE_ID / VAULT_SECRET_ID are populated once the openbao
+# Ansible role brings OpenBao live and provisions the Terraform AppRole.
+inputs = {
+  vault_addr      = get_env("VAULT_ADDR", "")
+  vault_role_id   = get_env("VAULT_ROLE_ID", "")
+  vault_secret_id = get_env("VAULT_SECRET_ID", "")
+}
+
+# Terragrunt will generate provider_override.tf with the Vault provider settings
+generate "provider" {
+  path      = "provider_override.tf"
+  if_exists = "overwrite"
+  contents  = <<EOF
+terraform {
+  required_version = ">= 1.10"
+  required_providers {
+    vault = {
+      source  = "hashicorp/vault"
+      version = "~> 5.9"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.7"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 4.1"
+    }
+  }
+}
+EOF
+}

--- a/vault-secrets/variables.tf
+++ b/vault-secrets/variables.tf
@@ -1,0 +1,18 @@
+# OpenBao (Vault) connection + AppRole auth
+
+variable "vault_addr" {
+  description = "OpenBao API address (e.g., https://openbao.example.com:8200)"
+  type        = string
+}
+
+variable "vault_role_id" {
+  description = "AppRole role ID for Terraform authentication to OpenBao"
+  type        = string
+  sensitive   = true
+}
+
+variable "vault_secret_id" {
+  description = "AppRole secret ID for Terraform authentication to OpenBao"
+  type        = string
+  sensitive   = true
+}


### PR DESCRIPTION
# OpenBao secrets manager IaC (Raft node 1)

## What

Phase 1 IaC for a self-hosted, highly-available secrets manager (hybrid
**OpenBao** + Infisical). This PR adds the Terraform/Terragrunt scaffolding for
**OpenBao Raft node 1**; the configuration management (install / init / unseal)
lands in a companion `ansible-proxmox-apps` PR.

## Changes

- **`locals.tf`** — `openbao_api` (8200) / `openbao_cluster` (8201) service
  ports, an `openbao` Traefik ingress route, and tag-driven
  `openbao_container_ids`.
- **`modules/firewall/`** — an `openbao-svc` security group + per-container
  rules: 8200 reachable from internal / Traefik, 8201 for Raft peers (scoped to
  internal RFC1918 for the single-node phase; tightened to the peer set during
  HA scale-out).
- **`aws-infra/modules/openbao-unseal/`** — a KMS key + a least-privilege IAM
  user (only `kms:Encrypt` / `kms:Decrypt` / `kms:DescribeKey` on the one key)
  for **AWS-KMS auto-unseal**, gated by `enable_openbao_unseal`.
- **`vault-secrets/`** — a separate Terragrunt unit (own state, no inventory
  `after_hook`) that runs **after** OpenBao is live. It reuses `modules/security`
  to generate a password + key pair, pushes them into OpenBao via the
  `hashicorp/vault` provider, and reads them back — proving the Terraform
  write + read loop.

## Operator notes (not covered by CI)

- ⚠️ **Applying `aws-infra` needs an admin-capable AWS principal**
  (`kms:CreateKey`, `iam:CreateUser`, …). The unit's existing Route53-scoped
  creds likely lack these. Documented in the module and `aws-infra/README.md`.
- The **`openbao1` LXC** lives in the gitignored `deployment.json`
  (operator-local), same as infisical / minio — it is not in this diff. Add it
  locally before applying.
- **Live apply is gated** on a clean full `terragrunt plan` (no `-target`) and
  `aws-vault` credentials; `vault-secrets/` applies only after OpenBao is up and
  its AppRole creds are in Doppler.

Companion configuration-management PR: `dryvist/ansible-proxmox-apps`
(openbao role).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
