### PR TITLE
feat(storage): document the databases dataset shape in deployment.json.example

### DIFF
--- a/deployment.json.example
+++ b/deployment.json.example
@@ -41,6 +41,7 @@
           "content": ["images", "rootdir"],
           "datasets": {
             "backups": { "quota": "1T", "properties": { "compression": "zstd" } },
+            "databases": { "quota": "1T", "nfs_export": "ro=@10.0.0.0/8", "properties": { "recordsize": "16K", "atime": "off", "compression": "zstd" } },
             "media/tv": { "quota": "2T", "properties": { "recordsize": "1M", "compression": "zstd" } },
             "media/movies": { "quota": "2T", "properties": { "recordsize": "1M", "compression": "zstd" } }
           }


### PR DESCRIPTION
## Why

The live (local-only) `deployment.json` now declares `node_storage.pve2.pools.bulk.datasets.databases` — the generic database warm-standby area (dryvist/ansible-proxmox#263) that was created live but undeclared. The public example should document the shape, including the `nfs_export` field (exact `zfs sharenfs` string) that the ansible `zfs_pools` role realizes.

## What

One example line under `node_storage`: a `databases` dataset with `quota`, `nfs_export`, and SQLite-tuned `properties` (recordsize 16K, atime off, zstd).

The next `terragrunt apply` publishes the declared dataset through the S3 inventory (#404) and the ansible run converges it — closing the loop on the previously-unmanaged live dataset.

Refs: dryvist/ansible-proxmox#263, #404, dryvist/ansible-proxmox#266

🤖 Generated with [Claude Code](https://claude.com/claude-code)