### PR TITLE
feat(monitoring): per-WAN network-diagnosis probers + netmon Splunk index

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,6 +153,7 @@ For slow operations and "context deadline exceeded" debugging:
 | Secrets roadmap | [`docs/SECRETS_ROADMAP.md`](./docs/SECRETS_ROADMAP.md) |
 | SOPS / age setup | [`docs/SOPS_SETUP.md`](./docs/SOPS_SETUP.md) |
 | Network-quality monitoring (SmokePing) | [`docs/SMOKEPING.md`](./docs/SMOKEPING.md) |
+| Per-WAN network diagnosis (modem/WAN telemetry) | [`docs/NETWORK_DIAGNOSIS.md`](./docs/NETWORK_DIAGNOSIS.md) |
 | Troubleshooting + timeout/debug logging | [`TROUBLESHOOTING.md`](./TROUBLESHOOTING.md) |
 | General docs | [`README.md`](./README.md) |
 | Planning | GitHub Issues |

--- a/deployment.json.example
+++ b/deployment.json.example
@@ -133,6 +133,35 @@
       "root_disk": { "size": 16 },
       "unprivileged": true,
       "features": { "nesting": true, "keyctl": true }
+    },
+    "_netmon_comment": "Per-uplink network-diagnosis probers (Docker-in-LXC on mgmt VLAN, tag netmon). Each runs one Telegraf agent: native ping/dns_query/http_response probes, inputs.snmp to a DOCSIS modem, and inputs.prometheus scraping a satellite gRPC exporter plus the speedtest-exporter; results push to Cribl Edge (HEC) then the Splunk netmon index. A prober measures its assigned uplink only once tofu-unifi applies a source-IP policy route per prober. See docs/NETWORK_DIAGNOSIS.md. vm_ids 197/198 are illustrative; pick free mgmt /24 hosts.",
+    "netmon-cable": {
+      "vm_id": 197,
+      "vlan": "mgmt",
+      "hostname": "netmon-cable",
+      "description": "Per-WAN diagnostics for the cable (DOCSIS) uplink: Telegraf active probes + modem SNMP into the Splunk netmon index",
+      "cpu_cores": 1,
+      "memory_dedicated": 512,
+      "memory_swap": 512,
+      "tags": ["terraform", "container", "monitoring", "netmon", "docker"],
+      "pool_id": "infrastructure",
+      "root_disk": { "size": 8 },
+      "unprivileged": true,
+      "features": { "nesting": true, "keyctl": true }
+    },
+    "netmon-sat": {
+      "vm_id": 198,
+      "vlan": "mgmt",
+      "hostname": "netmon-sat",
+      "description": "Per-uplink diagnostics for the satellite uplink: Telegraf active probes + satellite gRPC exporter into the Splunk netmon index",
+      "cpu_cores": 1,
+      "memory_dedicated": 512,
+      "memory_swap": 512,
+      "tags": ["terraform", "container", "monitoring", "netmon", "docker"],
+      "pool_id": "infrastructure",
+      "root_disk": { "size": 8 },
+      "unprivileged": true,
+      "features": { "nesting": true, "keyctl": true }
     }
   }
 }

--- a/docs/NETWORK_DIAGNOSIS.md
+++ b/docs/NETWORK_DIAGNOSIS.md
@@ -1,0 +1,79 @@
+# Per-WAN Network Diagnosis
+
+## Purpose
+
+Per-uplink probers that record active-probe and per-link source telemetry into Splunk, so a
+degraded uplink can be identified from data. This file documents the IaC scaffolding only; the
+probing agents are configured by the downstream Ansible role.
+
+## Architecture
+
+Each uplink gets a lightweight prober LXC (Docker-in-LXC, mgmt VLAN, tag `netmon`). One Telegraf
+agent per prober runs the active probes and reads its link's device, then pushes to the existing
+Cribl → Splunk pipeline.
+
+| Prober | vm_id | Uplink type | Source telemetry |
+| --- | --- | --- | --- |
+| `netmon-cable` | 197 | DOCSIS / cable | modem SNMP (power, MER/SNR, codewords, T3/T4 timeouts) |
+| `netmon-sat` | 198 | satellite | dish gRPC exporter (obstruction %, outages, latency) |
+| `netmon-lte` | optional | LTE | light probing only (metered link) |
+
+Telegraf inputs per prober (all native — no custom scripts):
+
+- `inputs.ping` — ICMP latency / loss / jitter to the link gateway + public anycast resolvers
+- `inputs.dns_query` — DNS resolution RTT
+- `inputs.http_response` — HTTPS response time
+- `inputs.snmp` — DOCSIS-IF / DOCS-IF3 MIB on a cable modem
+- `inputs.prometheus` — scrapes the satellite gRPC exporter and the speedtest-exporter
+- `outputs.http` — Splunk-HEC format → Cribl Edge → Cribl Stream → Splunk `netmon` index
+
+```mermaid
+flowchart LR
+  C[netmon-cable] -->|policy route| WA[(uplink A)]
+  S[netmon-sat] -->|policy route| WB[(uplink B)]
+  C --> CE[Cribl Edge]
+  S --> CE
+  CE --> CS[Cribl Stream] --> NM[(Splunk netmon index)]
+```
+
+## Implementation choices
+
+- **One Telegraf agent per prober** — a single agent natively covers ping/dns/http + SNMP +
+  Prometheus scrape, so no per-probe exporters are needed.
+- **Reuses the existing Cribl → Splunk pipeline** instead of adding a new metrics path.
+- **Firewall via the existing `monitoring` tag** — the probers inherit the open-egress monitoring
+  rules with no module change.
+
+## Per-uplink routing dependency
+
+A device diagnostic IP (commonly `192.168.100.1`) is shared across uplinks, so a prober reaches
+*its* link's device only when its traffic egresses the assigned uplink. A source-IP policy route
+per prober (owned by `tofu-unifi`) provides that. Until those routes apply, a prober measures the
+default-route uplink only; the per-link source counters still populate.
+
+## Splunk: the `netmon` index
+
+Defined in [`SPLUNK_INDEXES.md`](./SPLUNK_INDEXES.md); created by the `ansible-splunk` role. Probe
+data is high-volume, so the index uses **90-day** retention — separate from the 365-day
+security-log indexes.
+
+## Cross-repo ownership
+
+| Work | Repo |
+| --- | --- |
+| netmon LXC definitions, `netmon` index doc, ports | terraform-proxmox (this) |
+| Telegraf + exporter + SmokePing container config | ansible-proxmox-apps |
+| `netmon` Splunk index creation | ansible-splunk |
+| Per-uplink source-IP policy routes | tofu-unifi (gated apply) |
+
+## Prerequisites and caveats
+
+- Device SNMP (or an HTTP stats page) must be reachable from the prober; otherwise telemetry
+  degrades to active probing only.
+- All collection uses native Telegraf inputs and off-the-shelf exporters — no custom scripts.
+
+## Related documentation
+
+- [SMOKEPING.md](./SMOKEPING.md) — aggregate latency/loss/jitter RRD dashboard
+- [LOGGING_PIPELINE.md](./LOGGING_PIPELINE.md) — syslog/NetFlow → Cribl → Splunk architecture
+- [SPLUNK_INDEXES.md](./SPLUNK_INDEXES.md) — index definitions and retention

--- a/docs/SPLUNK_INDEXES.md
+++ b/docs/SPLUNK_INDEXES.md
@@ -12,6 +12,7 @@ This document defines the Splunk indexes used in the logging pipeline, their pur
 | os       | Operating system logs     | Linux, macOS, Windows hosts    | 365 days  |
 | firewall | Firewall logs             | Palo Alto, Cisco ASA           | 365 days  |
 | network  | General network logs      | Switches, routers, other       | 365 days  |
+| netmon   | Per-WAN network diagnosis | Probes, DOCSIS SNMP, satellite | 90 days   |
 
 ## Index Configuration
 
@@ -87,9 +88,29 @@ frozenTimePeriodInSecs = 31536000
 - Port status changes
 - General network telemetry
 
+### netmon
+
+```ini
+[netmon]
+homePath = $SPLUNK_DB/netmon/db
+coldPath = $SPLUNK_DB/netmon/colddb
+thawedPath = $SPLUNK_DB/netmon/thaweddb
+maxTotalDataSizeMB = 51200
+frozenTimePeriodInSecs = 7776000
+```
+
+**Data types**:
+
+- Per-WAN ICMP/DNS/HTTPS latency, loss, and jitter (Telegraf active probes)
+- DOCSIS modem counters (power, MER/SNR, correctable + uncorrectable codewords, T3/T4 timeouts)
+- Satellite obstruction %, outages, pop-ping latency
+- Hourly per-WAN throughput (speedtest-exporter)
+
 ## Retention Policy
 
-All indexes use a **365-day retention** period (`frozenTimePeriodInSecs = 31536000`).
+Security-log indexes use a **365-day retention** period (`frozenTimePeriodInSecs = 31536000`).
+The `netmon` diagnostics index is the exception at **90 days** (`7776000`) — a troubleshooting
+horizon, not a compliance window.
 
 **Rationale**:
 
@@ -99,13 +120,15 @@ All indexes use a **365-day retention** period (`frozenTimePeriodInSecs = 315360
 
 ## Size Limits
 
-Each index is limited to **100GB** (`maxTotalDataSizeMB = 102400`).
+Security-log indexes are limited to **100GB** each (`maxTotalDataSizeMB = 102400`); the `netmon`
+diagnostics index is capped at **50GB** (`51200`).
 
 **Capacity planning**:
 
-- Total: 400GB across 4 indexes
+- Total: 450GB across 5 indexes (4 × 100GB security + netmon 50GB)
 - Splunk VM disk: 500GB allocated
-- Buffer for internal indexes: 100GB
+- Buffer for Splunk internal indexes: ~50GB — grow the VM disk before onboarding the broader
+  host/container/firewall log sources
 
 ## Source Type Mapping
 
@@ -121,6 +144,9 @@ Each index is limited to **100GB** (`maxTotalDataSizeMB = 102400`).
 | pan:threat     | firewall | Palo Alto threats      |
 | cisco:asa      | firewall | Cisco ASA              |
 | syslog:network | network  | Generic network        |
+| netmon:probe   | netmon   | Telegraf active probes |
+| netmon:docsis  | netmon   | Cable modem SNMP       |
+| netmon:sat     | netmon   | satellite uplink probe |
 
 ## HEC Token Configuration
 
@@ -151,6 +177,9 @@ splunk_indexes:
   - name: network
     maxTotalDataSizeMB: 102400
     frozenTimePeriodInSecs: 31536000
+  - name: netmon
+    maxTotalDataSizeMB: 51200
+    frozenTimePeriodInSecs: 7776000
 ```
 
 ## Related Documentation

--- a/locals.tf
+++ b/locals.tf
@@ -178,6 +178,11 @@ locals {
       # endpoint scraped by Prometheus. See docs/SMOKEPING.md.
       smokeping_web      = 80
       speedtest_exporter = 9798
+      # Per-uplink network diagnosis (CT netmon-*, mgmt VLAN, Docker-in-LXC): the
+      # satellite gRPC exporter scraped by each prober's Telegraf, alongside DOCSIS
+      # modem SNMP and native active probes. Pushes to Cribl -> Splunk netmon
+      # index. See docs/NETWORK_DIAGNOSIS.md.
+      satellite_exporter = 9817
     }
     syslog_ports = {
       default   = 514


### PR DESCRIPTION
## What this PR adds

Per-uplink network-diagnosis prober scaffolding (terraform-proxmox; no live apply):

- **`deployment.json.example`** — per-uplink prober LXC templates (Docker-in-LXC, mgmt VLAN). Each runs one Telegraf agent: native ping/dns/http probes + DOCSIS modem SNMP + a satellite gRPC exporter, pushing to the existing Cribl Edge → Splunk pipeline.
- **`locals.tf`** — per-uplink exporter port constant in `pipeline_constants` (keeps ports DRY).
- **`docs/NETWORK_DIAGNOSIS.md`** — prober architecture and the per-uplink policy-route dependency.
- **`docs/SPLUNK_INDEXES.md`** — new `netmon` index (90-day retention, separate from the 365-day security indexes because probe data is high-volume).
- **`AGENTS.md`** — file-reference pointer.

## Implementation choices

- **One Telegraf agent per prober** rather than separate exporters per probe type — a single agent natively covers ping/dns/http + SNMP + Prometheus scrape.
- **Reuses the existing pipeline** (Cribl Edge → Splunk) instead of adding a new metrics path.
- **Firewall via the existing `monitoring` tag** — no module change.
- **No live apply** — the gitignored `deployment.json` is untouched; provisioning is a separate credentialed step.

## Notes

- Per-uplink separation depends on source-IP policy routes applied separately (each prober egresses its assigned uplink).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
