### PR TITLE
fix(ci): grant actions:read to retrigger-pr-checks caller

### DIFF
--- a/.github/workflows/retrigger-pr-checks.yml
+++ b/.github/workflows/retrigger-pr-checks.yml
@@ -12,6 +12,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
   pull-requests: read
 


### PR DESCRIPTION
## What

Add `actions: read` to the **Retrigger PR Checks** caller's `permissions:` block.

## Why

Every scheduled run failed with `startup_failure` (5/5 recent runs). The reusable
workflow it calls (`JacobPEvans-personal/.github` `_retrigger-pr-checks.yml`)
declares its job with:

```yaml
permissions:
  actions: read
  contents: read
  pull-requests: read
```

The caller granted only `contents: read` + `pull-requests: read`. A reusable
workflow's job cannot request a permission the caller didn't grant — requesting
`actions: read` against a caller that scoped it to `none` is a permission
escalation, which GitHub rejects **at startup** (no jobs ever run). Adding
`actions: read` to the caller resolves it.

The `uses:` ref and secrets are unchanged and correct — the secret
`GH_APP_PRIVATE_KEY` and variable `GH_APP_CLIENT_ID` both exist in this repo.

## Verified live

`startup_failure` only manifests on schedule/dispatch, so I dispatched this branch:

- **Before** (`main`, dispatch): `startup_failure`, zero jobs.
- **After** (this branch, dispatch run 27307039085): startup cleared — the
  `retrigger / Retrigger Missing CI Gate` job now **executes**.

## Known downstream blocker (NOT fixed here — needs org-admin action)

With startup fixed, the job now reaches and fails at **Generate GitHub App Token**:

```
Failed to create token for "dryvist/terraform-proxmox": Not Found (404)
get-a-repository-installation-for-the-authenticated-app
```

The App's JWT auth succeeds (otherwise 401), so the credentials are valid — the
App (client-id `Iv23li1hLRLXXMeXwO6f`) is simply **not installed on the `dryvist`
org / this repo** after the 2026-05-28 account migration. Installing it is a
GitHub UI/admin action, not a code change, and it blocks every app-token-dependent
automation across the fleet. Tracked in the gh-aw/migration triage issue. This PR
is still correct and required — without `actions: read` the workflow can never get
past startup even once the App is installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
