### PR TITLE
docs(splunk): add netflow index (90d) + route UniFi IPFIX to it

### DIFF
--- a/docs/LOGGING_PIPELINE.md
+++ b/docs/LOGGING_PIPELINE.md
@@ -22,7 +22,7 @@ NetFlow Sources             Load Balancer       Collectors            Processing
 +----------------+          +----------+        +---------------+      +-----------+      +---------+
 | UniFi IPFIX    |          |          |        | cribl-edge-01 |      |           |      |         |
 | (2055 UDP)     |   --->   | HAProxy  |  --->  |               | ---> | Cribl     | ---> | Splunk  |
-|                |          | :2055 UDP|        | cribl-edge-02 |      | Stream    |      | network |
+|                |          | :2055 UDP|        | cribl-edge-02 |      | Stream    |      | netflow |
 +----------------+          +----------+        +---------------+      +-----------+      +---------+
 ```
 
@@ -46,9 +46,9 @@ Network devices and hosts configured to send syslog to `<internal-domain>`.
 
 | Source         | Port | Protocol | Index   |
 | -------------- | ---- | -------- | ------- |
-| UniFi (IPFIX)  | 2055 | UDP      | network |
+| UniFi (IPFIX)  | 2055 | UDP      | netflow |
 
-The `network` Splunk index receives NetFlow/IPFIX data from UniFi for traffic analysis.
+The `netflow` Splunk index receives NetFlow/IPFIX data from UniFi for traffic analysis.
 See `SPLUNK_INDEXES.md` for index retention settings.
 
 #### UniFi Network Device Configuration
@@ -74,7 +74,7 @@ See `SPLUNK_INDEXES.md` for index retention settings.
 - Data Retention: 365 days
 - Collect Historical Client Data: Enabled
 - Debug Logs: Disabled
-- NetFlow (IPFIX): Enabled (UDP 2055 → HAProxy → Cribl Edge → `network` index)
+- NetFlow (IPFIX): Enabled (UDP 2055 → HAProxy → Cribl Edge → `netflow` index)
 
 #### UniFi Log Format (CEF)
 

--- a/docs/SPLUNK_INDEXES.md
+++ b/docs/SPLUNK_INDEXES.md
@@ -13,6 +13,7 @@ This document defines the Splunk indexes used in the logging pipeline, their pur
 | firewall | Firewall logs             | Palo Alto, Cisco ASA           | 365 days  |
 | network  | General network logs      | Switches, routers, other       | 365 days  |
 | netmon   | Per-WAN network diagnosis | Probes, DOCSIS SNMP, satellite | 90 days   |
+| netflow  | UniFi NetFlow/IPFIX flows | UniFi gateway (IPFIX 2055)     | 90 days   |
 
 ## Index Configuration
 
@@ -106,11 +107,28 @@ frozenTimePeriodInSecs = 7776000
 - Satellite obstruction %, outages, pop-ping latency
 - Hourly per-WAN throughput (speedtest-exporter)
 
+### netflow
+
+```ini
+[netflow]
+homePath = $SPLUNK_DB/netflow/db
+coldPath = $SPLUNK_DB/netflow/colddb
+thawedPath = $SPLUNK_DB/netflow/thaweddb
+maxTotalDataSizeMB = 51200
+frozenTimePeriodInSecs = 7776000
+```
+
+**Data types**:
+
+- UniFi NetFlow / IPFIX flow records (UDP 2055 → HAProxy → Cribl Edge → Cribl Stream)
+- High-volume traffic-flow telemetry, split from `network` so its volume has its own
+  size and retention envelope
+
 ## Retention Policy
 
 Security-log indexes use a **365-day retention** period (`frozenTimePeriodInSecs = 31536000`).
-The `netmon` diagnostics index is the exception at **90 days** (`7776000`) — a troubleshooting
-horizon, not a compliance window.
+The `netmon` diagnostics and `netflow` flow-record indexes are the exceptions at **90 days**
+(`7776000`) — a troubleshooting / volume horizon, not a compliance window.
 
 **Rationale**:
 
@@ -121,14 +139,14 @@ horizon, not a compliance window.
 ## Size Limits
 
 Security-log indexes are limited to **100GB** each (`maxTotalDataSizeMB = 102400`); the `netmon`
-diagnostics index is capped at **50GB** (`51200`).
+diagnostics and `netflow` flow indexes are each capped at **50GB** (`51200`).
 
 **Capacity planning**:
 
-- Total: 450GB across 5 indexes (4 × 100GB security + netmon 50GB)
+- Total: 500GB across 6 indexes (4 × 100GB security + netmon 50GB + netflow 50GB)
 - Splunk VM disk: 500GB allocated
-- Buffer for Splunk internal indexes: ~50GB — grow the VM disk before onboarding the broader
-  host/container/firewall log sources
+- Caps now equal the 500GB VM disk — grow the VM disk (leaving ~50GB for Splunk internal
+  indexes) before onboarding the broader host/container/firewall log sources
 
 ## Source Type Mapping
 
@@ -147,6 +165,7 @@ diagnostics index is capped at **50GB** (`51200`).
 | netmon:probe   | netmon   | Telegraf active probes |
 | netmon:docsis  | netmon   | Cable modem SNMP       |
 | netmon:sat     | netmon   | satellite uplink probe |
+| ipfix          | netflow  | UniFi NetFlow/IPFIX    |
 
 ## HEC Token Configuration
 
@@ -178,6 +197,9 @@ splunk_indexes:
     maxTotalDataSizeMB: 102400
     frozenTimePeriodInSecs: 31536000
   - name: netmon
+    maxTotalDataSizeMB: 51200
+    frozenTimePeriodInSecs: 7776000
+  - name: netflow
     maxTotalDataSizeMB: 51200
     frozenTimePeriodInSecs: 7776000
 ```


### PR DESCRIPTION
## What
Documents the end-state for splitting high-volume **UniFi NetFlow/IPFIX** out of the `network` index into a dedicated **`netflow`** index. Docs-first — lands ahead of the two code PRs.

- **SPLUNK_INDEXES.md**: `netflow` catalog row; `[netflow]` config block (**50 GB / 90-day** = `maxTotalDataSizeMB 51200` / `frozenTimePeriodInSecs 7776000`, the netmon high-volume pattern); retention, size-limit (now 6 indexes / 500 GB caps = the disk — grow note), source-type map (`ipfix → netflow`), and ansible snippet updates.
- **LOGGING_PIPELINE.md**: IPFIX destination `network` → `netflow` (diagram, sources table, prose).

## Why
UniFi NetFlow is high-volume; giving it its own index isolates that volume with a shorter (90-day) retention envelope instead of inflating the 365-day `network` index.

## Sizing note
Chose **50 GB / 90 d** (not the default 100 GB) so `netflow` matches the documented `netmon` high-volume treatment and keeps total index caps at the 500 GB disk. The retention (90 d) is the real volume control.

## Companion PRs (code)
- ansible-splunk: `netflow` index → `frozen_time_secs: 7776000` (90 d).
- ansible-proxmox-apps: Cribl Stream IPFIX pipeline `'network'` → `'netflow'`.

Deploy = ansible converge; verify via the Splunk MCP that `index=netflow` receives `ipfix`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)