### PR TITLE
feat(monitoring): adopt 6-digit VMID + DHCP/DNS-first addressing

### DIFF
--- a/deployment.json.example
+++ b/deployment.json.example
@@ -119,9 +119,10 @@
       "pool_id": "infrastructure",
       "root_disk": { "size": 8 }
     },
-    "_smokeping_comment": "Network-quality monitoring — Prometheus-native stack (Docker-in-LXC). The central `smokeping` collector on mgmt runs smokeping_prober (:9374, ICMP/UDP latency-distribution histograms = system of record), blackbox_exporter (:9115, DNS/HTTP/TLS/TCP + SLO probes), atlas_exporter (:9400, RIPE Atlas outside-in), an irtt server (:2112/udp, real RFC-3393 jitter/MOS), and optionally the classic SmokePing RRD/CGI UI (:80). Throughput is DECOUPLED onto its own `speedtest` host so saturation never corrupts latency samples. Add a per-segment `netq-probe-*` vantage on each VLAN you care about (multi-vantage) — one example below. See docs/SMOKEPING.md for the full blueprint the ansible-proxmox-apps roles apply. vm_ids are illustrative; pick free ones per VLAN /24.",
+    "_smokeping_comment": "Network-quality monitoring — Prometheus-native stack (Docker-in-LXC). The central `smokeping` collector runs smokeping_prober (:9374, ICMP/UDP latency-distribution histograms = system of record), blackbox_exporter (:9115, DNS/HTTP/TLS/TCP + SLO probes), atlas_exporter (:9400, RIPE Atlas outside-in), an irtt server (:2112/udp, real RFC-3393 jitter/MOS), and optionally the classic SmokePing RRD/CGI UI (:80). Throughput is DECOUPLED onto its own `speedtest` host so saturation never corrupts latency samples. Add a per-segment `netq-probe-*` vantage on each VLAN you care about (multi-vantage) — one example below. See docs/SMOKEPING.md for the full blueprint the ansible-proxmox-apps roles apply. These adopt the 6-digit positional VMID + DNS-first convention (docs.jacobpevans.com/infrastructure/vmid-network-tiers): observability = tier 4, so VMIDs are 41xxxx; `dhcp:true` means no vm_id-derived IP — DHCP leases the address and each guest is reached by {hostname}.{domain}. `vlan` stays at today's value during the incremental tier renumber.",
     "smokeping": {
-      "vm_id": 196,
+      "vm_id": 412000,
+      "dhcp": true,
       "vlan": "mgmt",
       "hostname": "smokeping",
       "description": "Central network-quality stack: smokeping_prober + blackbox_exporter + atlas_exporter + irtt server (+ optional SmokePing UI). Scraped by Prometheus.",
@@ -135,7 +136,8 @@
       "features": { "nesting": true, "keyctl": true }
     },
     "speedtest": {
-      "vm_id": 197,
+      "vm_id": 416000,
+      "dhcp": true,
       "vlan": "mgmt",
       "hostname": "speedtest",
       "description": "Decoupled throughput exporter (speedtest-exporter :9798). Separate host (pin off the prober's node) so a saturating speedtest never corrupts latency/loss probes. Scrape hourly, off-peak.",
@@ -150,7 +152,8 @@
       "features": { "nesting": true, "keyctl": true }
     },
     "netq-probe-media": {
-      "vm_id": 198,
+      "vm_id": 415000,
+      "dhcp": true,
       "vlan": "media_svc",
       "hostname": "netq-probe-media",
       "description": "Per-segment vantage prober (smokeping_prober + blackbox_exporter + irtt) measuring network quality FROM the media VLAN's perspective. Clone one per VLAN you care about — mgmt-only probing can't see each segment's real path. Add a WAN-edge vantage for true ISP-link quality.",

--- a/ingress.tf
+++ b/ingress.tf
@@ -48,15 +48,16 @@ locals {
 
   # Assembled routes: one {name, ip, port} per fronted service whose backend
   # container is actually defined (others are skipped, so a partial deployment
-  # never emits a dangling route). IP resolves via container_ipv4 (cidrhost),
-  # already nonsensitive; strip the CIDR mask for the proxy backend URL.
+  # never emits a dangling route). The backend address comes from
+  # local.container_address: a static guest's cidrhost IP, or a DNS-first
+  # (dhcp = true) guest's FQDN — same hostname-not-IP shape as proxmox_ui_backends.
   # The Splunk VM is appended separately: it is a VM (not in var.containers), so
-  # its IP comes from splunk_derived_ip (siem VLAN) rather than container_ipv4.
+  # its IP comes from splunk_derived_ip (siem VLAN) rather than container_address.
   ingress = concat(
     [
       for name, svc in local.ingress_services : {
         name = name
-        ip   = split("/", local.container_ipv4[svc.backend])[0]
+        ip   = local.container_address[svc.backend]
         port = svc.port
       }
       if contains(keys(var.containers), svc.backend)

--- a/inventory_publish.tf
+++ b/inventory_publish.tf
@@ -17,7 +17,7 @@ locals {
       for k, v in(length(var.containers) > 0 ? module.containers[0].container_details : {}) : k => {
         vmid     = v.id
         hostname = var.containers[k].hostname
-        ip       = split("/", local.container_ipv4[k])[0] # per-VLAN IP cidrhost(network_cidrs[vlan], vm_id); strip CIDR for Ansible
+        ip       = local.container_address[k] # static: per-VLAN cidrhost IP (CIDR stripped); DHCP guests: FQDN (DNS-first)
         node     = v.node_name
         # Connection settings for proxmox_pct_remote (community.proxmox)
         ansible_connection = "community.proxmox.proxmox_pct_remote"

--- a/locals.tf
+++ b/locals.tf
@@ -24,14 +24,34 @@ locals {
   # A container MAY pin a static ipv4_address (CIDR form, e.g. "192.168.5.10/24") to
   # override the vm_id-derived address — for fixed low-number hosts (e.g. a DNS server
   # at .10) whose address must not follow the vm_id. Otherwise derived as usual.
+  # DNS-first guests (dhcp = true) resolve to the literal "dhcp" instead: cidrhost is
+  # NOT evaluated for them (the ternary short-circuits), so a 6-digit positional VMID
+  # that would overflow the /24 host space is fine. Their gateway is null (DHCP-provided).
   container_ipv4 = {
-    for k, v in var.containers : k => nonsensitive(coalesce(
-      try(v.ip_config.ipv4_address, null),
-      "${cidrhost(var.network_cidrs[v.vlan], v.vm_id)}/${split("/", var.network_cidrs[v.vlan])[1]}"
-    ))
+    for k, v in var.containers : k => (
+      try(v.dhcp, false) ? "dhcp" : nonsensitive(coalesce(
+        try(v.ip_config.ipv4_address, null),
+        "${cidrhost(var.network_cidrs[v.vlan], v.vm_id)}/${split("/", var.network_cidrs[v.vlan])[1]}"
+      ))
+    )
   }
   container_gateway = {
-    for k, v in var.containers : k => nonsensitive(cidrhost(var.network_cidrs[v.vlan], 1))
+    for k, v in var.containers : k => (
+      try(v.dhcp, false) ? null : nonsensitive(cidrhost(var.network_cidrs[v.vlan], 1))
+    )
+  }
+
+  # Reachable address each container advertises to downstream consumers (the
+  # ansible_inventory ip field and the Traefik ingress backend). Static guests
+  # advertise their derived host IP (CIDR mask stripped); DNS-first guests
+  # (dhcp = true) advertise their FQDN {hostname}.{domain} so nothing downstream
+  # pins an address the DHCP lease can change — reachable by name regardless of IP.
+  container_address = {
+    for k, v in var.containers : k => (
+      try(v.dhcp, false)
+      ? (var.domain != "" ? "${v.hostname}.${var.domain}" : v.hostname)
+      : split("/", local.container_ipv4[k])[0]
+    )
   }
   vm_ipv4 = {
     for k, v in var.vms : k =>

--- a/modules/proxmox-container/main.tf
+++ b/modules/proxmox-container/main.tf
@@ -32,10 +32,13 @@ resource "proxmox_virtual_environment_container" "containers" {
   # Startup configuration
   start_on_boot = each.value.start_on_boot
 
-  # Startup order: 256 - vm_id (higher IDs start first)
+  # Startup order: 256 - vm_id (higher IDs start first). Clamped at 0 so
+  # 6-digit positional VMIDs (DNS-first/DHCP guests, see docs vmid-network-tiers)
+  # don't produce a negative order — those guests get order 0 (unordered), which
+  # is correct for non-critical DHCP workloads. Legacy <256 IDs are unaffected.
   # Delay: global startup_delay between each start
   startup {
-    order    = 256 - each.value.vm_id
+    order    = max(0, 256 - each.value.vm_id)
     up_delay = var.startup_delay
   }
 
@@ -43,7 +46,9 @@ resource "proxmox_virtual_environment_container" "containers" {
   initialization {
     hostname = each.value.hostname
 
-    # IP configuration
+    # IP configuration. address is either a CIDR (static, vm_id-derived) or the
+    # literal "dhcp" for DNS-first guests; in the DHCP case the caller passes a
+    # null gateway (the lease provides one), so gateway is simply omitted.
     dynamic "ip_config" {
       for_each = each.value.ip_config.ipv4_address != null ? [1] : []
       content {

--- a/tests/ansible_inventory_contract.tftest.hcl
+++ b/tests/ansible_inventory_contract.tftest.hcl
@@ -278,14 +278,17 @@ run "ansible_inventory_ingress_route_table" {
         hostname = "seerr"
         vlan     = "media_svc"
       }
-      # Network-quality monitoring LXC on the mgmt VLAN (id 5 -> 192.168.5.0/24).
+      # Network-quality monitoring LXC — DNS-first (dhcp) with a 6-digit positional
+      # VMID (observability tier 4). No vm_id-derived IP; fronted by FQDN.
       "smokeping" = {
-        vm_id    = 196
+        vm_id    = 412000
+        dhcp     = true
         hostname = "smokeping"
         vlan     = "mgmt"
         tags     = ["terraform", "container", "monitoring", "docker"]
       }
     }
+    domain = "example.com"
   }
 
   # plex: backend "plex" (192.168.55.210) on media_ports.plex_web (32400).
@@ -312,13 +315,14 @@ run "ansible_inventory_ingress_route_table" {
     error_message = "ingress must skip services whose backend container is not defined"
   }
 
-  # smokeping: backend "smokeping" (192.168.5.196) on service_ports.smokeping_web (80).
+  # smokeping: DNS-first backend — ingress fronts it by FQDN ({hostname}.{domain}),
+  # NOT a vm_id-derived IP, on service_ports.smokeping_web (80).
   assert {
     condition = length([
       for r in output.ansible_inventory.ingress :
-      r if r.name == "smokeping" && r.ip == "192.168.5.196" && r.port == 80
+      r if r.name == "smokeping" && r.ip == "smokeping.example.com" && r.port == 80
     ]) == 1
-    error_message = "ingress must front smokeping at 192.168.5.196:80 (derived mgmt IP + constant port)"
+    error_message = "ingress must front DHCP guest smokeping at smokeping.example.com:80 (FQDN backend + constant port)"
   }
 
   # No nodes set in this fixture -> the Proxmox apex pool is empty -> the apex

--- a/tests/locals.tftest.hcl
+++ b/tests/locals.tftest.hcl
@@ -412,7 +412,8 @@ run "monitoring_ids_picks_up_monitoring_tagged" {
   variables {
     containers = {
       "smokeping" = {
-        vm_id    = 196
+        vm_id    = 412000
+        dhcp     = true
         hostname = "smokeping"
         vlan     = "mgmt"
         tags     = ["terraform", "container", "monitoring", "docker"]
@@ -421,14 +422,45 @@ run "monitoring_ids_picks_up_monitoring_tagged" {
   }
 
   assert {
-    condition     = local.monitoring_container_ids["smokeping"] == 196
-    error_message = "monitoring_container_ids should map 'smokeping' to vm_id 196"
+    condition     = local.monitoring_container_ids["smokeping"] == 412000
+    error_message = "monitoring_container_ids should map 'smokeping' to its 6-digit VMID 412000"
   }
 
-  # mgmt VLAN id is 5 -> 192.168.5.0/24; vm_id 196 -> .196
+  # DNS-first guest: no vm_id-derived IP. cidrhost is skipped (a 6-digit id would
+  # overflow the /24 host space), so container_ipv4 is the literal "dhcp".
   assert {
-    condition     = local.container_ipv4["smokeping"] == "192.168.5.196/24"
-    error_message = "smokeping mgmt-VLAN IP should be 192.168.5.196/24, got ${local.container_ipv4["smokeping"]}"
+    condition     = local.container_ipv4["smokeping"] == "dhcp"
+    error_message = "dhcp smokeping container_ipv4 should be \"dhcp\" (cidrhost skipped), got ${local.container_ipv4["smokeping"]}"
+  }
+}
+
+# DNS-first (dhcp) addressing: a 6-digit positional VMID skips IP derivation, the
+# guest advertises its FQDN ({hostname}.{domain}) to downstream consumers, and no
+# gateway is derived (the DHCP lease provides one).
+run "container_dhcp_resolves_fqdn_and_null_gateway" {
+  command = plan
+
+  variables {
+    domain = "example.com"
+    containers = {
+      "speedtest" = {
+        vm_id    = 416000
+        dhcp     = true
+        hostname = "speedtest"
+        vlan     = "mgmt"
+        tags     = ["terraform", "container", "monitoring", "docker"]
+      }
+    }
+  }
+
+  assert {
+    condition     = local.container_address["speedtest"] == "speedtest.example.com"
+    error_message = "dhcp speedtest should advertise FQDN speedtest.example.com, got ${local.container_address["speedtest"]}"
+  }
+
+  assert {
+    condition     = local.container_gateway["speedtest"] == null
+    error_message = "dhcp speedtest container_gateway should be null (lease-provided)"
   }
 }
 

--- a/variables-containers.tf
+++ b/variables-containers.tf
@@ -11,9 +11,17 @@ variable "containers" {
 
     # Service VLAN name (required). Selects the guest's subnet + 802.1Q tag:
     # IP = cidrhost(network_cidrs[vlan], vm_id) (unless ip_config.ipv4_address pins a
-    # static address); NIC vlan_id = vlan_ids[vlan]. Must be a key in network_cidrs;
-    # a key ABSENT from vlan_ids yields an UNTAGGED NIC (native VLAN, e.g. mgmt_native).
+    # static address, or dhcp = true); NIC vlan_id = vlan_ids[vlan]. Must be a key in
+    # network_cidrs; a key ABSENT from vlan_ids yields an UNTAGGED NIC (native VLAN,
+    # e.g. mgmt_native).
     vlan = string
+
+    # DNS-first addressing (see docs vmid-network-tiers). When true the guest takes
+    # its address by DHCP and is referenced by FQDN ({hostname}.{domain}) everywhere
+    # — no vm_id-derived IP is computed, so the guest may carry a 6-digit positional
+    # VMID that the /24 cidrhost math could not express. DNS owns the address; the
+    # guest stays reachable across re-IP/rebuild. Defaults false (legacy static IP).
+    dhcp = optional(bool, false)
 
     # Node placement (optional). When unset, main.tf defaults to var.proxmox_node
     # (the primary node). Set to "proxmox-2"/"proxmox-3" to place an LXC on another cluster node.


### PR DESCRIPTION
Applies the VMID & network-tier convention (docs.jacobpevans.com/infrastructure/vmid-network-tiers) to the network-quality monitoring stack. Follow-up to #403, which merged the Prometheus-native hardening while these guests were still on the legacy 3-digit / vm_id-derived-static-IP scheme.

## What changes

The `smokeping` / `speedtest` / `netq-probe-media` LXCs adopt:

- **6-digit positional VMIDs** (observability = tier 4 → `41xxxx`): smokeping `412000`, netq-probe-media `415000`, speedtest `416000`.
- **DHCP + DNS-first addressing** (`dhcp: true`): no vm_id-derived IP; each guest is referenced by FQDN (`{hostname}.{domain}`) so it stays reachable across re-IP / rebuild. DNS owns the lease.

VLANs stay at today's values during the incremental tier renumber the convention defers to a later phase.

## Module support added

A 6-digit VMID overflows the `/24` `cidrhost()` host space and breaks the `256 - vm_id` startup-order math, so DHCP could not be config-only:

- `dhcp` flag added to the container schema. When set, `locals.tf` **skips `cidrhost()`** (a ternary short-circuits, so the overflow never evaluates) and emits `ipv4 { address = "dhcp" }` with a null gateway (the lease provides one).
- New `container_address` local resolves a guest to its derived IP (static) or FQDN (DHCP); the inventory `ip` field and the Traefik ingress backend both consume it (same hostname-not-IP shape the Proxmox apex pool already uses).
- Startup order clamped at `0` so 6-digit IDs don't go negative; legacy `<256` IDs are unaffected.

## Side effect

Retires the illustrative mgmt `vm_id 197` collision (`speedtest` vacates 197).

## Validation

- `tofu fmt` + `tofu validate`: clean.
- `tofu test`: the convention logic (DHCP skips cidrhost, FQDN resolution, null gateway, ingress FQDN backend) passes; new + updated assertions in `tests/locals.tftest.hcl` and `tests/ansible_inventory_contract.tftest.hcl`. The full local suite now needs AWS creds (the inventory S3-publish resource from #404), so the complete run is left to CI's OIDC-authenticated job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)