### PR TITLE
fix(ci): repoint shared reusable workflows to dryvist org

### DIFF
--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -90,13 +90,13 @@ jobs:
     name: Markdown Lint
     needs: changes
     if: needs.changes.outputs.markdown == 'true'
-    uses: JacobPEvans-personal/.github/.github/workflows/_markdown-lint.yml@main
+    uses: dryvist/.github/.github/workflows/_markdown-lint.yml@main
 
   file-size:
     name: File Size
     needs: changes
     if: needs.changes.outputs.terraform == 'true' || needs.changes.outputs.markdown == 'true'
-    uses: JacobPEvans-personal/.github/.github/workflows/_file-size.yml@main
+    uses: dryvist/.github/.github/workflows/_file-size.yml@main
 
   # Secrets can appear in ANY file, so this runs on every PR (no path filter,
   # never skipped). Official gitleaks-action; org GITLEAKS_LICENSE is seeded.

--- a/.github/workflows/osv-scan.yml
+++ b/.github/workflows/osv-scan.yml
@@ -1,7 +1,7 @@
 # Periodic + per-PR OSV vulnerability scan.
 #
-# Inherits the centralized reusable workflow from JacobPEvans-personal/.github.
-# Config: JacobPEvans-personal/.github/osv-scanner.toml (org default) or local
+# Inherits the centralized reusable workflow from dryvist/.github.
+# Config: dryvist/.github/osv-scanner.toml (org default) or local
 # osv-scanner.toml in this repo (takes precedence).
 #
 # Make this a required check via branch protection on `main` after merge.
@@ -24,8 +24,8 @@ permissions:
 
 jobs:
   scan:
-    # SHA pin → JacobPEvans-personal/.github main as of 2026-05-20.
+    # SHA pin → dryvist/.github main as of 2026-06-12.
     # Bump intentionally when the upstream workflow changes.
-    uses: JacobPEvans-personal/.github/.github/workflows/_osv-scan.yml@a76cf8faec4ea24036c9042bf52d18b573f172ae
+    uses: dryvist/.github/.github/workflows/_osv-scan.yml@dcc5257e5a6a24cbb137ddbd12494d9d2bf615b1
     with:
       runner_label: ubuntu-latest

--- a/.github/workflows/retrigger-pr-checks.yml
+++ b/.github/workflows/retrigger-pr-checks.yml
@@ -1,8 +1,8 @@
 name: Retrigger PR Checks
 
 # Ensures bot-created PRs (GITHUB_TOKEN) get the Merge Gate check.
-# Calls shared logic from JacobPEvans-personal/.github.
-# See: .github/workflows/_retrigger-pr-checks.yml in JacobPEvans-personal/.github
+# Calls shared logic from dryvist/.github.
+# See: .github/workflows/_retrigger-pr-checks.yml in dryvist/.github
 
 on:
   schedule:
@@ -18,6 +18,6 @@ permissions:
 
 jobs:
   retrigger:
-    uses: JacobPEvans-personal/.github/.github/workflows/_retrigger-pr-checks.yml@main
+    uses: dryvist/.github/.github/workflows/_retrigger-pr-checks.yml@main
     secrets:
       GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,4 +1,8 @@
 # markdownlint-cli2 configuration
+# Canonical source: dryvist/.github root .markdownlint-cli2.yaml.
+# Delta from canon: rules live in .markdownlint.yml (canon inlines them under
+# `config:`), and ignores extend canon's CHANGELOG.md with .docs/**, .direnv/**,
+# and .github/aw/** (repo-local generated/symlinked paths).
 # Rules are in .markdownlint.yml; this file handles CLI-level ignores.
 
 ignores:

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,4 +1,7 @@
 # Markdownlint configuration for terraform-proxmox repository
+# Canonical source: dryvist/.github root .markdownlint-cli2.yaml (config block).
+# Delta from canon: MD013 tables:false (canon: tables:true, strict:true) and
+# MD024 siblings_only:true (canon leaves MD024 strict-by-default).
 # See https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md
 
 # Default state for all rules

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,3 +1,7 @@
+# Canonical source: dryvist/.github root .markdownlint-cli2.yaml (ignores list).
+# Delta from canon: repo-local additions beyond CHANGELOG.md — Terraform caches,
+# symlinked docs dirs, and gh-aw generated artifacts.
+
 # Ignore Terraform provider files and cache directories
 .terraform/**
 .terragrunt-cache/**


### PR DESCRIPTION
## Summary

- Swap the owner segment of every reusable-workflow `uses:` reference from `JacobPEvans-personal/.github` to `dryvist/.github`. GitHub Actions `uses:` does not follow account-rename redirects, and policy is that dryvist repos must never depend on `JacobPEvans-personal/*`.
- `ci-gate.yml`: `_markdown-lint.yml@main`, `_file-size.yml@main` (refs unchanged, gate structure untouched)
- `retrigger-pr-checks.yml`: `_retrigger-pr-checks.yml@main` (passes `GH_APP_PRIVATE_KEY`; hub workflow reads `vars.GH_APP_CLIENT_ID` — both exist on this repo)
- `osv-scan.yml`: `_osv-scan.yml` re-pinned to dryvist/.github main (`dcc5257`) — the old SHA pin (`a76cf8f`) only exists in the personal hub's history
- Annotate local `.markdownlint*` configs with their canonical source (dryvist/.github root `.markdownlint-cli2.yaml`) and the intentional deltas they carry (kept because they diverge from canon)

Skipped per policy: `repo-health-audit.md` `{{#import}}` references and `*.lock.yml` (gh-aw generated).

## Known issue (separate grant needed)

The scheduled "Retrigger PR Checks" workflow fails at `actions/create-github-app-token` with 404 on `GET /repos/dryvist/terraform-proxmox/installation` — the GitHub App (client-id `Iv23li1hLRLXXMeXwO6f`) is not installed on this repo/org. Repointing does not fix that; the app installation must be granted at the dryvist org level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)