### PR TITLE
feat(ingress): add Proxmox cluster UI apex route (subdomain apex)

### DIFF
--- a/ingress.tf
+++ b/ingress.tf
@@ -34,6 +34,18 @@ locals {
     "haproxy-stats" = { backend = "haproxy", port = local.pipeline_constants.service_ports.haproxy_stats }
   }
 
+  # Proxmox cluster UI apex backend pool. Every commissioned node's web UI is
+  # reachable at https://<role>.<domain>:8006, using each node's role FQDN —
+  # these already resolve internally, while the bare Proxmox cluster-member name
+  # deliberately does NOT, so it never collides with the subdomain ingress apex.
+  # These are HOSTNAMES, not IPs: no node management IP is exported, so the
+  # sensitive rack_servers data stays out of the inventory. Traefik load-balances
+  # the pool and skips backend cert verification (nodes serve self-signed certs).
+  proxmox_ui_backends = [
+    for name, n in var.nodes : "${n.role}.${var.domain}"
+    if n.commissioned
+  ]
+
   # Assembled routes: one {name, ip, port} per fronted service whose backend
   # container is actually defined (others are skipped, so a partial deployment
   # never emits a dangling route). IP resolves via container_ipv4 (cidrhost),
@@ -60,6 +72,23 @@ locals {
         scheme       = "https"
         insecure_tls = true
       }
-    ]
+    ],
+    # Proxmox cluster UI apex (the ingress subdomain apex), load-balanced.
+    # apex=true -> the Traefik Host rule is the base domain itself (no <name>.
+    # prefix). backends (plural) -> a multi-server loadBalancer; sticky + health
+    # checks give a stable per-browser session + drop a down node from the pool.
+    # Omitted entirely if no node is commissioned (empty pool -> no route).
+    length(local.proxmox_ui_backends) > 0 ? [
+      {
+        name         = "proxmox"
+        apex         = true
+        backends     = local.proxmox_ui_backends
+        port         = local.pipeline_constants.service_ports.proxmox_web
+        scheme       = "https"
+        insecure_tls = true
+        sticky       = true
+        health_check = true
+      }
+    ] : []
   )
 }

--- a/locals.tf
+++ b/locals.tf
@@ -170,6 +170,9 @@ locals {
       homeassistant_web = 8123
       openproject_web   = 80
       prometheus_web    = 9090
+      # Proxmox cluster web UI (:8006) — fronted by Traefik at the ingress
+      # subdomain apex, load-balanced across every commissioned node's UI.
+      proxmox_web = 8006
       # Local LLM: Ollama API (CT 167 hermes-infer) + Open WebUI (CT 168 hermes-chat)
       ollama_api     = 11434
       open_webui_web = 8080

--- a/tests/ansible_inventory_contract.tftest.hcl
+++ b/tests/ansible_inventory_contract.tftest.hcl
@@ -320,6 +320,51 @@ run "ansible_inventory_ingress_route_table" {
     ]) == 1
     error_message = "ingress must front smokeping at 192.168.5.196:80 (derived mgmt IP + constant port)"
   }
+
+  # No nodes set in this fixture -> the Proxmox apex pool is empty -> the apex
+  # route is omitted entirely (the length(proxmox_ui_backends) > 0 gate).
+  assert {
+    condition     = length([for r in output.ansible_inventory.ingress : r if r.name == "proxmox"]) == 0
+    error_message = "ingress must omit the proxmox apex route when no node is commissioned"
+  }
+}
+
+# Proxmox cluster UI apex: the subdomain apex load-balanced across the
+# commissioned node role FQDNs (https://<role>.<domain>:8006). Pins the
+# multi-backend + apex contract the ansible-proxmox-apps traefik role consumes.
+run "ansible_inventory_ingress_apex_proxmox" {
+  command = plan
+
+  variables {
+    domain = "example.com"
+    nodes = {
+      # role is the resolvable FQDN label; proxmox3 is un-commissioned and must
+      # drop out of the load-balanced pool. Sample values only.
+      proxmox1 = { role = "proxmox1" }
+      proxmox2 = { role = "proxmox2" }
+      proxmox3 = { role = "proxmox3", commissioned = false }
+    }
+  }
+
+  # The apex entry fronts the subdomain apex with a multi-backend pool built from
+  # the commissioned node role FQDNs (proxmox1/proxmox2), https + skip-verify for
+  # the self-signed node certs, and sticky + health-check flags for the LB.
+  # proxmox3 (un-commissioned) is excluded. Apex-only fields are read via try()
+  # because the ingress tuple is heterogeneous (container/splunk rows lack them).
+  assert {
+    condition = length([
+      for r in output.ansible_inventory.ingress : r
+      if r.name == "proxmox"
+      && try(r.apex, false)
+      && try(r.backends, []) == ["proxmox1.example.com", "proxmox2.example.com"]
+      && try(r.port, 0) == 8006
+      && try(r.scheme, "") == "https"
+      && try(r.insecure_tls, false)
+      && try(r.sticky, false)
+      && try(r.health_check, false)
+    ]) == 1
+    error_message = "ingress must front the Proxmox UI apex (the subdomain apex) with an https sticky health-checked pool over the commissioned node role FQDNs, excluding un-commissioned nodes"
+  }
 }
 
 # --- host_services structure tests ---


### PR DESCRIPTION
## What

Add a Proxmox cluster-UI apex route to the tofu-owned `ingress` table so the
reverse proxy (Traefik, in `ansible-proxmox-apps`) can front the Proxmox web UI
at the ingress **subdomain apex**, load-balanced across every commissioned node.

## Why

The bare ingress apex (`https://<subdomain>`) should be a secure front door to
the cluster UI. That apex is already a SAN on the existing Let's Encrypt wildcard
cert, so only the route + backend pool are missing. Backends are the node **role
FQDNs** (`https://<role>.<domain>:8006`) — hostnames that already resolve
internally — so **no node management IP is exported**: the sensitive
`rack_servers` data stays out of the inventory.

## Changes

- `locals.tf`: add `proxmox_web = 8006` to `service_ports`.
- `ingress.tf`: add a `proxmox_ui_backends` local (each commissioned node's
  `role` → `<role>.<domain>`, filtered on `commissioned`) and append an apex
  entry to the `ingress` output:
  `{ name = "proxmox", apex = true, backends[], port = 8006, scheme = "https",
  insecure_tls = true, sticky = true, health_check = true }`. Omitted entirely
  when no node is commissioned (empty pool → no route).
- `tests/ansible_inventory_contract.tftest.hcl`: pin the apex contract (the
  commissioned filter drops a decommissioned node from the pool) and assert the
  apex route is omitted when no nodes are set. Sample node names use
  `proxmox1/2/3`.

## Tests

`tofu fmt` + `tofu validate` clean; `tofu test` → **30 passed, 0 failed**.

## Consumer

The apex `ingress` row is consumed by the Traefik (router + LB pool) and
Technitium (apex A record) roles in the companion PR.

Refs: dryvist/ansible-proxmox-apps#376

🤖 Generated with [Claude Code](https://claude.com/claude-code)
