### PR TITLE
feat(ingress): expose Ollama API via Traefik

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -175,7 +175,9 @@ Authoritative list lives in `deployment.json` `containers.*`. Summary by pool:
   (HTTPS/TLS ingress)
 - **`logging`** — `haproxy`, `cribl-edge-01/02`, `cribl-stream-01/02`,
   `splunk-mgmt` (SH + DS + LM + MC + CM)
-- **`ai`** — `claude-code-01/02`, `gemini-01/02`, `qdrant`, `llamaindex`
+- **`ai`** — `claude-code-01/02`, `gemini-01/02`, `qdrant`, `llamaindex`,
+  `hermes-infer` (Ollama LLM inference on the RX 6800 GPU), `hermes-chat`
+  (Open WebUI chat frontend)
 - **`media`** (v1 pinned to the primary media node — `node_name`,
   `node_storage`, and ansible inventory label all aligned on that node;
   v2 lives on the secondary media node) — `download-vpn` (qBittorrent +
@@ -191,6 +193,13 @@ Notable per-container facts:
 - `splunk-mgmt` is the LXC search head + deployment server + license manager +
   monitoring console + cluster manager. The `splunk-aio` VM 200 is the
   dedicated indexing node.
+- `hermes-infer` is a **privileged** LXC with the AMD RX 6800 passed through
+  (`/dev/kfd` + `/dev/dri`, via the `ansible-proxmox` `lxc_gpu_features` role)
+  running Ollama on ROCm; it serves the `hermes4` model (NousResearch
+  Hermes-4-14B) on port 11434 from a 120 GB volume at `/var/lib/ollama`.
+  `hermes-chat` runs Open WebUI, fronted by Traefik via the `llm` ingress; the
+  `ollama` ingress exposes the raw API. Full write-up:
+  [docs.jacobpevans.com/infrastructure/local-llm](https://docs.jacobpevans.com/infrastructure/local-llm).
 - `mailpit` and `ntfy` run Docker-in-LXC (`nesting: true`, `keyctl: true`) for
   internal notifications.
 - `download-vpn` is an unprivileged LXC with `/dev/net/tun` passed through

--- a/docs/INFRASTRUCTURE_NUMBERING.md
+++ b/docs/INFRASTRUCTURE_NUMBERING.md
@@ -44,6 +44,14 @@ Heavy I/O workloads run as full VMs:
 | 161 | gemini-01      | LXC  | 2     | 2GB  | 64GB    | ai   | Gemini development environment 1     |
 | 162 | gemini-02      | LXC  | 2     | 2GB  | 64GB    | ai   | Gemini development environment 2     |
 | 165 | qdrant         | LXC  | 2     | 8GB  | 108GB   | ai   | Qdrant vector database - AI RAG      |
+| 166 | llamaindex     | LXC  | 2     | 4GB  | 16GB    | ai   | LlamaIndex RAG engine (CPU)          |
+| 167 | hermes-infer   | LXC  | 6     | 6GB  | 144GB   | ai   | Ollama LLM inference (GPU RX 6800)   |
+| 168 | hermes-chat    | LXC  | 2     | 2GB  | 16GB    | ai   | Open WebUI chat frontend             |
+
+The GPU LLM stack (`hermes-infer` + `hermes-chat`) is documented end-to-end at
+[docs.jacobpevans.com/infrastructure/local-llm](https://docs.jacobpevans.com/infrastructure/local-llm).
+`hermes-infer` is a privileged LXC with the RX 6800 passed through (`/dev/kfd`,
+`/dev/dri`) and a 120 GB model volume at `/var/lib/ollama`.
 
 ### LXC Containers - Cribl Stream (171-179)
 
@@ -131,6 +139,9 @@ Example configuration uses 192.168.1.0/24:
 - 192.168.1.161/24 - gemini-01
 - 192.168.1.162/24 - gemini-02
 - 192.168.1.165/24 - qdrant
+- 192.168.1.166/24 - llamaindex
+- 192.168.1.167/24 - hermes-infer
+- 192.168.1.168/24 - hermes-chat
 
 ### Cribl Stream (171-179)
 

--- a/locals.tf
+++ b/locals.tf
@@ -219,6 +219,7 @@ locals {
     openproject     = { backend = "openproject", port = local.pipeline_constants.service_ports.openproject_web }
     prometheus      = { backend = "prometheus", port = local.pipeline_constants.service_ports.prometheus_web }
     llm             = { backend = "hermes-chat", port = local.pipeline_constants.service_ports.open_webui_web }
+    ollama          = { backend = "hermes-infer", port = local.pipeline_constants.service_ports.ollama_api }
     qdrant          = { backend = "qdrant", port = local.pipeline_constants.vector_db_ports.qdrant_http }
     "haproxy-stats" = { backend = "haproxy", port = local.pipeline_constants.service_ports.haproxy_stats }
   }


### PR DESCRIPTION
## What

1. **`feat(ingress)`** — add an `ollama` entry to `ingress_services` in
   `locals.tf` so the raw Ollama API on `hermes-infer` (CT 167) is reachable
   by DNS over HTTPS, alongside the existing Open WebUI (`llm`) front-end.
   Unblocks the `ollama` CLI (`OLLAMA_HOST`) and OpenAI-compatible `/v1`
   clients from LAN machines. The route inherits the wildcard TLS cert and a
   Technitium A record via the existing inventory-driven `traefik` /
   `technitium_dns` roles, so it goes live on the next apply.
2. **`docs`** — add the GPU LLM containers (`llamaindex` 166, `hermes-infer`
   167, `hermes-chat` 168) to `INFRASTRUCTURE_NUMBERING.md` and
   `ARCHITECTURE.md`, which had omitted them.

## Validation (already live)

- `hermes-infer` Ollama is active; the `hermes4` model (Hermes-4-14B) returns
  results running **100% on the GPU**.
- Open WebUI is reachable by DNS over HTTPS and returns 200.
- The `ollama` route is the only missing piece for keyless `ollama` CLI / `/v1`
  access from LAN machines — this PR adds it.

The full user-facing write-up lives in dryvist/docs#63.

Refs: dryvist/docs#63

🤖 Generated with [Claude Code](https://claude.com/claude-code)