### PR TITLE
feat(inventory): gate the S3 publish on a precondition, fail before writing garbage

### DIFF
--- a/inventory_publish.tf
+++ b/inventory_publish.tf
@@ -101,4 +101,41 @@ resource "aws_s3_object" "ansible_inventory" {
   key          = "terraform-proxmox/inventory/ansible_inventory.json"
   content      = jsonencode(local.ansible_inventory)
   content_type = "application/json"
+
+  # Publish gate: a malformed inventory must fail the apply BEFORE this object is
+  # written. The after-hook (scripts/sync-inventory.sh) runs check-jsonschema
+  # only AFTER this resource has already updated S3, so a schema break there
+  # leaves S3 fresh-but-wrong while the cache silently stays stale — exactly the
+  # half-publish hole behind the ingress outage. These preconditions encode the
+  # critical "do not publish garbage" invariants in HCL so they're evaluated at
+  # plan/apply time, before any S3 write; the full JSON-schema check stays in the
+  # hook as defense-in-depth for the cache copy.
+  #
+  # NOTE: `domain` is deliberately NOT asserted here. An empty domain is a
+  # supported state in this module — locals.tf falls back to a bare hostname when
+  # var.domain == "" (and `tofu test` exercises that default). The downstream
+  # requirement that domain be set for the Ansible per-node ansible_host lives in
+  # the ansible-proxmox-apps loader (load_tofu.yml), which fails loud there.
+  lifecycle {
+    precondition {
+      condition = alltrue([
+        for k, c in local.ansible_inventory.containers :
+        c.ip != null && c.ip != "" &&
+        c.node != null && c.node != "" &&
+        c.hostname != null && c.hostname != "" &&
+        c.vmid != null
+      ])
+      error_message = "One or more containers have an empty ip/node/hostname/vmid in the inventory — the Ansible connection target and DNS A-records derive from these. Inspect module.containers output and deployment.json."
+    }
+    precondition {
+      condition = alltrue([
+        for e in local.ansible_inventory.ingress :
+        try(e.name, "") != "" && try(e.port, 0) > 0 && (
+          try(e.ip, "") != "" ||
+          (try(e.apex, false) && length(try(e.backends, [])) > 0)
+        )
+      ])
+      error_message = "One or more ingress entries are malformed — each needs a name, a port > 0, and either a non-empty ip (service route) or apex=true with a non-empty backends pool. Inspect ingress.tf."
+    }
+  }
 }


### PR DESCRIPTION
## Why

The `ansible_inventory` is published to S3 by the `aws_s3_object` resource
**during** apply, but the only content validation (`check-jsonschema` in
`scripts/sync-inventory.sh`) runs in the **after-hook — after** the object has
already been written. So a malformed inventory reaches S3 first, and the hook
failure only blocks the local-cache refresh. The result is a **half-publish**:
S3 ends up fresh-but-wrong while the cache silently stays stale. That split is
the pipeline hole behind the recent ingress (Bad Gateway) outage.

## What

Add `lifecycle.precondition` blocks to `aws_s3_object.ansible_inventory` that
encode the critical "do not publish garbage" invariants in HCL, evaluated at
plan/apply time **before any S3 write**:

- every container carries a non-empty `ip`/`node`/`hostname` and a `vmid`
- every ingress entry has a `name`, a `port > 0`, and either a non-empty `ip`
  (service route) **or** `apex=true` with a non-empty `backends` pool

`domain` is **deliberately not asserted**: an empty domain is a supported state
(`locals.tf` falls back to a bare hostname, and `tofu test` exercises that
default). The downstream requirement that domain be set lives in the
ansible-proxmox-apps loader, which fails loud there.

The full JSON-schema check stays in the after-hook as defense-in-depth for the
cache copy.

## Verification

- `tofu fmt -check` + `tofu validate` pass.
- Full `tofu test` suite: **102 passed, 0 failed** (the preconditions are
  test-safe; an earlier domain assertion broke the empty-domain default tests
  and was removed).
- Preconditions evaluate on every plan/apply, so a future malformed inventory
  fails the apply before S3 is touched (full negative test requires a
  credentialed plan).