### PR TITLE
feat(servarr-config): scheduled tofu-plan drift detection on self-hosted runner

### DIFF
--- a/.github/workflows/servarr-config-drift.yml
+++ b/.github/workflows/servarr-config-drift.yml
@@ -104,7 +104,7 @@ jobs:
           NTFY_BASE_URL: ${{ steps.doppler.outputs.NTFY_BASE_URL }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: >-
-          test -n "${NTFY_BASE_URL:-}" && curl -fsS
+          test -n "${NTFY_BASE_URL:-}" && curl -fsS --connect-timeout 5 --max-time 15 --retry 2
           -H "Title: servarr-config drift" -H "Priority: high" -H "Tags: warning,arr,drift"
           -d "Live Sonarr/Radarr config drifted from code (or plan failed). Review: ${RUN_URL}"
           "${NTFY_BASE_URL%/}/keystone"

--- a/.github/workflows/servarr-config-drift.yml
+++ b/.github/workflows/servarr-config-drift.yml
@@ -1,0 +1,111 @@
+# Scheduled config-as-code drift detection for the *arr structural config in
+# servarr-config/ (devopsarr providers). `tofu plan -detailed-exitcode` is the
+# purpose-built drift detector: exit 0 = in sync, exit 2 = the live
+# Sonarr/Radarr config has drifted from code (the non-zero exit fails the step,
+# so drift is loud, never a silent green). Out-of-band UI changes surface here
+# for triage (codify into IaC, or revert by apply) instead of being clobbered.
+#
+# Runs on the self-hosted `terraform` runner because the Sonarr/Radarr APIs live
+# on the homelab LAN and are unreachable from GitHub-hosted runners. Prowlarr is
+# deliberately NOT covered: it sits behind the download-vpn killswitch and is
+# only reachable from inside that container.
+#
+# Gated by repo variable `SERVARR_DRIFT_ENABLED == 'true'`. When off, the run
+# FAILS LOUDLY rather than skipping silently. Activation: servarr-config/README.md.
+
+name: Servarr Config Drift
+
+on:
+  schedule:
+    # Daily, off the :00 mark to avoid the cron thundering herd.
+    - cron: "17 9 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: servarr-config-drift
+  cancel-in-progress: false
+
+jobs:
+  gate-check:
+    name: Check drift gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail when SERVARR_DRIFT_ENABLED is not true
+        if: vars.SERVARR_DRIFT_ENABLED != 'true'
+        env:
+          GATE_MESSAGE: >-
+            SERVARR_DRIFT_ENABLED is not 'true' -- scheduled *arr config drift
+            detection is OFF, so out-of-band changes to Sonarr/Radarr go
+            unnoticed. Provision the iac-conf-mgmt/prd Doppler keys and repo
+            secret/variable (see servarr-config/README.md), then set the
+            variable to enable. Disable this schedule intentionally if drift
+            detection is meant to be off.
+        run: |
+          echo "::error::${GATE_MESSAGE}"
+          exit 1
+
+  drift:
+    name: Detect *arr config drift
+    needs: gate-check
+    runs-on: [self-hosted, Linux, terraform]
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: servarr-config
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup OpenTofu
+        uses: opentofu/setup-opentofu@v2
+        with:
+          # Pass the real plan exit code through (needed for -detailed-exitcode).
+          tofu_wrapper: false
+
+      - name: Fetch secrets from Doppler
+        id: doppler
+        uses: dopplerhq/secrets-fetch-action@v2
+        with:
+          doppler-token: ${{ secrets.GH_ACTION_DOPPLER_IAC_CONF_MGMT }}
+          doppler-project: iac-conf-mgmt
+          doppler-config: prd
+
+      - name: OpenTofu init (S3 backend)
+        env:
+          # The one read-only AWS account (read counterpart of the tf-proxmox
+          # write role). Account id is a non-secret Doppler value that builds the
+          # bucket name, so the runner needs no aws CLI.
+          AWS_REGION: us-east-2
+          AWS_ACCESS_KEY_ID: ${{ steps.doppler.outputs.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.doppler.outputs.AWS_SECRET_ACCESS_KEY }}
+          AWS_ACCOUNT_ID: ${{ steps.doppler.outputs.AWS_ACCOUNT_ID }}
+        run: tofu init -input=false -backend-config="bucket=terraform-proxmox-state-useast2-${AWS_ACCOUNT_ID}"
+
+      - name: OpenTofu plan (non-zero exit = drift, fails the step)
+        env:
+          AWS_REGION: us-east-2
+          AWS_ACCESS_KEY_ID: ${{ steps.doppler.outputs.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.doppler.outputs.AWS_SECRET_ACCESS_KEY }}
+          TF_VAR_sonarr_url: ${{ steps.doppler.outputs.SONARR_URL }}
+          TF_VAR_sonarr_api_key: ${{ steps.doppler.outputs.SONARR_API_KEY }}
+          TF_VAR_radarr_url: ${{ steps.doppler.outputs.RADARR_URL }}
+          TF_VAR_radarr_api_key: ${{ steps.doppler.outputs.RADARR_API_KEY }}
+          TF_VAR_qbittorrent_host: ${{ steps.doppler.outputs.QBITTORRENT_HOST }}
+          TF_VAR_qbittorrent_password: ${{ steps.doppler.outputs.QBITTORRENT_ADMIN_PASSWORD }}
+        # -lock=false: a read-only drift plan must never block a real apply.
+        run: tofu plan -input=false -lock=false -detailed-exitcode
+
+      - name: Alert ntfy on drift/failure
+        if: failure()
+        env:
+          NTFY_BASE_URL: ${{ steps.doppler.outputs.NTFY_BASE_URL }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: >-
+          test -n "${NTFY_BASE_URL:-}" && curl -fsS
+          -H "Title: servarr-config drift" -H "Priority: high" -H "Tags: warning,arr,drift"
+          -d "Live Sonarr/Radarr config drifted from code (or plan failed). Review: ${RUN_URL}"
+          "${NTFY_BASE_URL%/}/keystone"
+          || echo "ntfy unset/failed; the job failure is the signal."

--- a/servarr-config/README.md
+++ b/servarr-config/README.md
@@ -73,10 +73,13 @@ IDs come from each app's API (`GET /api/v3/rootfolder`,
 ## Drift detection (scheduled)
 
 `.github/workflows/servarr-config-drift.yml` runs `tofu plan -detailed-exitcode`
-on a daily schedule (and on `workflow_dispatch`). Exit `2` means the live
-Sonarr/Radarr config has drifted from this code; the job alerts ntfy and fails
-loudly so the drift is triaged (codify into this module, or revert via apply)
-rather than silently clobbered.
+on a daily schedule (and on `workflow_dispatch`). When the workflow is **enabled**,
+exit `2` means the live Sonarr/Radarr config has drifted from this code: the
+drift job posts an ntfy alert (if `NTFY_BASE_URL` is set) and fails loudly so the
+drift is triaged (codify into this module, or revert via apply) rather than
+silently clobbered. When the workflow is **disabled** (`SERVARR_DRIFT_ENABLED` is
+not `true`), the gate job fails loudly with no ntfy alert — a deliberate signal
+that drift coverage is off.
 
 It runs on the **self-hosted `terraform` runner** because the *arr APIs are on
 the homelab LAN. It is **off by default**; activation is gated on the repo

--- a/servarr-config/README.md
+++ b/servarr-config/README.md
@@ -70,10 +70,36 @@ tofu import radarr_download_client_qbittorrent.qbittorrent <id>
 IDs come from each app's API (`GET /api/v3/rootfolder`,
 `GET /api/v3/downloadclient`). After import, `tofu plan` should be clean.
 
+## Drift detection (scheduled)
+
+`.github/workflows/servarr-config-drift.yml` runs `tofu plan -detailed-exitcode`
+on a daily schedule (and on `workflow_dispatch`). Exit `2` means the live
+Sonarr/Radarr config has drifted from this code; the job alerts ntfy and fails
+loudly so the drift is triaged (codify into this module, or revert via apply)
+rather than silently clobbered.
+
+It runs on the **self-hosted `terraform` runner** because the *arr APIs are on
+the homelab LAN. It is **off by default**; activation is gated on the repo
+variable `SERVARR_DRIFT_ENABLED` and these secrets, supplied via the same
+`dopplerhq/secrets-fetch-action` pattern the rest of CI uses:
+
+| Where | Key | Note |
+| --- | --- | --- |
+| Repo variable | `SERVARR_DRIFT_ENABLED` | set to `true` to enable |
+| Repo secret | `GH_ACTION_DOPPLER_IAC_CONF_MGMT` | Doppler service token, read `iac-conf-mgmt/prd` |
+| Doppler `iac-conf-mgmt/prd` | `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` | the **read-only** AWS account — the read counterpart of the `tf-proxmox` write role (one read role per write role). Plan runs `-lock=false`, so it needs S3 read only, no DynamoDB |
+| Doppler `iac-conf-mgmt/prd` | `SONARR_URL`, `SONARR_API_KEY`, `RADARR_URL`, `RADARR_API_KEY` | *arr endpoints + keys |
+| Doppler `iac-conf-mgmt/prd` | `QBITTORRENT_HOST`, `QBITTORRENT_ADMIN_PASSWORD` | download-client check |
+| Doppler `iac-conf-mgmt/prd` | `AWS_ACCOUNT_ID` | already present; builds the bucket name (no aws CLI on the runner) |
+| Doppler `iac-conf-mgmt/prd` | `NTFY_BASE_URL` | optional; without it, the job failure is the only signal |
+
+The read-only AWS account is the one genuinely new principal. It can read state
+(which contains the *arr keys), so keep it read-only — one shared read role
+paired with the `tf-proxmox` write role, not a per-workflow key.
+
 ## Follow-ups
 
 - Prowlarr config via an in-container runner (devopsarr or Configarr executed
   inside download-vpn).
 - Configarr for quality profiles / custom formats (TRaSH).
 - Retire the Ansible servarr wiring once parity is verified.
-- Wire a scheduled `tofu plan -detailed-exitcode` for drift alerting.


### PR DESCRIPTION
## What

Adds a scheduled drift-detection workflow for the devopsarr `servarr-config`
module: `.github/workflows/servarr-config-drift.yml`.

- `tofu plan -detailed-exitcode` runs daily (and on `workflow_dispatch`). Exit
  `2` means the live Sonarr/Radarr structural config has drifted from code.
- On drift the job posts an ntfy alert and **fails loudly** — a silent skip
  would report green while real drift went unseen.
- Runs on the self-hosted `terraform` runner: the `*arr` APIs are reachable
  only from the homelab LAN. Prowlarr is intentionally out of scope (it sits
  behind the download-vpn killswitch).

## How it authenticates

Reuses the existing CI pattern — `dopplerhq/secrets-fetch-action` against
`iac-conf-mgmt/prd` — for the `*arr` endpoints/keys and a **read-only**
state-bucket key. No cross-repo SOPS, no new OIDC trust. The plan runs
`-lock=false` (read-only; never blocks a real apply), so no DynamoDB access is
needed.

## Activation (off by default)

Gated behind repo variable `SERVARR_DRIFT_ENABLED`; until it is `true` the gate
job fails loudly by design. Full key list (repo variable, repo secret, and the
Doppler entries including the one new read-only AWS principal) is documented in
`servarr-config/README.md`.

## Notes

- The `tofu plan` itself is the drift detector — no custom script.
- Tracked internally.