### PR TITLE
fix(splunk-vm): ignore disk drift to unblock apply on live bootdisk

### DIFF
--- a/modules/splunk-vm/main.tf
+++ b/modules/splunk-vm/main.tf
@@ -162,6 +162,15 @@ resource "proxmox_virtual_environment_vm" "splunk_vm" {
       # bpg rebuild the cloud-init drive — and that fails on the non-removable
       # ide2 disk. Ansible owns post-boot networking, so ignore the drift.
       initialization[0].ip_config,
+      # The live disk layout diverged from this module out-of-band: the boot
+      # disk is scsi0/50G (not virtio0/25G), and the empty leftover disk-1 was
+      # reaped directly on the host. bpg keys disk blocks positionally and tofu
+      # state tracks only the virtio1 data disk, so ANY disk reconciliation tries
+      # to unplug the live scsi0 bootdisk (Proxmox HTTP 400) and would reinterpret
+      # the 200G data disk. Disk sizing/layout is owned outside tofu (Proxmox +
+      # the ansible sanoid/syncoid protection layer), so ignore disk drift. Revisit
+      # if tofu is ever made the source of truth for the disk split (see #247).
+      disk,
     ]
   }
 }


### PR DESCRIPTION
## Problem

Every `terragrunt apply` failed inside `module.splunk_vm` with Proxmox **HTTP 400 "can't unplug bootdisk"**, aborting the *entire* apply (blocking unrelated changes and the pve3 commission pipeline).

Root cause: tofu state tracks only the `virtio1`/200G **data** disk, while the live VM is `scsi0`/50G (**boot**) + `virtio1`/200G — the boot disk is **untracked**. bpg keys disk blocks **positionally**, so reconciling state→config tried to reinterpret the live 200G data disk as a 25G boot disk and unplug the live `scsi0` bootdisk.

The layout diverged out-of-band (boot added as `scsi0`; the empty leftover `disk-1` reaped on the host), and `apply -refresh-only` does **not** adopt the untracked boot disk into state — so module-alignment alone can't reach zero-diff without risky production state surgery.

## Fix

Add `disk` to the splunk_vm resource's **existing** `ignore_changes` list (which already ignores the cloud-init drive for the same non-removable-disk reason). tofu stops fighting the out-of-band disk layout; the broken reconciliation disappears; apply runs clean with **zero data risk** and no state surgery. Disk sizing/layout is owned outside tofu (Proxmox + the ansible sanoid/syncoid protection layer). Revisit if tofu ever becomes the source of truth for the disk split (#247).

## Verification (applied live)

- Pre-fix plan: `module.splunk_vm … will be updated in-place` (the bootdisk-unplug bug).
- Post-fix plan: **splunk_vm 0 changes**; `Plan: 1 to add, 0 to change, 0 to destroy` (only the pre-existing openbao firewall SG).
- `terragrunt apply`: **`1 added, 0 changed, 0 destroyed`** — no HTTP 400, Splunk VM untouched (the SG is a definition, not attached to the VM). `sync_inventory` hook ran (`ok -- validation done`).
- Post-apply plan: no resource changes pending for splunk_vm; only cosmetic `ansible_inventory` output recompute of docker-host transient veth/MAC values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)