### PR TITLE
fix(ci): repoint retrigger-pr-checks to same-org .github

### DIFF
--- a/.github/workflows/retrigger-pr-checks.yml
+++ b/.github/workflows/retrigger-pr-checks.yml
@@ -1,8 +1,8 @@
 name: Retrigger PR Checks
 
 # Ensures bot-created PRs (GITHUB_TOKEN) get the Merge Gate check.
-# Calls shared logic from JacobPEvans-personal/.github.
-# See: .github/workflows/_retrigger-pr-checks.yml in JacobPEvans-personal/.github
+# Calls shared logic from JacobPEvans/.github.
+# See: .github/workflows/_retrigger-pr-checks.yml in JacobPEvans/.github
 
 on:
   schedule:
@@ -17,6 +17,6 @@ permissions:
 
 jobs:
   retrigger:
-    uses: JacobPEvans-personal/.github/.github/workflows/_retrigger-pr-checks.yml@main
+    uses: JacobPEvans/.github/.github/workflows/_retrigger-pr-checks.yml@main
     secrets:
       GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## What

Repoint the **Retrigger PR Checks** workflow's reusable-workflow `uses:` from the
cross-account `JacobPEvans-personal/.github` to the same-org `JacobPEvans/.github`.

## Why

Every scheduled run of `Retrigger PR Checks` has failed with `startup_failure`
(5/5 recent runs). GitHub could not load the reusable workflow at startup because
`JacobPEvans-personal/.github` is a different account left over from the
2026-05-28 org migration (`JacobPEvans` -> `dryvist` org / `JacobPEvans-personal`).

`JacobPEvans/.github` is the exact ref the repo's **working** workflows already use
(`gh-aw-pin-refresh.yml`, `repo-health-audit.md`) and it resolves via redirect to
the same-org `.github` with no startup failure. The reusable
`_retrigger-pr-checks.yml@main` is present there at the same SHA as the personal
account, so behavior is unchanged — only the owner the caller can load is fixed.

Matches the repo convention and respects the workspace rule against mass-rewriting
`JacobPEvans/*` -> `dryvist/*` on sight.

## Verification

`startup_failure` is only exercised on schedule/dispatch, not by normal PR checks.
Verified live by dispatching the workflow on this branch and confirming the run
reaches its job instead of failing at startup (see PR thread).

## Scope note

This is one of several pre-existing, migration-era CI failures surfaced while
reviewing post-merge CI. The remaining ones (gh-aw pin-refresh broken fleet-wide ->
stale locks failing Repo Health Audit; persistent agent-level workflow failures)
are rooted in the central `JacobPEvans/.github` framework and are tracked separately
rather than hand-patched per repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
