### PR TITLE
fix(locals): support static-IP exception hosts with positional VMIDs

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -24,15 +24,21 @@ locals {
   # A container MAY pin a static ipv4_address (CIDR form, e.g. "192.168.5.10/24") to
   # override the vm_id-derived address — for fixed low-number hosts (e.g. a DNS server
   # at .10) whose address must not follow the vm_id. Otherwise derived as usual.
-  # DNS-first guests (dhcp = true) resolve to the literal "dhcp" instead: cidrhost is
-  # NOT evaluated for them (the ternary short-circuits), so a 6-digit positional VMID
-  # that would overflow the /24 host space is fine. Their gateway is null (DHCP-provided).
+  # DNS-first guests (dhcp = true) resolve to the literal "dhcp" instead.
+  #
+  # cidrhost is evaluated ONLY on the derive branch. An explicit if/else (not
+  # coalesce, which evaluates every argument eagerly) short-circuits it, so a
+  # 6-7-digit positional VMID — which overflows the /24 host space — is safe with
+  # EITHER dhcp = true OR a pinned static ipv4_address. This is what lets a
+  # static-IP exception host (a DNS server, reachable before DNS is up) carry a
+  # positional VMID instead of a legacy 3-digit one.
   container_ipv4 = {
     for k, v in var.containers : k => (
-      try(v.dhcp, false) ? "dhcp" : nonsensitive(coalesce(
-        try(v.ip_config.ipv4_address, null),
-        "${cidrhost(var.network_cidrs[v.vlan], v.vm_id)}/${split("/", var.network_cidrs[v.vlan])[1]}"
-      ))
+      try(v.dhcp, false) ? "dhcp" : (
+        try(v.ip_config.ipv4_address, null) != null
+        ? nonsensitive(v.ip_config.ipv4_address)
+        : nonsensitive("${cidrhost(var.network_cidrs[v.vlan], v.vm_id)}/${split("/", var.network_cidrs[v.vlan])[1]}")
+      )
     )
   }
   container_gateway = {

--- a/tests/locals.tftest.hcl
+++ b/tests/locals.tftest.hcl
@@ -507,6 +507,36 @@ run "container_dhcp_resolves_fqdn_and_null_gateway" {
   }
 }
 
+# Static-IP exception host (a DNS server, reachable before DNS is up) carrying a
+# 7-digit positional VMID. cidrhost(<dns cidr>, 5310010) would overflow the /24,
+# so this run only passes because the static ip_config short-circuits the derive
+# branch — the regression guard for the coalesce -> if/else change in locals.tf.
+run "container_static_ip_with_positional_vmid_skips_cidrhost" {
+  command = plan
+
+  variables {
+    containers = {
+      "technitium-dns-2" = {
+        vm_id     = 5310010
+        hostname  = "technitium-dns-2"
+        vlan      = "dns"
+        ip_config = { ipv4_address = "192.168.2.3/24" }
+        tags      = ["terraform", "container", "dns"]
+      }
+    }
+  }
+
+  assert {
+    condition     = local.container_ipv4["technitium-dns-2"] == "192.168.2.3/24"
+    error_message = "static ip_config must win without evaluating cidrhost for the 7-digit vm_id, got ${local.container_ipv4["technitium-dns-2"]}"
+  }
+
+  assert {
+    condition     = local.container_gateway["technitium-dns-2"] == "192.168.2.1"
+    error_message = "static positional-VMID guest gateway should be the .1 of its VLAN, got ${local.container_gateway["technitium-dns-2"]}"
+  }
+}
+
 run "cribl_stream_ids_picks_up_stream_tagged" {
   command = plan
 


### PR DESCRIPTION
## Problem

`container_ipv4` resolved a guest's address with `coalesce(ip_config, cidrhost(cidr, vm_id))`. `coalesce()` evaluates **every** argument eagerly, so even a guest with a pinned static `ip_config` still evaluated `cidrhost(cidr, vm_id)`. For a 6-7-digit **positional VMID** (the [VMID/network-tier scheme](https://docs.jacobpevans.com/infrastructure/vmid-network-tiers)) the host number overflows the `/24` and `cidrhost` **errors at plan** — forcing every positional-VMID guest onto `dhcp = true`.

That conflicts with the scheme's own static-IP exception: **DNS servers** (and other gear that must be reachable before DNS is up) need a *static* IP **and** a positional VMID. Today they can't have both.

## Fix

Replace the `coalesce` with an explicit `if/else`. Terraform conditional expressions short-circuit, so `cidrhost` is evaluated **only** on the derive branch:

- `dhcp = true` → `"dhcp"` (unchanged)
- static `ip_config` set → that address, **without** evaluating `cidrhost` (no overflow)
- otherwise → `cidrhost(cidr, vm_id)` derive (unchanged)

In-range static and dhcp behavior are identical to before; only the previously-broken *static + out-of-range positional VMID* case now works.

## Why now

Unblocks giving the pve2 DNS secondary a proper positional VMID + static IP instead of a legacy 3-digit ID, per the numbering convention.

## Validation

- `tofu fmt -check`, `tofu validate`: clean.
- `tofu test`: **102 passed, 0 failed**, including a new regression run `container_static_ip_with_positional_vmid_skips_cidrhost` (static `ip_config` + 7-digit `vm_id` resolves without overflowing `cidrhost`).

Assisted-by: Claude:claude-opus-4-8