### PR TITLE
docs(inventory): consumer matrix, env-var contract, DNS-first addressing invariant

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,20 +92,28 @@ containers, IPs, ports, and firewall rules.
 
 ### Downstream repos
 
+All three consumers resolve the inventory the same way (their
+`load_tofu.yml`): `TOFU_INVENTORY_PATH` (explicit pin) → the **S3 published
+artifact** (written natively by every apply via `aws_s3_object`; fetched with
+`amazon.aws` modules — AWS read creds only, no checkout, no toolchain) → the
+local gitignored cache. See `docs/INVENTORY_PUBLISHING.md`.
+
 | Repo | Consumes | Purpose |
 | --- | --- | --- |
-| `ansible-proxmox` | `ansible_inventory.host_services` | Host config (kernel, ZFS, monitoring, NAS/Samba) |
-| `ansible-proxmox-apps` | `ansible_inventory` (containers, docker_vms, constants) | Cribl, HAProxy, DNS, etc. |
+| `ansible-proxmox` | `ansible_inventory` (host_services, node_storage, nodes) | Host config (kernel, ZFS, monitoring, NAS/Samba) |
+| `ansible-proxmox-apps` | `ansible_inventory` (containers, docker_vms, constants, ingress) | Cribl, HAProxy, DNS, etc. |
 | `ansible-splunk` | `ansible_inventory` (splunk_vm) | Splunk Enterprise (Docker) |
 
-### Inventory sync (automatic)
+### Inventory publish + sync (automatic)
 
-`terragrunt.hcl` runs an `after_hook` post-apply (`scripts/sync-inventory.sh`)
-that validates the `ansible_inventory` output against the schema, then
-distributes it to its consumers, writing `tofu_inventory.json`
-to each downstream repo's `inventory/` directory under `$GIT_HOME/<repo>/main/`.
-A partial/invalid output is rejected (nothing written). Repos not cloned locally
-are skipped with a stderr warning.
+Every apply publishes the inventory **natively** to the versioned state bucket
+(`inventory_publish.tf`, `aws_s3_object.ansible_inventory`). The
+`after_hook` (`scripts/sync-inventory.sh`) then validates the output against
+the schema and handles what Terraform can't: the versioned-mirror PR into the
+private data repo (gated on `INVENTORY_DATA_REPO`) and the local
+`tofu_inventory.json` cache each consumer repo's resolver uses as its offline
+fallback. A partial/invalid output is rejected (nothing written). Repos not
+cloned locally are skipped with a stderr warning.
 
 To sync manually after importing state without applying, see
 `docs/ARCHITECTURE.md`.

--- a/docs/INVENTORY_PUBLISHING.md
+++ b/docs/INVENTORY_PUBLISHING.md
@@ -39,29 +39,51 @@ This makes `apply` the single, auditable way to change what every consumer sees.
 
 ## Relationship to `scripts/sync-inventory.sh`
 
-The S3 publish is **native Terraform**. The existing after-hook
-(`scripts/sync-inventory.sh`) is unchanged and still handles the
-distribution targets Terraform cannot, including the local gitignored
-copies for development.
+The S3 publish is **native Terraform**. The after-hook
+(`scripts/sync-inventory.sh`) handles only what Terraform cannot: the
+versioned-mirror PR into the private data repo (gated on the
+`INVENTORY_DATA_REPO` env var) and cache-warming — the local gitignored
+`tofu_inventory.json` each consumer's resolver uses as its offline fallback.
 
 ## IAM
 
-The credentials used for `apply` need `s3:PutObject` (and `s3:GetObject` for
-plan refresh) on `…/terraform-proxmox/inventory/*`; each consumer needs
-`s3:GetObject` on the same key. If the state bucket policy scopes access to the
-`terraform.tfstate` key only, widen it to the `terraform-proxmox/` prefix (or
-the `inventory/` sub-prefix) for these objects.
+The credentials used for `apply` need `s3:PutObject` (and `s3:GetObject` +
+`s3:GetObjectTagging` for plan refresh) on `…/terraform-proxmox/inventory/*`
+(the `tf-proxmox` role carries these via the `s3-inventory-publish` inline
+policy); each consumer needs `s3:GetObject` on the same key.
 
 ## Consuming the inventory
 
-Consumers fetch the raw object and adapt it. Example
-(`ansible-proxmox`'s `playbooks/load_tofu.yml` resolver):
+Every consumer resolves the same way (each repo's `load_tofu.yml`):
 
-1. `TOFU_INVENTORY_PATH` — explicit local file.
+1. `TOFU_INVENTORY_PATH` — explicit local file (pin / tests / overrides).
 2. S3 artifact — fetched natively with `amazon.aws.s3_object` (URI from
    `TOFU_INVENTORY_S3_URI` or derived from the account via
-   `amazon.aws.aws_caller_info`); no `aws` CLI needed.
-3. `inventory/tofu_inventory.json` — local cache.
+   `amazon.aws.aws_caller_info`; region `TOFU_INVENTORY_S3_REGION`,
+   default `us-east-2`); no `aws` CLI needed.
+3. `inventory/tofu_inventory.json` — local cache (written by the after-hook).
 
 A consumer needs only AWS read creds for option 2 — no repo checkout and no
 terraform/terragrunt toolchain.
+
+| Consumer | Resolver | Notes |
+| --- | --- | --- |
+| `ansible-proxmox` | `playbooks/load_tofu.yml` | host_services, node_storage, nodes |
+| `ansible-proxmox-apps` | `inventory/load_tofu.yml` | containers, docker_vms, constants, ingress |
+| `ansible-splunk` | `inventory/load_tofu.yml` | splunk_vm; static fallback `SPLUNK_VM_HOST` else DNS-first `splunk-aio.{PROXMOX_DOMAIN}` |
+
+## Addressing: the inventory carries identity, DNS carries reachability
+
+The artifact stays authoritative for **identity and topology** — VMIDs, tags,
+ports, node placement, storage — which DNS cannot carry. Addresses, however,
+trend DNS-first: `dhcp: true` guests publish `{hostname}.{domain}` as their
+inventory `ip` (see `container_address` in `locals.tf`), and Technitium serves
+A-records derived from this same inventory. Invariants:
+
+- **Bootstrap-pinned hosts stay static-IP forever**: the DNS containers
+  (technitium-dns, pi-hole), the Proxmox nodes, and the Splunk VM — everything
+  that must be reachable before DNS works.
+- Everything else migrates to `dhcp: true` under the VMID/tier convention;
+  its address self-heals via DHCP+DNS even if a consumer's inventory copy lags.
+- A consumer that only needs to *reach a service* (not configure hosts) should
+  use the FQDN and skip the inventory fetch entirely.

--- a/outputs.tf
+++ b/outputs.tf
@@ -78,8 +78,11 @@ output "ansible_inventory" {
   value = local.ansible_inventory
 }
 
-# Rack-server cluster inventory - consumed by ansible-proxmox via terraform_remote_state.
-# Sensitive: BMC IPs/MACs and host mgmt IPs are operational secrets. ansible-proxmox
+# Rack-server cluster inventory - NO consumer yet. When one materializes, it
+# should fetch a published S3 artifact (the ansible_inventory pattern in
+# inventory_publish.tf), not terraform_remote_state — consumers must not need
+# the toolchain or full state read access.
+# Sensitive: BMC IPs/MACs and host mgmt IPs are operational secrets. A consumer
 # must use nonsensitive() when constructing inventory strings from these.
 output "rack_servers" {
   description = "Rack-server identity (names, BMC IPs/MACs, mgmt IPs, service tags, by-chassis grouping, ansible inventory shape). Real values come from terraform.sops.json; when var.rack_servers defaults to an empty map, this output is an object whose collections are all empty."

--- a/scripts/sync-inventory.sh
+++ b/scripts/sync-inventory.sh
@@ -72,7 +72,9 @@ else
   echo "sync-inventory: INVENTORY_DATA_REPO unset or clone not found — skipped versioned commit" >&2
 fi
 
-# Transitional: the gitignored copy each Ansible repo reads today.
+# Cache-warming: the gitignored copy each consumer's resolver uses as its
+# offline fallback (resolution priority 3, after TOFU_INVENTORY_PATH and the
+# S3 artifact).
 for repo in ansible-proxmox ansible-proxmox-apps ansible-splunk; do
   for root in "${GIT_HOME_PUBLIC:-}" "$GIT_HOME"; do
     if [[ -n "$root" && -d "$root/$repo/main/inventory" ]]; then


### PR DESCRIPTION
Documentation pass closing out the inventory consolidation:

- **AGENTS.md**: downstream table updated — all three consumers (ansible-proxmox, ansible-proxmox-apps#397, ansible-splunk#249) resolve the same way: `TOFU_INVENTORY_PATH` → S3 artifact (native `amazon.aws`) → local cache. Publish is native `aws_s3_object`; the after-hook does only the versioned-mirror PR (`INVENTORY_DATA_REPO`) + cache-warming.
- **INVENTORY_PUBLISHING.md**: consumer matrix, shared env-var contract, IAM note (`s3-inventory-publish` inline policy on the tf-proxmox role), and the **addressing invariant**: the inventory carries identity/topology, DNS carries reachability — bootstrap-pinned hosts (DNS containers, Proxmox nodes, Splunk VM) stay static-IP forever; everything else trends `dhcp: true`/DNS-first; reach-a-service consumers should use FQDNs and skip the inventory entirely.
- **outputs.tf**: `rack_servers` comment corrected — no consumer exists; a future one fetches a published S3 artifact, not `terraform_remote_state`.
- **sync-inventory.sh**: comment-only relabel of the local-copy leg (cache-warming).

Verification: `tofu fmt`/`validate` clean; `bash -n` clean; no behavior changes.

Refs: dryvist/ansible-proxmox-apps#397, dryvist/ansible-splunk#249, dryvist/ansible-proxmox#266, #404, #431

🤖 Generated with [Claude Code](https://claude.com/claude-code)