### PR TITLE
feat(containers): deterministic MAC + reserved-IP contract for DHCP-first guests

### DIFF
--- a/deployment.json.example
+++ b/deployment.json.example
@@ -123,6 +123,7 @@
     "smokeping": {
       "vm_id": 412000,
       "dhcp": true,
+      "reserved_host": 30,
       "vlan": "mgmt",
       "hostname": "smokeping",
       "description": "Central network-quality stack: smokeping_prober + blackbox_exporter + atlas_exporter + irtt server (+ optional SmokePing UI). Scraped by Prometheus.",
@@ -137,6 +138,7 @@
     "speedtest": {
       "vm_id": 416000,
       "dhcp": true,
+      "reserved_host": 31,
       "vlan": "mgmt",
       "hostname": "speedtest",
       "description": "Decoupled throughput exporter (speedtest-exporter :9798). Separate host (pin off the prober's node) so a saturating speedtest never corrupts latency/loss probes. Scrape hourly, off-peak.",
@@ -152,6 +154,7 @@
     "netq-probe-media": {
       "vm_id": 415000,
       "dhcp": true,
+      "reserved_host": 32,
       "vlan": "media_svc",
       "hostname": "netq-probe-media",
       "description": "Per-segment vantage prober (smokeping_prober + blackbox_exporter + irtt) measuring network quality FROM the media VLAN's perspective. Clone one per VLAN you care about — mgmt-only probing can't see each segment's real path. Add a WAN-edge vantage for true ISP-link quality.",

--- a/inventory_publish.tf
+++ b/inventory_publish.tf
@@ -18,7 +18,12 @@ locals {
         vmid     = v.id
         hostname = var.containers[k].hostname
         ip       = local.container_address[k] # static: per-VLAN cidrhost IP (CIDR stripped); DHCP guests: FQDN (DNS-first)
-        node     = v.node_name
+        # Deterministic MAC + reserved IP for DHCP-first guests (both null for
+        # static guests). tofu-unifi reads {mac, reserved_ip} to build the DHCP
+        # reservation; the technitium_dns role points the A record at reserved_ip.
+        mac         = try(var.containers[k].dhcp, false) ? local.container_mac[k] : null
+        reserved_ip = local.container_reserved_ip[k]
+        node        = v.node_name
         # Connection settings for proxmox_pct_remote (community.proxmox)
         ansible_connection = "community.proxmox.proxmox_pct_remote"
         ansible_pct_vmid   = v.id

--- a/locals.tf
+++ b/locals.tf
@@ -41,6 +41,35 @@ locals {
     )
   }
 
+  # Deterministic, locally-administered MAC per DHCP-first guest. The `02:` prefix
+  # marks it locally-administered + unicast (RFC 7042). The remaining 5 octets are
+  # a stable digest of the hostname, so the MAC is reproducible across rebuilds and
+  # plan runs WITHOUT reading provider state. This is the join key downstream:
+  # tofu-unifi pins this MAC to container_reserved_ip (DHCP reservation) and the
+  # technitium_dns role points the A record at the same address. We set it on the
+  # NIC explicitly because bpg/proxmox auto-generates a random MAC otherwise and
+  # (v0.90+) does not expose it as an output — leaving nothing stable to reserve.
+  container_mac = {
+    for k, v in var.containers : k => format("02:%s:%s:%s:%s:%s",
+      substr(md5(v.hostname), 0, 2), substr(md5(v.hostname), 2, 2),
+      substr(md5(v.hostname), 4, 2), substr(md5(v.hostname), 6, 2),
+    substr(md5(v.hostname), 8, 2))
+  }
+
+  # Reserved IP for DHCP-first guests that declare a reserved_host octet. This is
+  # the address tofu-unifi pins the MAC to and the DNS A record resolves to. It is
+  # decoupled from the (possibly 6-digit) positional vm_id: reserved_host is a real
+  # host octet within the guest's VLAN /24, so cidrhost stays in range. Static
+  # guests and DHCP guests with no reserved_host resolve to null (they advertise an
+  # IP or FQDN via container_address instead). nonsensitive(): a single host address
+  # is not independently secret and must flow into the non-sensitive inventory.
+  container_reserved_ip = {
+    for k, v in var.containers : k => (
+      try(v.dhcp, false) && try(v.reserved_host, null) != null
+      ? nonsensitive(cidrhost(var.network_cidrs[v.vlan], v.reserved_host)) : null
+    )
+  }
+
   # Reachable address each container advertises to downstream consumers (the
   # ansible_inventory ip field and the Traefik ingress backend). Static guests
   # advertise their derived host IP (CIDR mask stripped); DNS-first guests

--- a/main.tf
+++ b/main.tf
@@ -116,8 +116,14 @@ module "containers" {
         ipv4_gateway = local.container_gateway[k]
       }
       # Tag every NIC onto the LXC's service VLAN (802.1Q id from var.vlan_ids).
+      # DHCP-first guests also get a deterministic MAC (local.container_mac) so
+      # tofu-unifi can pin a stable DHCP reservation; static guests keep a null MAC
+      # (provider auto-generates) so they are not replaced.
       network_interfaces = [
-        for ni in v.network_interfaces : merge(ni, { vlan_id = lookup(var.vlan_ids, v.vlan, null) })
+        for ni in v.network_interfaces : merge(ni, {
+          vlan_id     = lookup(var.vlan_ids, v.vlan, null)
+          mac_address = try(v.dhcp, false) ? local.container_mac[k] : null
+        })
       ]
       # DRY: Always inject SSH key for Ansible access
       # Uses container's password/keys if specified, otherwise empty password with SSH key only

--- a/modules/proxmox-container/main.tf
+++ b/modules/proxmox-container/main.tf
@@ -127,6 +127,9 @@ resource "proxmox_virtual_environment_container" "containers" {
       bridge   = network_interface.value.bridge
       firewall = network_interface.value.firewall
       vlan_id  = network_interface.value.vlan_id
+      # Deterministic MAC for DHCP-first guests; null for static guests lets the
+      # provider keep its auto-generated MAC (no churn on existing containers).
+      mac_address = network_interface.value.mac_address
     }
   }
 

--- a/modules/proxmox-container/variables.tf
+++ b/modules/proxmox-container/variables.tf
@@ -49,6 +49,10 @@ variable "containers" {
       bridge   = optional(string, "vmbr0")
       firewall = optional(bool, true)
       vlan_id  = optional(number)
+      # Deterministic MAC for DHCP-first guests (set by the root module from
+      # local.container_mac). Null for static guests, so the provider keeps
+      # auto-generating their MAC and existing containers are not disrupted.
+      mac_address = optional(string)
     })), [{ name = "eth0", bridge = "vmbr0", firewall = true }])
 
     # Initialization

--- a/tests/ansible_inventory_contract.tftest.hcl
+++ b/tests/ansible_inventory_contract.tftest.hcl
@@ -303,11 +303,12 @@ run "ansible_inventory_ingress_route_table" {
       # Network-quality monitoring LXC — DNS-first (dhcp) with a 6-digit positional
       # VMID (observability tier 4). No vm_id-derived IP; fronted by FQDN.
       "smokeping" = {
-        vm_id    = 412000
-        dhcp     = true
-        hostname = "smokeping"
-        vlan     = "mgmt"
-        tags     = ["terraform", "container", "monitoring", "docker"]
+        vm_id         = 412000
+        dhcp          = true
+        reserved_host = 30
+        hostname      = "smokeping"
+        vlan          = "mgmt"
+        tags          = ["terraform", "container", "monitoring", "docker"]
       }
     }
     domain = "example.com"

--- a/tests/locals.tftest.hcl
+++ b/tests/locals.tftest.hcl
@@ -453,11 +453,12 @@ run "monitoring_ids_picks_up_monitoring_tagged" {
   variables {
     containers = {
       "smokeping" = {
-        vm_id    = 412000
-        dhcp     = true
-        hostname = "smokeping"
-        vlan     = "mgmt"
-        tags     = ["terraform", "container", "monitoring", "docker"]
+        vm_id         = 412000
+        dhcp          = true
+        reserved_host = 30
+        hostname      = "smokeping"
+        vlan          = "mgmt"
+        tags          = ["terraform", "container", "monitoring", "docker"]
       }
     }
   }
@@ -485,11 +486,12 @@ run "container_dhcp_resolves_fqdn_and_null_gateway" {
     domain = "example.com"
     containers = {
       "speedtest" = {
-        vm_id    = 416000
-        dhcp     = true
-        hostname = "speedtest"
-        vlan     = "mgmt"
-        tags     = ["terraform", "container", "monitoring", "docker"]
+        vm_id         = 416000
+        dhcp          = true
+        reserved_host = 31
+        hostname      = "speedtest"
+        vlan          = "mgmt"
+        tags          = ["terraform", "container", "monitoring", "docker"]
       }
     }
   }
@@ -557,5 +559,103 @@ run "dns_servers_empty_without_dns_containers" {
   assert {
     condition     = length(local.dns_servers) == 0
     error_message = "dns_servers must be empty with no DNS containers, got ${jsonencode(local.dns_servers)}"
+  }
+}
+
+# --- deterministic MAC + reserved IP contract (DHCP-first guests) ---
+#
+# DHCP-first LXCs carry a stable, locally-administered MAC (02:-prefixed digest of
+# the hostname) and a reserved IP derived from reserved_host (NOT the 6-digit
+# positional vm_id). tofu-unifi pins MAC -> reserved_ip; technitium_dns points the
+# A record at reserved_ip. Static guests get a null reserved_ip.
+
+run "container_mac_is_deterministic_locally_administered" {
+  command = plan
+
+  variables {
+    containers = {
+      "smokeping" = {
+        vm_id         = 412000
+        dhcp          = true
+        reserved_host = 30
+        hostname      = "smokeping"
+        vlan          = "mgmt"
+        tags          = ["terraform", "container", "monitoring", "docker"]
+      }
+    }
+  }
+
+  # 02: prefix => locally-administered + unicast (RFC 7042).
+  assert {
+    condition     = startswith(local.container_mac["smokeping"], "02:")
+    error_message = "container_mac must be locally-administered (02:-prefixed), got ${local.container_mac["smokeping"]}"
+  }
+
+  # Canonical 6-octet colon-separated form (17 chars: 02 + 5*':'+2 hex).
+  assert {
+    condition     = length(local.container_mac["smokeping"]) == 17
+    error_message = "container_mac must be a 17-char MAC (02:xx:xx:xx:xx:xx), got ${local.container_mac["smokeping"]}"
+  }
+
+  # Deterministic: equals the md5-digest format() recomputed from the same hostname.
+  assert {
+    condition = local.container_mac["smokeping"] == format("02:%s:%s:%s:%s:%s",
+      substr(md5("smokeping"), 0, 2), substr(md5("smokeping"), 2, 2),
+    substr(md5("smokeping"), 4, 2), substr(md5("smokeping"), 6, 2), substr(md5("smokeping"), 8, 2))
+    error_message = "container_mac must be the deterministic md5(hostname) digest, got ${local.container_mac["smokeping"]}"
+  }
+}
+
+run "container_reserved_ip_from_reserved_host" {
+  command = plan
+
+  variables {
+    containers = {
+      # DHCP-first media-VLAN guest: reserved_host 210 -> 192.168.55.210, decoupled
+      # from the 6-digit positional vm_id (which the /24 cidrhost math can't express).
+      "netq-probe-media" = {
+        vm_id         = 415000
+        dhcp          = true
+        reserved_host = 210
+        hostname      = "netq-probe-media"
+        vlan          = "media_svc"
+        tags          = ["terraform", "container", "monitoring", "docker"]
+      }
+      # Static guest: no reserved_ip (advertises its derived IP instead).
+      "haproxy" = {
+        vm_id    = 175
+        hostname = "haproxy"
+        vlan     = "pipeline"
+      }
+    }
+  }
+
+  # media_svc id 55 -> 192.168.55.0/24; reserved_host 210 -> 192.168.55.210.
+  assert {
+    condition     = local.container_reserved_ip["netq-probe-media"] == "192.168.55.210"
+    error_message = "dhcp guest reserved_host 210 on media_svc must yield 192.168.55.210, got ${local.container_reserved_ip["netq-probe-media"]}"
+  }
+
+  # Static guest has no reservation.
+  assert {
+    condition     = local.container_reserved_ip["haproxy"] == null
+    error_message = "static guest must have reserved_ip = null"
+  }
+
+  # Static guest also carries no DHCP MAC in the inventory export.
+  assert {
+    condition     = output.ansible_inventory.containers["haproxy"].mac == null
+    error_message = "static guest inventory mac must be null"
+  }
+
+  # DHCP guest surfaces both mac and reserved_ip in the inventory export.
+  assert {
+    condition     = output.ansible_inventory.containers["netq-probe-media"].reserved_ip == "192.168.55.210"
+    error_message = "dhcp guest inventory reserved_ip must be 192.168.55.210, got ${output.ansible_inventory.containers["netq-probe-media"].reserved_ip}"
+  }
+
+  assert {
+    condition     = startswith(output.ansible_inventory.containers["netq-probe-media"].mac, "02:")
+    error_message = "dhcp guest inventory mac must be the 02:-prefixed deterministic MAC"
   }
 }

--- a/variables-containers.tf
+++ b/variables-containers.tf
@@ -23,6 +23,13 @@ variable "containers" {
     # guest stays reachable across re-IP/rebuild. Defaults false (legacy static IP).
     dhcp = optional(bool, false)
 
+    # DHCP-reservation host octet for dhcp guests. UniFi pins the guest's
+    # deterministic MAC (local.container_mac) to cidrhost(network_cidrs[vlan],
+    # reserved_host), and the DNS A record points at that same address. Decoupled
+    # from the 6-digit positional vm_id so the reserved address is a real host in the
+    # guest's VLAN /24. Required whenever dhcp = true (see the validation below).
+    reserved_host = optional(number)
+
     # Node placement (optional). When unset, main.tf defaults to var.proxmox_node
     # (the primary node). Set to "proxmox-2"/"proxmox-3" to place an LXC on another cluster node.
     node_name = optional(string)
@@ -112,5 +119,12 @@ variable "containers" {
       for k, v in var.containers : v.memory_dedicated >= 64 && v.memory_dedicated <= 65536
     ])
     error_message = "Container memory must be between 64 MB and 64 GB."
+  }
+
+  validation {
+    condition = alltrue([
+      for k, v in var.containers : try(v.reserved_host, null) != null if try(v.dhcp, false)
+    ])
+    error_message = "Every dhcp = true container must set reserved_host: it is the host octet UniFi pins the deterministic MAC to (DHCP reservation) and the DNS A record resolves to."
   }
 }


### PR DESCRIPTION
## What
A deterministic-MAC + reserved-IP contract so DHCP/DNS-first LXC guests have a stable MAC and reserved IP that downstream consumers can pin.

## Why
bpg/proxmox auto-generates a random MAC per container and (v0.90+) doesn't expose it as an output, so there's nothing stable for a UniFi DHCP reservation or a DNS A record to target. This contract is the prerequisite for migrating `dhcp` guests (e.g. the 6-digit media stack) to reservation-based addressing.

## Contract
- `local.container_mac` — `02:`-prefixed `md5(hostname)` digest (locally administered, unicast, reproducible without reading provider state).
- `reserved_host` (new optional container field) → `local.container_reserved_ip` = `cidrhost(network_cidrs[vlan], reserved_host)`. Decoupled from the (possibly 6-digit) `vm_id`. Required whenever `dhcp = true`.
- `ansible_inventory.containers[k]` now carries `{ mac, reserved_ip }` (both null for static guests) — tofu-unifi builds the reservation from them; the `technitium_dns` role points the A record at `reserved_ip`.

## Non-destructive
MAC is set on the NIC ONLY for `dhcp = true` guests; static containers keep a null `mac_address` so the provider keeps their existing MAC (no replacement).

## Validation
`tofu fmt`/`validate` clean; `tofu test` **101 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)