### PR TITLE
fix(firewall): allow inbound HEC on cribl_edge for netmon probers

### DIFF
--- a/modules/firewall/locals.tf
+++ b/modules/firewall/locals.tf
@@ -64,6 +64,7 @@ locals {
   pipeline_services_rules = [
     { proto = "tcp", dport = tostring(local.svc_ports.haproxy_stats), source = local.internal_src, comment = "HAProxy stats from internal" },
     { proto = "tcp", dport = tostring(local.svc_ports.cribl_edge_api), source = local.internal_src, comment = "Cribl Edge API from internal" },
+    { proto = "tcp", dport = tostring(local.svc_ports.splunk_hec), source = local.internal_src, comment = "Cribl Edge HEC input (netmon Telegraf push, reuses the splunk_hec port) from internal" },
   ]
 
   netflow_rules = [

--- a/modules/firewall/tests/rule_generation.tftest.hcl
+++ b/modules/firewall/tests/rule_generation.tftest.hcl
@@ -23,6 +23,8 @@ variables {
       minio_api         = 9000
       minio_console     = 9001
       infisical_api     = 8080
+      openbao_api       = 8200
+      openbao_cluster   = 8201
       postgres_default  = 5432
       redis_default     = 6379
       ntp               = 123
@@ -103,17 +105,17 @@ run "syslog_rules_always_four" {
   }
 }
 
-run "pipeline_services_rules_always_two" {
+run "pipeline_services_rules_always_three" {
   command = plan
 
   variables {
     internal_networks = ["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"]
   }
 
-  # HAProxy stats (8404) + Cribl Edge API (9000)
+  # HAProxy stats (8404) + Cribl Edge API (9420) + Cribl Edge HEC input (8088)
   assert {
-    condition     = length(local.pipeline_services_rules) == 2
-    error_message = "pipeline_services_rules must be exactly 2, got ${length(local.pipeline_services_rules)}"
+    condition     = length(local.pipeline_services_rules) == 3
+    error_message = "pipeline_services_rules must be exactly 3, got ${length(local.pipeline_services_rules)}"
   }
 }
 


### PR DESCRIPTION
Deployment-review fix found while reviewing the netmon collection path (ansible-proxmox-apps #383/#386).

## Problem

The netmon per-WAN probers push Splunk-HEC to Cribl Edge on the HEC port, but the pipeline containers (HAProxy + Cribl Edge) run `input_policy = DROP` and only allow inbound **syslog (1514-1518)** and the **Cribl Edge API (9420)**. Nothing opens the HEC port, so the probers' delivery would be silently dropped.

## Change

- Add the HEC port to `pipeline_services_rules` (`modules/firewall/locals.tf`), sourced from the `splunk_hec` constant (8088 — the same port the apps `cribl_hec_input_port` reuses) and scoped to internal networks, matching the existing inbound rules.
- **Pre-existing fixture fix:** `modules/firewall/tests/rule_generation.tftest.hcl`'s `pipeline_constants` was missing `openbao_api`/`openbao_cluster` (added to the firewall locals by the OpenBao work but never to the fixture), which broke this module test on its own. Added them, and bumped the `pipeline_services_rules` count assertion 2 → 3.

## Verification

- `tofu validate` + `tofu fmt`: clean.
- `modules/firewall` test suite: **20 passed, 0 failed** (was failing on the stale openbao fixture).
- Root `tofu test` is AWS-gated locally; CI's OIDC job covers it.

## Scope note

This is inert until the netmon probers are added to the live `deployment.json` and applied, and the per-WAN source routing lands in tofu-unifi (held). It removes one of those gates ahead of time. The `modules/firewall/tests/` suite is **not run by the root `tofu test`** CI step — surfaced here because the fixture was already stale; making it CI-run is a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)