### PR TITLE
feat(inventory): publish ansible_inventory to S3 (native aws_s3_object)

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -23,6 +23,32 @@ provider "registry.opentofu.org/bpg/proxmox" {
   ]
 }
 
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "6.49.0"
+  constraints = ">= 5.0.0"
+  hashes = [
+    "h1:0WqfoBWjZLSnJ5bvxEObUWcNb7WnzcY9ykbRjIVbVrM=",
+    "h1:NYTh/95wjWoXnLcufPF+9OiTH40tIeimMTFxJAir7HA=",
+    "h1:RDq+cZIn+VjE5IB/BMuP9GzkjzBetNpH860fZlNldeY=",
+    "h1:ypAokSdDxgR55nQJwx0y8Hg0CxEFXHeSpK9TKHMu+9A=",
+    "zh:11e3bdc8ad4bbf4cc0578d495b7c8984cbd0a091eb33a93d1e4052c2749debc5",
+    "zh:157592d843e09692be2f47685c083774b7c733696d85158959e777c39bce7146",
+    "zh:1a22861c96fd121191508a62ef26766abb2a74d8a6743e8a5767070b300f2c71",
+    "zh:1c903d9604481f8a3c8bc433a42fe5996e82d90eae997bd73be6c28a96a9f5da",
+    "zh:5fd4b32e028878fab61a998036a8d3fb464ac14760613e178a8ef1e9acd7553d",
+    "zh:66069bc751b3923672160ff5e43e2e26e2195de333559946f455168302da7d84",
+    "zh:6b2f5165d113056a135469ec5cad23719747797a26d168b432139051081bcf2d",
+    "zh:6d8e2bf4648329434431a54d59e557371e33a008a62bc274ceeb3fad5f65cf31",
+    "zh:85b78949524516acf6fa0fb42fa65864a1224cf3c0544c29f3ff030d4af9fa48",
+    "zh:8867a24d0cf0d2115e93c0e8ec8be12d36de16ee244473e8783df76446390bf3",
+    "zh:8b8c098fa5ec67950283e5b3f1b4b829c0a2aee9df03669046ab1efe21499162",
+    "zh:95f96caa2634fc6cbfc25f6b5202482f5fa6bf7e8fa56d77cd1c52e5d0128bd0",
+    "zh:c076d91da0d38bf4a9849df616f61fb9b4f8297792bb878d1f570992e033d778",
+    "zh:da2b431dab43584f98ebd8653cac6ebbc44645aa1fc888c899f34cfd544bb186",
+    "zh:e7e69626934dadf54ea52e7d27e13c89ec927f93e850169ae13e440283977dd8",
+  ]
+}
+
 provider "registry.opentofu.org/hashicorp/local" {
   version     = "2.9.0"
   constraints = "~> 2.5"

--- a/docs/INVENTORY_PUBLISHING.md
+++ b/docs/INVENTORY_PUBLISHING.md
@@ -1,0 +1,67 @@
+# Inventory Publishing
+
+The Ansible inventory is published to the terragrunt S3 backend **natively** —
+an `aws_s3_object` resource (`inventory_publish.tf`), not a script. `terragrunt
+apply` is the publish boundary: when the inventory content changes, Terraform
+uploads the object as part of the apply.
+
+```hcl
+resource "aws_s3_object" "ansible_inventory" {
+  bucket       = "terraform-proxmox-state-useast2-${data.aws_caller_identity.current.account_id}"
+  key          = "terraform-proxmox/inventory/ansible_inventory.json"
+  content      = jsonencode(local.ansible_inventory)
+  content_type = "application/json"
+}
+```
+
+- The AWS provider uses the **same ambient credential chain as the S3 state
+  backend** (aws-vault locally, OIDC in CI) — no static keys, no `aws` CLI.
+- The object content is `jsonencode(local.ansible_inventory)` — the same value
+  as the `ansible_inventory` output. Consumers adapt the shape to their needs.
+- The resource updates only when the content changes, and only when it is in
+  scope: a `-target` apply that excludes it does **not** republish a partial
+  inventory.
+
+## Why S3
+
+The inventory contains real node names, IPs, and pool names, so it cannot be
+committed to a public repo. The terragrunt **state backend bucket already
+exists** and is access-controlled, so it is the natural cloud-reachable source:
+GitHub Actions assume a read role via OIDC, cloud agents use a scoped read role,
+and `aws-vault` covers local use — all fetch the same object with no checkout
+and no terraform toolchain.
+
+## Freshness contract
+
+The published object reflects the **last apply**. Editing `deployment.json`
+without applying changes nothing downstream — `apply` is the only publish point.
+This makes `apply` the single, auditable way to change what every consumer sees.
+
+## Relationship to `scripts/sync-inventory.sh`
+
+The S3 publish is **native Terraform**. The existing after-hook
+(`scripts/sync-inventory.sh`) is unchanged and still handles the two
+distribution targets Terraform cannot: the schema-validated versioned commit
+into the private `int_homelab` repo, and the local gitignored copies for
+development.
+
+## IAM
+
+The credentials used for `apply` need `s3:PutObject` (and `s3:GetObject` for
+plan refresh) on `…/terraform-proxmox/inventory/*`; each consumer needs
+`s3:GetObject` on the same key. If the state bucket policy scopes access to the
+`terraform.tfstate` key only, widen it to the `terraform-proxmox/` prefix (or
+the `inventory/` sub-prefix) for these objects.
+
+## Consuming the inventory
+
+Consumers fetch the raw object and adapt it. Example
+(`ansible-proxmox`'s `playbooks/load_tofu.yml` resolver):
+
+1. `TOFU_INVENTORY_PATH` — explicit local file.
+2. S3 artifact — fetched with the `aws` CLI (URI from `TOFU_INVENTORY_S3_URI`
+   or derived from the account).
+3. `inventory/tofu_inventory.json` — local cache.
+
+A consumer needs only AWS read creds for option 2 — no repo checkout and no
+terraform/terragrunt toolchain.

--- a/inventory_publish.tf
+++ b/inventory_publish.tf
@@ -1,0 +1,99 @@
+# Native publish of the Ansible inventory to the terragrunt S3 backend.
+#
+# `terragrunt apply` is the publish boundary: the aws_s3_object below uploads the
+# inventory whenever its content changes — no shell script, no `aws` CLI. Any
+# consumer (CI via OIDC, cloud agents, ansible) fetches this object with scoped
+# read creds, with no checkout and no terraform toolchain.
+#
+# The AWS provider uses the same ambient credential chain as the S3 *state*
+# backend (terragrunt.hcl) — no static keys here.
+
+locals {
+  # The inventory value, shared by output.ansible_inventory and the publish
+  # resource below (a resource cannot reference an output, so this lives here).
+  ansible_inventory = {
+    # LXC Containers - using proxmox_pct_remote connection
+    containers = {
+      for k, v in(length(var.containers) > 0 ? module.containers[0].container_details : {}) : k => {
+        vmid     = v.id
+        hostname = var.containers[k].hostname
+        ip       = split("/", local.container_ipv4[k])[0] # per-VLAN IP cidrhost(network_cidrs[vlan], vm_id); strip CIDR for Ansible
+        node     = v.node_name
+        # Connection settings for proxmox_pct_remote (community.proxmox)
+        ansible_connection = "community.proxmox.proxmox_pct_remote"
+        ansible_pct_vmid   = v.id
+        tags               = v.tags
+        pool_id            = v.pool_id
+      }
+    }
+    # Regular VMs - using SSH connection
+    # DRY: IP derived from vm_id (consistent with containers and cloud-init config)
+    vms = {
+      for k, v in module.vms.vm_details : k => {
+        vmid               = v.id
+        hostname           = v.name
+        ip                 = split("/", local.vm_ipv4[k])[0]
+        node               = v.node_name
+        ansible_connection = "ssh"
+        tags               = v.tags
+        pool_id            = v.pool_id
+      }
+    }
+    # Docker VMs - filtered subset of VMs with "docker" tag
+    docker_vms = {
+      for k, v in module.vms.vm_details : k => {
+        vmid               = v.id
+        hostname           = v.name
+        ip                 = split("/", local.vm_ipv4[k])[0]
+        node               = v.node_name
+        ansible_connection = "ssh"
+        tags               = v.tags
+        pool_id            = v.pool_id
+      } if contains(try(v.tags, []), "docker")
+    }
+    # Splunk VM - dedicated Docker host with SSH connection
+    splunk_vm = {
+      splunk = {
+        vmid               = module.splunk_vm.vm_id
+        hostname           = module.splunk_vm.name
+        ip                 = module.splunk_vm.ip_address # CIDR already stripped in module output
+        node               = var.proxmox_node
+        ansible_connection = "ssh"
+      }
+    }
+    # Pipeline constants - service and syslog port definitions
+    constants = local.pipeline_constants
+    # Traefik ingress route table - one {name, ip, port} per fronted service UI.
+    # The ansible-proxmox-apps traefik + technitium_dns roles derive their routers
+    # and DNS aliases from this single source instead of hand-listing hosts.
+    ingress = local.ingress
+    # Host-level NAS service config - consumed by ansible-proxmox to provision ZFS dataset + Samba
+    host_services = var.host_services
+    # Cluster node inventory (non-secret identity) - ansible-proxmox targets hosts and
+    # skips nodes where commissioned = false.
+    nodes = var.nodes
+    # Per-node ZFS storage to provision (pools/datasets/quotas) - ansible-proxmox creates
+    # and registers these; Terraform only references the datastore by id on disks.
+    node_storage = var.node_storage
+    # Domain for FQDN resolution (e.g., example.com)
+    domain = var.domain
+  }
+}
+
+# Same ambient credential chain as the S3 state backend (aws-vault locally, OIDC
+# in CI). Region matches the state bucket in terragrunt.hcl.
+provider "aws" {
+  region = "us-east-2"
+}
+
+data "aws_caller_identity" "current" {}
+
+# Publish point. The object updates only when the inventory content changes, and
+# only when this resource is in scope — a `-target` apply that excludes it does
+# not republish a partial inventory.
+resource "aws_s3_object" "ansible_inventory" {
+  bucket       = "terraform-proxmox-state-useast2-${data.aws_caller_identity.current.account_id}"
+  key          = "terraform-proxmox/inventory/ansible_inventory.json"
+  content      = jsonencode(local.ansible_inventory)
+  content_type = "application/json"
+}

--- a/main.tf
+++ b/main.tf
@@ -5,6 +5,12 @@ terraform {
       source  = "bpg/proxmox"
       version = "~> 0.106"
     }
+    # Publishes the ansible_inventory output to S3 (inventory_publish.tf), using
+    # the same ambient credential chain as the S3 state backend.
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
     tls = {
       source  = "hashicorp/tls"
       version = "~> 4.1"

--- a/outputs.tf
+++ b/outputs.tf
@@ -72,73 +72,10 @@ output "acme_dns_plugins" {
 # generation, eliminating hardcoded VM IDs and IPs from Ansible configuration.
 output "ansible_inventory" {
   description = "Structured inventory for Ansible consumption - includes all VMs, containers, and Splunk infrastructure"
-  value = {
-    # LXC Containers - using proxmox_pct_remote connection
-    containers = {
-      for k, v in(length(var.containers) > 0 ? module.containers[0].container_details : {}) : k => {
-        vmid     = v.id
-        hostname = var.containers[k].hostname
-        ip       = split("/", local.container_ipv4[k])[0] # per-VLAN IP cidrhost(network_cidrs[vlan], vm_id); strip CIDR for Ansible
-        node     = v.node_name
-        # Connection settings for proxmox_pct_remote (community.proxmox)
-        ansible_connection = "community.proxmox.proxmox_pct_remote"
-        ansible_pct_vmid   = v.id
-        tags               = v.tags
-        pool_id            = v.pool_id
-      }
-    }
-    # Regular VMs - using SSH connection
-    # DRY: IP derived from vm_id (consistent with containers and cloud-init config)
-    vms = {
-      for k, v in module.vms.vm_details : k => {
-        vmid               = v.id
-        hostname           = v.name
-        ip                 = split("/", local.vm_ipv4[k])[0]
-        node               = v.node_name
-        ansible_connection = "ssh"
-        tags               = v.tags
-        pool_id            = v.pool_id
-      }
-    }
-    # Docker VMs - filtered subset of VMs with "docker" tag
-    docker_vms = {
-      for k, v in module.vms.vm_details : k => {
-        vmid               = v.id
-        hostname           = v.name
-        ip                 = split("/", local.vm_ipv4[k])[0]
-        node               = v.node_name
-        ansible_connection = "ssh"
-        tags               = v.tags
-        pool_id            = v.pool_id
-      } if contains(try(v.tags, []), "docker")
-    }
-    # Splunk VM - dedicated Docker host with SSH connection
-    splunk_vm = {
-      splunk = {
-        vmid               = module.splunk_vm.vm_id
-        hostname           = module.splunk_vm.name
-        ip                 = module.splunk_vm.ip_address # CIDR already stripped in module output
-        node               = var.proxmox_node
-        ansible_connection = "ssh"
-      }
-    }
-    # Pipeline constants - service and syslog port definitions
-    constants = local.pipeline_constants
-    # Traefik ingress route table - one {name, ip, port} per fronted service UI.
-    # The ansible-proxmox-apps traefik + technitium_dns roles derive their routers
-    # and DNS aliases from this single source instead of hand-listing hosts.
-    ingress = local.ingress
-    # Host-level NAS service config - consumed by ansible-proxmox to provision ZFS dataset + Samba
-    host_services = var.host_services
-    # Cluster node inventory (non-secret identity) - ansible-proxmox targets hosts and
-    # skips nodes where commissioned = false.
-    nodes = var.nodes
-    # Per-node ZFS storage to provision (pools/datasets/quotas) - ansible-proxmox creates
-    # and registers these; Terraform only references the datastore by id on disks.
-    node_storage = var.node_storage
-    # Domain for FQDN resolution (e.g., example.com)
-    domain = var.domain
-  }
+  # The value lives in local.ansible_inventory (inventory_publish.tf) so the
+  # native aws_s3_object publish resource can reference the same data — a
+  # resource cannot reference an output.
+  value = local.ansible_inventory
 }
 
 # Rack-server cluster inventory - consumed by ansible-proxmox via terraform_remote_state.


### PR DESCRIPTION
## Summary

Make the Ansible inventory reachable from anywhere (CI, cloud agents) by publishing it to the terragrunt S3 state backend — **natively**, via an `aws_s3_object` resource. No shell script.

## What changed

- `inventory_publish.tf` — `aws_s3_object.ansible_inventory` uploads `jsonencode(local.ansible_inventory)` to `s3://…-state-…/terraform-proxmox/inventory/ansible_inventory.json` on apply. The AWS provider uses the **same ambient credential chain as the S3 state backend** (no static keys, no `aws` CLI).
- The `ansible_inventory` output value is extracted to `local.ansible_inventory` so the resource can reference it (a resource cannot reference an output).
- `main.tf` — adds the `hashicorp/aws` provider (`>= 5.0`); `.terraform.lock.hcl` locked for linux/darwin (amd64/arm64).

## Why native (v2)

The first revision used `aws s3 cp` inside `scripts/sync-inventory.sh` — a no-scripts violation when a Terraform resource exists. Reverted; `sync-inventory.sh` is unchanged and still owns the int_homelab versioned commit + local copies (which Terraform cannot do).

## Behavior

- `terragrunt apply` is the publish boundary; the object updates only when the inventory content changes.
- A `-target` apply that excludes the resource does **not** republish a partial inventory (better than the always-runs script).

## IAM (action needed)

Apply creds need `s3:PutObject`/`s3:GetObject` on `…/terraform-proxmox/inventory/*`; consumers need `s3:GetObject`. Widen the bucket policy beyond the `terraform.tfstate` key if it is scoped.

## Verification

- `tofu validate`: Success. `tofu fmt`: clean.
- Live publish validates on the next apply (the `aws-vault` session expired mid-work).

Consumer side: dryvist/ansible-proxmox#264. Docs: `docs/INVENTORY_PUBLISHING.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)