### PR TITLE
fix(container): ignore mount_point drift so applies don't replace media LXCs

### DIFF
--- a/modules/proxmox-container/main.tf
+++ b/modules/proxmox-container/main.tf
@@ -169,6 +169,16 @@ resource "proxmox_virtual_environment_container" "containers" {
       # "no options specified" when an update sends no meaningful feature changes.
       # Features are only set at creation time (privileged containers require root@pam).
       features,
+      # Ignore mount_point drift. HOST bind-mounts (e.g. the media stack's single
+      # /bulk/data mount) are root@pam-only, so the BPG API token cannot set them —
+      # they are applied post-creation by the ansible-proxmox `media_lxc_features`
+      # role, not by terraform. Without this, every refresh sees the live mount as
+      # drift and tries to strip it, which forces replacement of the (data-bearing)
+      # media containers. Same rationale as `features` and the splunk-vm boot disk
+      # (terraform-proxmox #390). Storage-VOLUME mounts declared in deployment.json
+      # are still created at provision time; only post-creation reconciliation is
+      # ignored (mounts are effectively set-once here).
+      mount_point,
     ]
   }
 }


### PR DESCRIPTION
## Why

The media stack uses a single **host bind-mount** (`/bulk/data`) into its LXCs (ansible-proxmox #270). Host bind-mounts are **root@pam-only**, so the BPG provider's API token cannot set them — they're applied post-creation by the `media_lxc_features` Ansible role, never by terraform. With no `ignore_changes` on `mount_point`, every refresh sees the live mount as drift and plans to **strip it, which forces replacement** of the data-bearing media containers (`download-vpn`, `plex`, `sonarr`, `radarr`). That makes **any full `terragrunt apply` destructive** — the long-known "don't apply media post-Ansible (mount ForceNew)" landmine, which has meant *no* container could be added via apply without wrecking media.

A live `terragrunt plan` confirmed it: with this drift present, the plan replaces all four media containers.

## What

Add `mount_point` to the container module's `lifecycle.ignore_changes`, mirroring:
- the existing **`features`** exclusion (identical root@pam / creation-only rationale), and
- the **splunk-vm boot-disk** ignore added in #390 ("unblock apply on live bootdisk").

Storage-**volume** mounts declared in `deployment.json` (minio, infisical, mssql, openproject, qdrant, hermes-infer) are still created at provision time — `ignore_changes` only suppresses *post-creation* reconciliation, which is acceptable (these mounts are effectively set-once, same tradeoff already accepted for `features`).

## Verification

- `tofu fmt` clean; module change only.
- Pre-fix live plan: **replaces 4 media containers** (the bug).
- Post-fix verification plan: **pending a fresh AWS session** (the token expired mid-plan). Must confirm the post-fix plan shows no media replacement before any apply.

Unblocks the DNS-secondary-on-pve2 work (and every future apply). Part of the resiliency program (makes `terragrunt apply` safe again).