### PR TITLE
fix(vm): ignore cloud-init dns drift to avoid rebuilding the non-removable ide2 drive

### DIFF
--- a/modules/proxmox-vm/.terraform.lock.hcl
+++ b/modules/proxmox-vm/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/bpg/proxmox" {
+  version     = "0.109.0"
+  constraints = "~> 0.106"
+  hashes = [
+    "h1:7WUepUyfX6ss8bmtp0YJRgfJfmwutG+bSq0ZGTHh9L4=",
+    "zh:05b1e1e8c149be25e151f5c0e76cf94cb9b61979b962778ae79b27182961ebe6",
+    "zh:471650b7477343423f0e700c85fb5cbc309f72e490314db839885be7c0a161d0",
+    "zh:51298968a55885158ac51015deb59b3d5ed65b5f4141026f43ed63a37d54e002",
+    "zh:53baf9ff5fc803a35dc387f9424fc7c522d9d726aed69752445e08777db4e738",
+    "zh:55f5d4e0517bf6b6eb45250d18a7664302bebd4903a7792ae3d740c44daeb4a6",
+    "zh:617078968329ea54ce7e3c44f6a1a1b7c4577e1556a5f63c8e5ceab083621162",
+    "zh:974e71c86ea4831524b266e29bb525af40b22563669fa261626f6738fef764d5",
+    "zh:a23795985630c54e91a14dbd5543ec7dcab9246b450aa95f8afab513b3860a84",
+    "zh:b0677349053af1a0ef90bbfbeeff4a4525465d3d6ce1c330337aeb1babe4a92a",
+    "zh:ce9eb7354cde44aca3ebbf5146a254f49558e4467f4d10eec7d6e1b54ff16dfa",
+    "zh:e17b54ac5e12097118d60e4d12e87f4ed468c2cd8e565689bc3bc8de245cd0b1",
+    "zh:e91bffd3b4b9797143ae99ad9b0c8bdd86fcf798de40fc7a2b20372767b2a20c",
+    "zh:ef0ab1755de3ef478d88a129b6e60fbb6477fb833c738fcc5f79a74b83d93dfb",
+    "zh:f26e0763dbe6a6b2195c94b44696f2110f7f55433dc142839be16b9697fa5597",
+  ]
+}

--- a/modules/proxmox-vm/main.tf
+++ b/modules/proxmox-vm/main.tf
@@ -170,6 +170,12 @@ resource "proxmox_virtual_environment_vm" "vms" {
       # ip_config — ignore it so bpg does not rebuild the cloud-init drive
       # (which fails: the ide2 cloud-init disk is not removable on a running VM).
       initialization[0].ip_config,
+      # Same failure mode for resolvers: a dns diff (e.g. changing the explicit
+      # DNS-server derivation) makes bpg rebuild the non-removable ide2 drive on
+      # every running VM — that is what broke the 2026-06-11 full apply. New VMs
+      # pick up the dns block at first boot; existing VMs get resolvers via
+      # Ansible post-boot.
+      initialization[0].dns,
     ]
   }
 

--- a/modules/splunk-vm/.terraform.lock.hcl
+++ b/modules/splunk-vm/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/bpg/proxmox" {
+  version     = "0.109.0"
+  constraints = "~> 0.106"
+  hashes = [
+    "h1:7WUepUyfX6ss8bmtp0YJRgfJfmwutG+bSq0ZGTHh9L4=",
+    "zh:05b1e1e8c149be25e151f5c0e76cf94cb9b61979b962778ae79b27182961ebe6",
+    "zh:471650b7477343423f0e700c85fb5cbc309f72e490314db839885be7c0a161d0",
+    "zh:51298968a55885158ac51015deb59b3d5ed65b5f4141026f43ed63a37d54e002",
+    "zh:53baf9ff5fc803a35dc387f9424fc7c522d9d726aed69752445e08777db4e738",
+    "zh:55f5d4e0517bf6b6eb45250d18a7664302bebd4903a7792ae3d740c44daeb4a6",
+    "zh:617078968329ea54ce7e3c44f6a1a1b7c4577e1556a5f63c8e5ceab083621162",
+    "zh:974e71c86ea4831524b266e29bb525af40b22563669fa261626f6738fef764d5",
+    "zh:a23795985630c54e91a14dbd5543ec7dcab9246b450aa95f8afab513b3860a84",
+    "zh:b0677349053af1a0ef90bbfbeeff4a4525465d3d6ce1c330337aeb1babe4a92a",
+    "zh:ce9eb7354cde44aca3ebbf5146a254f49558e4467f4d10eec7d6e1b54ff16dfa",
+    "zh:e17b54ac5e12097118d60e4d12e87f4ed468c2cd8e565689bc3bc8de245cd0b1",
+    "zh:e91bffd3b4b9797143ae99ad9b0c8bdd86fcf798de40fc7a2b20372767b2a20c",
+    "zh:ef0ab1755de3ef478d88a129b6e60fbb6477fb833c738fcc5f79a74b83d93dfb",
+    "zh:f26e0763dbe6a6b2195c94b44696f2110f7f55433dc142839be16b9697fa5597",
+  ]
+}

--- a/modules/splunk-vm/main.tf
+++ b/modules/splunk-vm/main.tf
@@ -171,6 +171,11 @@ resource "proxmox_virtual_environment_vm" "splunk_vm" {
       # bpg rebuild the cloud-init drive — and that fails on the non-removable
       # ide2 disk. Ansible owns post-boot networking, so ignore the drift.
       initialization[0].ip_config,
+      # Same failure mode for resolvers: a dns diff makes bpg rebuild the
+      # cloud-init drive too — on THIS VM that rebuild took 15+ minutes and
+      # rebooted production Splunk during the 2026-06-11 apply. Resolvers on the
+      # running VM are Ansible-owned; the dns block only matters at first boot.
+      initialization[0].dns,
       # The live disk layout diverged from this module out-of-band: the boot
       # disk is scsi0/50G (not virtio0/25G), and the empty leftover disk-1 was
       # reaped directly on the host. bpg keys disk blocks positionally and tofu


### PR DESCRIPTION
## Why

#419 derives explicit guest DNS servers in the VM cloud-init `dns` block. On existing VMs that creates a permanent `initialization.dns` diff, and the bpg provider responds by rebuilding the cloud-init drive — which fails on running VMs (\`ide2 is not removable\`, seen on the docker VM) and forced a 15-minute cloud-init rebuild + reboot of production Splunk during the 2026-06-11 full apply. This blocks every clean full apply until guarded.

## What changed

Add \`initialization[0].dns\` to the \`lifecycle.ignore_changes\` lists in \`modules/proxmox-vm\` and \`modules/splunk-vm\`, mirroring the existing \`ip_config\` guard from #366 and the modules' stated philosophy: cloud-init is first-boot only; Ansible owns post-boot config.

- New VMs still get the explicit resolvers at first boot (the \`dns\` block is unchanged).
- Existing VMs keep their current resolvers (the one affected host was already corrected live; Ansible owns this post-boot).
- Containers need no guard — LXC dns changes apply live with no cloud-init drive.

## Risk

Low — \`ignore_changes\` only; no resource or rendering changes. Unblocks the pending full apply of the merged firewall work (#416/#424).

## Verification

\`tofu fmt -check\` and per-module \`tofu validate\` pass locally; CI runs the full static suite. The real proof is the next credentialed \`terragrunt plan\`: it must show security-group changes only, with no VM cloud-init rebuilds.