### PR TITLE
feat(vm): explicit guest DNS servers derived from the DNS containers

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -64,6 +64,16 @@ locals {
   # VGA type validation helper
   valid_vga_types = ["std", "cirrus", "vmware", "qxl"]
 
+  # Resolver list for guest cloud-init DNS: Technitium primary, Pi-hole
+  # secondary. Derived via container_ipv4 (honors static ip pins) so no
+  # literal resolver IPs exist anywhere in the repo. Containers inherit the
+  # node's resolv.conf instead; this feeds VMs only.
+  dns_servers = [
+    for name in ["technitium-dns", "pi-hole"] :
+    split("/", local.container_ipv4[name])[0]
+    if contains(keys(var.containers), name)
+  ]
+
   # Internal networks for guest-firewall source scoping — derived from the
   # Doppler-sourced per-VLAN CIDR map (the existing single source of truth),
   # so the real ranges never appear in committed files. nonsensitive(): the

--- a/main.tf
+++ b/main.tf
@@ -89,6 +89,7 @@ module "vms" {
   environment       = var.environment
   default_datastore = var.datastore_default
   domain            = var.domain
+  dns_servers       = local.dns_servers
 
   # SSH credentials for provisioners (BPG provider reads auth from PROXMOX_VE_* env vars)
   proxmox_ssh_username    = var.proxmox_ssh_username
@@ -159,6 +160,7 @@ module "splunk_vm" {
   cpu_cores      = var.splunk_cpu_cores
   memory         = var.splunk_memory
   domain         = var.domain
+  dns_servers    = local.dns_servers
 
   depends_on = [module.pools]
 }

--- a/modules/proxmox-vm/main.tf
+++ b/modules/proxmox-vm/main.tf
@@ -111,11 +111,15 @@ resource "proxmox_virtual_environment_vm" "vms" {
   initialization {
     datastore_id = var.default_datastore
 
-    # DNS search domain for FQDN resolution
+    # DNS search domain + explicit resolvers for FQDN resolution. Without
+    # servers, guests inherit the node's resolvers at provision time and
+    # silently keep them forever — stale-resolver drift broke docker-host
+    # DNS entirely (2026-06-10). Takes effect on cloud-init re-run/reboot.
     dynamic "dns" {
-      for_each = var.domain != "" ? [1] : []
+      for_each = var.domain != "" || length(var.dns_servers) > 0 ? [1] : []
       content {
-        domain = var.domain
+        domain  = var.domain != "" ? var.domain : null
+        servers = length(var.dns_servers) > 0 ? var.dns_servers : null
       }
     }
 

--- a/modules/proxmox-vm/variables.tf
+++ b/modules/proxmox-vm/variables.tf
@@ -127,3 +127,9 @@ variable "startup_delay" {
   type        = number
   default     = 30
 }
+
+variable "dns_servers" {
+  description = "Resolver IPs for guest cloud-init DNS. Derived by the root module from the DNS containers' addresses — never literals."
+  type        = list(string)
+  default     = []
+}

--- a/modules/splunk-vm/main.tf
+++ b/modules/splunk-vm/main.tf
@@ -117,6 +117,15 @@ resource "proxmox_virtual_environment_vm" "splunk_vm" {
   initialization {
     datastore_id = var.datastore_id
 
+    # Explicit resolvers — see modules/proxmox-vm for rationale.
+    dynamic "dns" {
+      for_each = var.domain != "" || length(var.dns_servers) > 0 ? [1] : []
+      content {
+        domain  = var.domain != "" ? var.domain : null
+        servers = length(var.dns_servers) > 0 ? var.dns_servers : null
+      }
+    }
+
     ip_config {
       ipv4 {
         address = var.ip_address

--- a/modules/splunk-vm/variables.tf
+++ b/modules/splunk-vm/variables.tf
@@ -165,3 +165,9 @@ variable "memory" {
     error_message = "Memory must be between 1024 MB and 65536 MB."
   }
 }
+
+variable "dns_servers" {
+  description = "Resolver IPs for guest cloud-init DNS. Derived by the root module from the DNS containers' addresses — never literals."
+  type        = list(string)
+  default     = []
+}

--- a/tests/locals.tftest.hcl
+++ b/tests/locals.tftest.hcl
@@ -529,3 +529,33 @@ run "cribl_stream_ids_picks_up_stream_tagged" {
     error_message = "cribl_stream_container_ids should map 'cribl-stream' to vm_id 182"
   }
 }
+
+run "dns_servers_derived_from_dns_containers" {
+  command = plan
+
+  variables {
+    containers = {
+      "technitium-dns" = { vm_id = 103, hostname = "technitium-dns", vlan = "dns", ip_config = { ipv4_address = "192.168.2.2/24" } }
+      "pi-hole"        = { vm_id = 104, hostname = "pi-hole", vlan = "dns" }
+    }
+  }
+
+  # Static pin honored for Technitium; Pi-hole derived from vm_id; order fixed
+  assert {
+    condition     = jsonencode(local.dns_servers) == jsonencode(["192.168.2.2", "192.168.2.104"])
+    error_message = "dns_servers must be [technitium (pinned), pi-hole (derived)], got ${jsonencode(local.dns_servers)}"
+  }
+}
+
+run "dns_servers_empty_without_dns_containers" {
+  command = plan
+
+  variables {
+    containers = {}
+  }
+
+  assert {
+    condition     = length(local.dns_servers) == 0
+    error_message = "dns_servers must be empty with no DNS containers, got ${jsonencode(local.dns_servers)}"
+  }
+}


### PR DESCRIPTION
## Summary

VMs inherit the Proxmox node's resolvers at provision time and keep them forever. docker-host (VM 250) was still pointing at retired VLAN-1-era resolvers — **every DNS lookup on the VM timed out**, which is what crashlooped the GitHub Actions runners (no route to `api.github.com` by name) and would break anything name-based on any VM after a resolver move. This also conflicts with the FQDN-everywhere policy: FQDNs only work when resolvers are right.

- `modules/proxmox-vm` + `modules/splunk-vm`: cloud-init `dns { servers }` support.
- Root: `local.dns_servers` derived from the Technitium + Pi-hole containers' addresses via `container_ipv4` (static pins honored) — no resolver literals in the repo.
- Tests: derivation asserted (static pin first, derived second; empty without DNS containers). 99 root runs pass.

## Apply notes

- Takes effect per-VM on cloud-init re-run/reboot (plan should show in-place `initialization` updates, no replacement).
- docker-host carries an interim netplan override (`60-dns-interim.yaml`, applied live 2026-06-10) that this supersedes — delete it after the apply + reboot.
- docker-host also had a stale `90-static.yaml` netplan with its old VLAN-1 identity (second IP + second default route) — already removed live; backup at `/var/tmp/90-static.yaml.removed-20260610`.

Refs: #416

🤖 Generated with [Claude Code](https://claude.com/claude-code)