### PR TITLE
fix(monitoring): correct SmokePing vm_id from placeholder 150 to 196

### DIFF
--- a/deployment.json.example
+++ b/deployment.json.example
@@ -119,9 +119,9 @@
       "pool_id": "infrastructure",
       "root_disk": { "size": 8 }
     },
-    "_smokeping_comment": "Network-quality monitoring (Docker-in-LXC on mgmt VLAN). Runs SmokePing (latency/loss/jitter, web UI :80) plus a speedtest-exporter (Mbps, Prometheus metrics :9798) via Docker Compose — see docs/SMOKEPING.md for the full Probes/Targets design the ansible-proxmox-apps role applies. Pick a vm_id that is free on the mgmt /24; 150 is illustrative.",
+    "_smokeping_comment": "Network-quality monitoring (Docker-in-LXC on mgmt VLAN). Runs SmokePing (latency/loss/jitter, web UI :80) plus a speedtest-exporter (Mbps, Prometheus metrics :9798) via Docker Compose — see docs/SMOKEPING.md for the full Probes/Targets design the ansible-proxmox-apps role applies. Pick a vm_id that is free on the mgmt /24; 196 is illustrative.",
     "smokeping": {
-      "vm_id": 150,
+      "vm_id": 196,
       "vlan": "mgmt",
       "hostname": "smokeping",
       "description": "SmokePing latency/loss/jitter + speedtest-exporter (network quality monitoring)",

--- a/docs/SMOKEPING.md
+++ b/docs/SMOKEPING.md
@@ -32,7 +32,7 @@ Inter-VLAN reachability itself is enforced at UniFi — ensure the mgmt VLAN is
 permitted to ICMP/DNS/HTTPS the VLANs and WAN you want to probe.
 
 To deploy the guest: add the same `smokeping` block to your live `deployment.json`
-(confirm the `vm_id` is free on the mgmt /24 — `150` in the example is
+(confirm the `vm_id` is free on the mgmt /24 — `196` in the example is
 illustrative), then `terragrunt apply`. The `after_hook` sync writes the updated
 inventory into `ansible-proxmox-apps`, which then builds the config below.
 

--- a/tests/ansible_inventory_contract.tftest.hcl
+++ b/tests/ansible_inventory_contract.tftest.hcl
@@ -280,7 +280,7 @@ run "ansible_inventory_ingress_route_table" {
       }
       # Network-quality monitoring LXC on the mgmt VLAN (id 5 -> 192.168.5.0/24).
       "smokeping" = {
-        vm_id    = 150
+        vm_id    = 196
         hostname = "smokeping"
         vlan     = "mgmt"
         tags     = ["terraform", "container", "monitoring", "docker"]
@@ -312,13 +312,13 @@ run "ansible_inventory_ingress_route_table" {
     error_message = "ingress must skip services whose backend container is not defined"
   }
 
-  # smokeping: backend "smokeping" (192.168.5.150) on service_ports.smokeping_web (80).
+  # smokeping: backend "smokeping" (192.168.5.196) on service_ports.smokeping_web (80).
   assert {
     condition = length([
       for r in output.ansible_inventory.ingress :
-      r if r.name == "smokeping" && r.ip == "192.168.5.150" && r.port == 80
+      r if r.name == "smokeping" && r.ip == "192.168.5.196" && r.port == 80
     ]) == 1
-    error_message = "ingress must front smokeping at 192.168.5.150:80 (derived mgmt IP + constant port)"
+    error_message = "ingress must front smokeping at 192.168.5.196:80 (derived mgmt IP + constant port)"
   }
 }
 

--- a/tests/locals.tftest.hcl
+++ b/tests/locals.tftest.hcl
@@ -391,7 +391,7 @@ run "monitoring_ids_picks_up_monitoring_tagged" {
   variables {
     containers = {
       "smokeping" = {
-        vm_id    = 150
+        vm_id    = 196
         hostname = "smokeping"
         vlan     = "mgmt"
         tags     = ["terraform", "container", "monitoring", "docker"]
@@ -400,14 +400,14 @@ run "monitoring_ids_picks_up_monitoring_tagged" {
   }
 
   assert {
-    condition     = local.monitoring_container_ids["smokeping"] == 150
-    error_message = "monitoring_container_ids should map 'smokeping' to vm_id 150"
+    condition     = local.monitoring_container_ids["smokeping"] == 196
+    error_message = "monitoring_container_ids should map 'smokeping' to vm_id 196"
   }
 
-  # mgmt VLAN id is 5 -> 192.168.5.0/24; vm_id 150 -> .150
+  # mgmt VLAN id is 5 -> 192.168.5.0/24; vm_id 196 -> .196
   assert {
-    condition     = local.container_ipv4["smokeping"] == "192.168.5.150/24"
-    error_message = "smokeping mgmt-VLAN IP should be 192.168.5.150/24, got ${local.container_ipv4["smokeping"]}"
+    condition     = local.container_ipv4["smokeping"] == "192.168.5.196/24"
+    error_message = "smokeping mgmt-VLAN IP should be 192.168.5.196/24, got ${local.container_ipv4["smokeping"]}"
   }
 }
 


### PR DESCRIPTION
## Summary

- `vm_id 150` in the SmokePing block conflicts with `claude-code-01` (AI Dev range 150-169)
- SmokePing belongs in the LB/Management range (190-199); `196` is the next free VMID after `prometheus` at `195`
- Updates the example, docs, and all test fixtures — no logic change

## Test plan

- [ ] CI `tofu validate` + `tofu test` pass with new fixture values
- [ ] Confirm `196` is free on the live mgmt `/24` before applying

🤖 Generated with [Claude Code](https://claude.com/claude-code)