### PR TITLE
fix(servarr-config): align committed config to the adopted live state

### DIFF
--- a/servarr-config/README.md
+++ b/servarr-config/README.md
@@ -42,9 +42,14 @@ Not yet here (see Follow-ups):
 
 ```bash
 cp terraform.tfvars.example local.auto.tfvars   # gitignored; fill from secret store
-tofu init
-tofu plan                                        # drift detection — no changes applied
+# bucket embeds the AWS account id, so it is passed at init (never committed):
+tofu init -backend-config="bucket=terraform-proxmox-state-useast2-$(aws sts get-caller-identity --query Account --output text)"
+tofu plan                                        # drift detection — exit 2 = drift
 ```
+
+State lives in S3 (`terraform-proxmox/servarr-config/terraform.tfstate`). The live
+Sonarr/Radarr resources have already been imported (adopted) and `tofu plan` is
+clean, so the config manages them with no behavior change.
 
 Real values (URLs, API keys, qBittorrent password) come from the secret store
 (SOPS / Doppler / env), never committed. The example file uses RFC1918

--- a/servarr-config/main.tf
+++ b/servarr-config/main.tf
@@ -30,6 +30,15 @@ resource "sonarr_download_client_qbittorrent" "qbittorrent" {
   use_ssl                    = false
   tv_category                = var.tv_category
   remove_completed_downloads = true
+  remove_failed_downloads    = true
+
+  # devopsarr stores the qBittorrent password write-only, so it can never be read
+  # back and would otherwise show as drift on every plan. The password is managed
+  # out-of-band (set by the app/secret store); ignore it so tofu plan stays a
+  # meaningful drift signal.
+  lifecycle {
+    ignore_changes = [password]
+  }
 }
 
 # --- Radarr ------------------------------------------------------------------
@@ -48,4 +57,10 @@ resource "radarr_download_client_qbittorrent" "qbittorrent" {
   use_ssl                    = false
   movie_category             = var.movie_category
   remove_completed_downloads = true
+  remove_failed_downloads    = true
+
+  # See the Sonarr client above — password is write-only in devopsarr.
+  lifecycle {
+    ignore_changes = [password]
+  }
 }

--- a/servarr-config/remote-state.tf
+++ b/servarr-config/remote-state.tf
@@ -1,0 +1,12 @@
+# Partial S3 backend — the bucket (which embeds the AWS account id) is supplied
+# at init time via -backend-config, so it is never committed:
+#   tofu init -backend-config="bucket=terraform-proxmox-state-useast2-$(aws sts get-caller-identity --query Account --output text)"
+# (named remote-state.tf because the repo gitignores backend.tf — terragrunt-generated)
+terraform {
+  backend "s3" {
+    key            = "terraform-proxmox/servarr-config/terraform.tfstate"
+    region         = "us-east-2"
+    dynamodb_table = "terraform-proxmox-locks-useast2"
+    encrypt        = true
+  }
+}

--- a/servarr-config/variables.tf
+++ b/servarr-config/variables.tf
@@ -61,12 +61,12 @@ variable "movie_root_folder" {
 
 variable "tv_category" {
   type        = string
-  default     = "tv"
+  default     = "tv-sonarr"
   description = "qBittorrent category Sonarr assigns to its downloads."
 }
 
 variable "movie_category" {
   type        = string
-  default     = "movies"
+  default     = "radarr"
   description = "qBittorrent category Radarr assigns to its downloads."
 }


### PR DESCRIPTION
## What

#448 squash-merged an earlier revision of the branch, so `main` ended up with the
pre-alignment config and **without** the S3 backend. The live Sonarr/Radarr
resources are already imported/adopted (state in S3) using the aligned config, so
`main` currently diverges from the managed state. This restores parity.

## Changes
- qBittorrent categories corrected to the live values (`tv-sonarr` / `radarr`).
- `remove_failed_downloads = true` (matches live).
- `lifecycle { ignore_changes = [password] }` on both download clients — devopsarr
  stores the password write-only, so this keeps `tofu plan` a clean drift signal.
- `remote-state.tf` — the S3 backend (named to avoid the gitignored `backend.tf`).

This is byte-for-byte the config previously validated as a **clean plan** ("No
changes") against the imported state.

## Validation
- `tofu fmt`, pre-commit (tflint / tfsec / gitleaks): pass.
- Plan re-validation against S3 pending (AWS session expired mid-session); the
  config is identical to the already-validated clean-plan revision.

Related: #448, design ref #443.