### PR TITLE
fix(storage): replace deprecated proxmox_virtual_environment_datastores with proxmox_datastores

### DIFF
--- a/modules/storage/main.tf
+++ b/modules/storage/main.tf
@@ -11,7 +11,7 @@ terraform {
 # These are created at the Proxmox/ZFS level and managed outside Terraform
 # Data sources provide type safety and ensure storage exists before use
 
-data "proxmox_virtual_environment_datastores" "available" {
+data "proxmox_datastores" "available" {
   node_name = var.node_name
 }
 

--- a/modules/storage/outputs.tf
+++ b/modules/storage/outputs.tf
@@ -1,4 +1,4 @@
-# Note: The proxmox_virtual_environment_datastores data source doesn't expose
+# Note: The proxmox_datastores data source doesn't expose
 # a list of datastore IDs. Storage validation happens implicitly when resources
 # reference datastore_id - the provider will error if a datastore doesn't exist.
 
@@ -10,7 +10,7 @@ output "cloud_init_file_id" {
 output "datastores_available" {
   description = "Available datastores on the target node"
   value = {
-    for ds in coalesce(data.proxmox_virtual_environment_datastores.available.datastores, []) : ds.id => {
+    for ds in coalesce(data.proxmox_datastores.available.datastores, []) : ds.id => {
       type          = ds.type
       content_types = ds.content_types
     }


### PR DESCRIPTION
## Summary

- Replaces the deprecated `proxmox_virtual_environment_datastores` data source with `proxmox_datastores` in `modules/storage/main.tf` and `outputs.tf`
- The BPG provider warns this will be removed in v1.0; schema is identical (same `node_name`, `datastores[].id/type/content_types` attributes)
- `terragrunt validate` now exits with no warnings

## Test plan

- [x] `terragrunt validate` clean (no deprecation warning)
- [ ] CI static checks pass