### PR TITLE
feat(servarr-config): declarative Sonarr/Radarr config via devopsarr

### DIFF
--- a/servarr-config/.terraform.lock.hcl
+++ b/servarr-config/.terraform.lock.hcl
@@ -1,0 +1,48 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/devopsarr/radarr" {
+  version     = "2.3.5"
+  constraints = "~> 2.3"
+  hashes = [
+    "h1:Smk5+GeHNnXmxyQVmFyK+kBB4igfbJbez5+j/sL0YO4=",
+    "zh:18cb2579f9312aee8d17ffa938664f71c9376abea0a6da3d053ebdaef66a2f62",
+    "zh:19dbdff678f6f5b90da2f61ef4b1afed619a317474b344f9de15db35c57e2e47",
+    "zh:21af82e9cdd7b85f6a943655675bae1d330d225e6c4c683f9bbabfc938280228",
+    "zh:26bebd01c85d457dbe7e80978456695f00396ed830878b0151d495a4ce7ef4ba",
+    "zh:66eba536cf2b5de49c62386e65910347cb4deac6cdf9bec920a1090db6a8a5a4",
+    "zh:6905bbfbec2b7d67cab381c6491c018163e7cb410e55bfedc598ada378643c56",
+    "zh:78bdf398fe1db2c63c2ccc9da1b8fc27fb711ae831bef91e3ea198d7d684dc98",
+    "zh:890df766e9b839623b1f0437355032a3c006226a6c200cd911e15ee1a9014e9f",
+    "zh:8cff19564bf543894fbbca5c936f47fa9446724cefbaa2f63dedd79feb3ca52a",
+    "zh:94be12c4165d5fda164aff3e7b600e9dab40528563a0758dd198c9ace69437b6",
+    "zh:9c22c104248cb8022935df1674404bded46a4f4f54daf6ba96ee800316eb95b9",
+    "zh:a5d217038373d605531537ebaecae8ba136b8c7198a50c6a47c6932cb8485737",
+    "zh:c244be13b67eecbd395b123986343e77f168dc07eaaf888bc8206db2ba4a6cfc",
+    "zh:cee38aa1920f5d37ea56421b0ea57ebcefde87b0c57a61c5aa6476d4f185291a",
+    "zh:e95c3c4caad13cf1e4e37b721205d09564978d514f42ccb56d7ea94a498dad7e",
+  ]
+}
+
+provider "registry.opentofu.org/devopsarr/sonarr" {
+  version     = "3.4.2"
+  constraints = "~> 3.4"
+  hashes = [
+    "h1:RCI1fuccrZXNgu04VzxjD2e2A1hsMO8UP/BLDagThqw=",
+    "zh:01d675253aef5586b165bc4749d006f91cda6ce65b24842c7911cc178fe7e09d",
+    "zh:2da242ee58c1726cff9ce9260bc94756bc8a775a717da5aec8e9a8bf60578ac6",
+    "zh:30acc52a3a31ac75387728c27b3193f0419dcb72ee7488e8dbcd407884921205",
+    "zh:47adaba9c7915c832a9d8dfb5d0a18dd08b60fd7c531a810b2642ab75d200ee1",
+    "zh:551b580729cd82cc7a303d836985286e79a26062f02629bf51081ba2e4edf471",
+    "zh:5e5c5b1614cf0c61aa154543da1d5bda295a405fda52746d9193b0b8db922ddb",
+    "zh:65ebe76847129677f747364ee20591f01f5df4a67b06c5dff1bf53b813ec613a",
+    "zh:67db823f6016e345f2cbceb5300d0cce595bdeb0da32b15a1743724f0a4f978f",
+    "zh:75f119f674b3b0988133d38c1645e97cf6f0aee62a4131dfd62c8462636c2a94",
+    "zh:7ca3d6cfd4ccc2a9fb008ca93362c97a98f2ae98b55a56a7902fd33030d64179",
+    "zh:82033841c5a3fceecc1e3b84ef7328f027e2bb4bf63dfc24886510fed9d8a843",
+    "zh:890df766e9b839623b1f0437355032a3c006226a6c200cd911e15ee1a9014e9f",
+    "zh:9aee54de9fcce6ef4f6b4f4f394a5628690d7d4849b03cd996ff991f8b29433a",
+    "zh:cda3fd66138de23856f869549aa06c82ce1f899474bc133d29d8463bfa032b16",
+    "zh:e4f8a67b8d08702056073a5ac8928dbb991767a52d3f36c3726399df0b5f2b96",
+  ]
+}

--- a/servarr-config/README.md
+++ b/servarr-config/README.md
@@ -1,0 +1,74 @@
+# servarr-config
+
+Declarative Sonarr/Radarr structural config via the
+[devopsarr](https://registry.terraform.io/namespaces/devopsarr) Terraform
+providers. This is the config-as-code replacement for the hand-rolled servarr
+wiring: a destroyed/rebuilt app is reconfigured from code, and `tofu plan`
+doubles as drift detection.
+
+This config is **self-contained** — it has its own state and is **not** part of
+the main terragrunt workspace, so it never touches the cluster/container state.
+
+## Requirements
+
+| Requirement | Version / Note |
+| --- | --- |
+| OpenTofu / Terraform | `>= 1.6` |
+| `devopsarr/sonarr` provider | `~> 3.4` |
+| `devopsarr/radarr` provider | `~> 2.3` |
+| Network | the runner must reach the Sonarr/Radarr APIs (LAN/CI; not the VPN-locked Prowlarr) |
+| Secrets | Sonarr/Radarr API keys + qBittorrent password from the secret store |
+
+## Scope (phase 1)
+
+Manages the CI-reachable apps only:
+
+| App | Resources |
+| --- | --- |
+| Sonarr | `root_folder` (`/data/media/tv`), `download_client_qbittorrent` |
+| Radarr | `root_folder` (`/data/media/movies`), `download_client_qbittorrent` |
+
+Not yet here (see Follow-ups):
+
+- **Prowlarr** (indexers + Sonarr/Radarr app links) — it runs behind the
+  download-vpn killswitch, so it is **not reachable from CI/a workstation**. It
+  must be driven from inside that container, not from this CI config.
+- **Quality profiles / custom formats / media-management** — these are
+  community-maintained content best sourced from
+  [Configarr](https://configarr.de/) / [Recyclarr](https://recyclarr.dev/)
+  ([TRaSH-Guides](https://trash-guides.info/)) rather than hand-declared.
+
+## Usage
+
+```bash
+cp terraform.tfvars.example local.auto.tfvars   # gitignored; fill from secret store
+tofu init
+tofu plan                                        # drift detection — no changes applied
+```
+
+Real values (URLs, API keys, qBittorrent password) come from the secret store
+(SOPS / Doppler / env), never committed. The example file uses RFC1918
+placeholders only.
+
+## Adopting an already-configured instance (import, don't clobber)
+
+The live apps already have these resources. Import them before the first apply
+so `tofu` adopts the existing config instead of trying to recreate it:
+
+```bash
+tofu import sonarr_root_folder.tv <id>
+tofu import sonarr_download_client_qbittorrent.qbittorrent <id>
+tofu import radarr_root_folder.movies <id>
+tofu import radarr_download_client_qbittorrent.qbittorrent <id>
+```
+
+IDs come from each app's API (`GET /api/v3/rootfolder`,
+`GET /api/v3/downloadclient`). After import, `tofu plan` should be clean.
+
+## Follow-ups
+
+- Prowlarr config via an in-container runner (devopsarr or Configarr executed
+  inside download-vpn).
+- Configarr for quality profiles / custom formats (TRaSH).
+- Retire the Ansible servarr wiring once parity is verified.
+- Wire a scheduled `tofu plan -detailed-exitcode` for drift alerting.

--- a/servarr-config/main.tf
+++ b/servarr-config/main.tf
@@ -1,0 +1,51 @@
+# Declarative Sonarr/Radarr structural config via the devopsarr providers — the
+# CI-reachable replacement for the hand-rolled servarr wiring. `tofu plan`
+# doubles as drift detection. Prowlarr lives behind the download-vpn killswitch
+# and is handled separately (see README); TRaSH custom-formats/quality come from
+# Configarr.
+
+provider "sonarr" {
+  url     = var.sonarr_url
+  api_key = var.sonarr_api_key
+}
+
+provider "radarr" {
+  url     = var.radarr_url
+  api_key = var.radarr_api_key
+}
+
+# --- Sonarr ------------------------------------------------------------------
+resource "sonarr_root_folder" "tv" {
+  path = var.tv_root_folder
+}
+
+resource "sonarr_download_client_qbittorrent" "qbittorrent" {
+  name                       = "qBittorrent"
+  enable                     = true
+  priority                   = 1
+  host                       = var.qbittorrent_host
+  port                       = var.qbittorrent_port
+  username                   = var.qbittorrent_username
+  password                   = var.qbittorrent_password
+  use_ssl                    = false
+  tv_category                = var.tv_category
+  remove_completed_downloads = true
+}
+
+# --- Radarr ------------------------------------------------------------------
+resource "radarr_root_folder" "movies" {
+  path = var.movie_root_folder
+}
+
+resource "radarr_download_client_qbittorrent" "qbittorrent" {
+  name                       = "qBittorrent"
+  enable                     = true
+  priority                   = 1
+  host                       = var.qbittorrent_host
+  port                       = var.qbittorrent_port
+  username                   = var.qbittorrent_username
+  password                   = var.qbittorrent_password
+  use_ssl                    = false
+  movie_category             = var.movie_category
+  remove_completed_downloads = true
+}

--- a/servarr-config/terraform.tfvars.example
+++ b/servarr-config/terraform.tfvars.example
@@ -1,0 +1,11 @@
+# Copy to a gitignored *.auto.tfvars (or pass via -var-file) and fill from the
+# secret store. Placeholders use RFC1918 192.168.x addresses only.
+
+sonarr_url     = "http://192.168.55.222:8989"
+sonarr_api_key = "REPLACE_FROM_SECRET_STORE" # SONARR_API_KEY
+
+radarr_url     = "http://192.168.55.223:7878"
+radarr_api_key = "REPLACE_FROM_SECRET_STORE" # RADARR_API_KEY
+
+qbittorrent_host     = "192.168.55.224"
+qbittorrent_password = "REPLACE_FROM_SECRET_STORE" # QBITTORRENT_ADMIN_PASSWORD

--- a/servarr-config/variables.tf
+++ b/servarr-config/variables.tf
@@ -1,0 +1,72 @@
+# All real values are supplied at apply time from the secret store
+# (SOPS / Doppler / env / a gitignored *.auto.tfvars) — never committed. The
+# examples in terraform.tfvars.example use RFC1918 192.168.x placeholders only.
+
+variable "sonarr_url" {
+  type        = string
+  description = "Base URL of the Sonarr instance (e.g. http://192.168.55.222:8989)."
+}
+
+variable "sonarr_api_key" {
+  type        = string
+  sensitive   = true
+  description = "Sonarr API key (SONARR_API_KEY from the secret store)."
+}
+
+variable "radarr_url" {
+  type        = string
+  description = "Base URL of the Radarr instance (e.g. http://192.168.55.223:7878)."
+}
+
+variable "radarr_api_key" {
+  type        = string
+  sensitive   = true
+  description = "Radarr API key (RADARR_API_KEY from the secret store)."
+}
+
+variable "qbittorrent_host" {
+  type        = string
+  description = "Host/IP the *arr apps use to reach qBittorrent on the download-vpn LAN address (e.g. 192.168.55.224)."
+}
+
+variable "qbittorrent_port" {
+  type        = number
+  default     = 8080
+  description = "qBittorrent WebUI port."
+}
+
+variable "qbittorrent_username" {
+  type        = string
+  default     = "admin"
+  description = "qBittorrent WebUI username."
+}
+
+variable "qbittorrent_password" {
+  type        = string
+  sensitive   = true
+  description = "qBittorrent WebUI password (QBITTORRENT_ADMIN_PASSWORD from the secret store)."
+}
+
+variable "tv_root_folder" {
+  type        = string
+  default     = "/data/media/tv"
+  description = "Sonarr root folder (unified /data hardlink layout)."
+}
+
+variable "movie_root_folder" {
+  type        = string
+  default     = "/data/media/movies"
+  description = "Radarr root folder (unified /data hardlink layout)."
+}
+
+variable "tv_category" {
+  type        = string
+  default     = "tv"
+  description = "qBittorrent category Sonarr assigns to its downloads."
+}
+
+variable "movie_category" {
+  type        = string
+  default     = "movies"
+  description = "qBittorrent category Radarr assigns to its downloads."
+}

--- a/servarr-config/versions.tf
+++ b/servarr-config/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.6"
+
+  required_providers {
+    sonarr = {
+      source  = "devopsarr/sonarr"
+      version = "~> 3.4"
+    }
+    radarr = {
+      source  = "devopsarr/radarr"
+      version = "~> 2.3"
+    }
+  }
+}


### PR DESCRIPTION
## What

Adds a self-contained `servarr-config/` tofu config that manages Sonarr/Radarr
**structural config as code** via the [devopsarr](https://registry.terraform.io/namespaces/devopsarr)
providers — the config-as-code replacement for the hand-rolled servarr wiring. A
rebuilt app is reconfigured from code, and `tofu plan` doubles as drift detection.

It has its **own state** and is **not** part of the terragrunt workspace, so it
never touches cluster/container state.

## Scope (phase 1 — CI-reachable apps)
- Sonarr: `root_folder` (`/data/media/tv`) + `download_client_qbittorrent`
- Radarr: `root_folder` (`/data/media/movies`) + `download_client_qbittorrent`

Parameterized; real values (URLs, API keys, qBittorrent password) come from the
secret store and are never committed. The example tfvars uses RFC1918
placeholders only.

## Not here (documented follow-ups in the README)
- **Prowlarr** — runs behind the download-vpn killswitch, unreachable from CI, so
  it needs an in-container runner (not this CI config).
- **Quality profiles / custom formats** — community content via Configarr/Recyclarr (TRaSH).
- Retiring the Ansible servarr wiring once parity is verified.
- A scheduled `tofu plan -detailed-exitcode` for drift alerting.

## Validation
- `tofu fmt`: clean
- `tofu init -backend=false` + `tofu validate`: **Success! The configuration is valid.**
- pre-commit (tofu fmt / tflint / tfsec / gitleaks): pass

## Apply note
Not applied. The live apps already have these resources — import them first
(README documents the `tofu import` IDs) so a first apply adopts existing config
instead of recreating it. Apply is windowed.

Related: design ref #443.