### PR TITLE
feat(containers): document unifi-metrics LXC for UniFi telemetry collector

### DIFF
--- a/deployment.json.example
+++ b/deployment.json.example
@@ -192,6 +192,20 @@
       "root_disk": { "size": 8 },
       "unprivileged": true,
       "features": { "nesting": true, "keyctl": true }
+    },
+    "_unifi_metrics_comment": "UniFi controller telemetry collector (Docker-in-LXC on mgmt VLAN, tag unifi_metrics). Runs unpoller (polls the UniFi controller API, exposes Prometheus) + a Telegraf inputs.prometheus scrape that ships Splunk-HEC to Cribl Edge then the Splunk unifi_metrics index. Captures device cpu/mem/temp/uptime, per-port bytes/errors/drops/PoE/STP, per-client signal/rate/satisfaction, and WAN quality. Controller creds via UNIFI_* env. See ansible-proxmox-apps roles/unifi_metrics. vm_id 199 is illustrative; pick a free mgmt /24 host.",
+    "unifi-metrics": {
+      "vm_id": 199,
+      "vlan": "mgmt",
+      "hostname": "unifi-metrics",
+      "description": "UniFi controller telemetry: unpoller + Telegraf into the Splunk unifi_metrics index",
+      "cpu_cores": 1,
+      "memory_dedicated": 512,
+      "tags": ["terraform", "container", "monitoring", "unifi_metrics", "docker"],
+      "pool_id": "infrastructure",
+      "root_disk": { "size": 8 },
+      "unprivileged": true,
+      "features": { "nesting": true, "keyctl": true }
     }
   }
 }


### PR DESCRIPTION
## What

Documents the `unifi-metrics` container in `deployment.json.example` — a mgmt-VLAN Docker-in-LXC running unpoller + Telegraf that polls the UniFi controller and ships full device/port/client/WAN telemetry via Cribl into the Splunk `unifi_metrics` index. Mirrors the netmon prober shape.

## Companion PRs

- `ansible-proxmox-apps#425` — the `unifi_metrics` role (unpoller + Telegraf + Cribl stream-branch).
- `ansible-splunk#253` — the `unifi_metrics` Splunk index (90-day).

## To deploy

Add the same entry to the live (gitignored) `deployment.json` and run a credentialed `terragrunt apply` to create the LXC, then converge `--tags unifi_metrics`. (Coordinate with the in-flight resiliency-program apply + the mount-drift fix so the media containers aren't disturbed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)