### PR TITLE
feat(firewall): cribl_s2s port 10300 for remote Edge -> HAProxy -> Stream

### DIFF
--- a/constants.tf
+++ b/constants.tf
@@ -26,17 +26,19 @@ locals {
       splunk_forwarding = 9997
       cribl_edge_api    = 9420
       cribl_stream_api  = 9000
-      apt_cacher_ng     = 3142
-      minio_api         = 9000
-      minio_console     = 9001
-      infisical_api     = 8080
-      openbao_api       = 8200
-      openbao_cluster   = 8201
-      postgres_default  = 5432
-      redis_default     = 6379
-      ntp               = 123
-      idrac_kvm_r410    = 5410
-      idrac_kvm_r710    = 5710
+      # Cribl-to-Cribl (S2S/TCP-JSON) ingestion: remote Edge nodes -> HAProxy -> Stream
+      cribl_s2s        = 10300
+      apt_cacher_ng    = 3142
+      minio_api        = 9000
+      minio_console    = 9001
+      infisical_api    = 8080
+      openbao_api      = 8200
+      openbao_cluster  = 8201
+      postgres_default = 5432
+      redis_default    = 6379
+      ntp              = 123
+      idrac_kvm_r410   = 5410
+      idrac_kvm_r710   = 5710
       # Web UIs fronted by Traefik that have no other constant home. Kept here so
       # every port lives in one place and the ingress table (below) references
       # constants, never literals.

--- a/modules/firewall/locals.tf
+++ b/modules/firewall/locals.tf
@@ -68,6 +68,7 @@ locals {
     { proto = "tcp", dport = tostring(local.svc_ports.haproxy_stats), source = local.internal_src, comment = "HAProxy stats from internal" },
     { proto = "tcp", dport = tostring(local.svc_ports.cribl_edge_api), source = local.internal_src, comment = "Cribl Edge API from internal" },
     { proto = "tcp", dport = tostring(local.svc_ports.splunk_hec), source = local.internal_src, comment = "Cribl Edge HEC input (netmon Telegraf push, reuses the splunk_hec port) from internal" },
+    { proto = "tcp", dport = tostring(local.svc_ports.cribl_s2s), source = local.internal_src, comment = "Cribl S2S frontend (remote Edge -> HAProxy -> Stream) from internal" },
   ]
 
   netflow_rules = [
@@ -95,6 +96,7 @@ locals {
 
   cribl_stream_services_rules = [
     { proto = "tcp", dport = tostring(local.svc_ports.cribl_stream_api), source = local.internal_src, comment = "Cribl Stream API from internal" },
+    { proto = "tcp", dport = tostring(local.svc_ports.cribl_s2s), source = local.internal_src, comment = "Cribl S2S input (HAProxy -> Stream) from internal" },
   ]
 
   minio_services_rules = [


### PR DESCRIPTION
## What

- `service_ports.cribl_s2s = 10300` in constants (single source for downstream ansible repos via the inventory contract).
- Firewall: `pipeline_services` group accepts tcp/10300 from internal (HAProxy frontend); `cribl_stream_services` group accepts tcp/10300 from internal (Stream input behind HAProxy).

## How

Remote Cribl Edge nodes ship events over Cribl TCP (S2S) to a HAProxy frontend on :10300, which load-balances across the Cribl Stream workers; Stream forwards to Splunk HEC. Companion config lands in ansible-proxmox-apps (HAProxy frontend/backend + Stream input).

## Apply

`terragrunt apply` (state-backend credentials required), then the ansible-proxmox-apps run.

Refs: dryvist/ansible-splunk#246

🤖 Generated with [Claude Code](https://claude.com/claude-code)