### PR TITLE
feat(object-storage): add RustFS object-storage LXC alongside MinIO for migration

### DIFF
--- a/constants.tf
+++ b/constants.tf
@@ -27,18 +27,22 @@ locals {
       cribl_edge_api    = 9420
       cribl_stream_api  = 9000
       # Cribl-to-Cribl (S2S/TCP-JSON) ingestion: remote Edge nodes -> HAProxy -> Stream
-      cribl_s2s        = 10300
-      apt_cacher_ng    = 3142
-      minio_api        = 9000
-      minio_console    = 9001
-      infisical_api    = 8080
-      openbao_api      = 8200
-      openbao_cluster  = 8201
-      postgres_default = 5432
-      redis_default    = 6379
-      ntp              = 123
-      idrac_kvm_r410   = 5410
-      idrac_kvm_r710   = 5710
+      cribl_s2s     = 10300
+      apt_cacher_ng = 3142
+      minio_api     = 9000
+      minio_console = 9001
+      # Object storage (RustFS) — replaces MinIO. Both kept during the migration
+      # soak; remove the minio_* pair once object-storage cutover is stable.
+      object_storage_s3      = 9000
+      object_storage_console = 9001
+      infisical_api          = 8080
+      openbao_api            = 8200
+      openbao_cluster        = 8201
+      postgres_default       = 5432
+      redis_default          = 6379
+      ntp                    = 123
+      idrac_kvm_r410         = 5410
+      idrac_kvm_r710         = 5710
       # Web UIs fronted by Traefik that have no other constant home. Kept here so
       # every port lives in one place and the ingress table (below) references
       # constants, never literals.

--- a/ingress.tf
+++ b/ingress.tf
@@ -10,28 +10,29 @@ locals {
   # backend = the container key whose IP is resolved from the inventory.
   # port = a pipeline_constants reference (never a literal, so ports stay DRY).
   ingress_services = {
-    plex            = { backend = "plex", port = local.pipeline_constants.media_ports.plex_web }
-    seerr           = { backend = "seerr", port = local.pipeline_constants.media_ports.seerr_web }
-    sonarr          = { backend = "sonarr", port = local.pipeline_constants.media_ports.sonarr_web }
-    radarr          = { backend = "radarr", port = local.pipeline_constants.media_ports.radarr_web }
-    qbittorrent     = { backend = "download-vpn", port = local.pipeline_constants.media_ports.qbittorrent_web }
-    prowlarr        = { backend = "download-vpn", port = local.pipeline_constants.media_ports.prowlarr_web }
-    technitium      = { backend = "technitium-dns", port = local.pipeline_constants.service_ports.technitium_web }
-    pihole          = { backend = "pi-hole", port = local.pipeline_constants.service_ports.pihole_web }
-    phpipam         = { backend = "phpipam", port = local.pipeline_constants.service_ports.phpipam_web }
-    minio           = { backend = "minio", port = local.pipeline_constants.service_ports.minio_console }
-    infisical       = { backend = "infisical", port = local.pipeline_constants.service_ports.infisical_api }
-    openbao         = { backend = "openbao1", port = local.pipeline_constants.service_ports.openbao_api }
-    mailpit         = { backend = "mailpit", port = local.pipeline_constants.notification_ports.mailpit_web }
-    ntfy            = { backend = "ntfy", port = local.pipeline_constants.notification_ports.ntfy_http }
-    homeassistant   = { backend = "homeassistant", port = local.pipeline_constants.service_ports.homeassistant_web }
-    openproject     = { backend = "openproject", port = local.pipeline_constants.service_ports.openproject_web }
-    prometheus      = { backend = "prometheus", port = local.pipeline_constants.service_ports.prometheus_web }
-    llm             = { backend = "hermes-chat", port = local.pipeline_constants.service_ports.open_webui_web }
-    ollama          = { backend = "hermes-infer", port = local.pipeline_constants.service_ports.ollama_api }
-    qdrant          = { backend = "qdrant", port = local.pipeline_constants.vector_db_ports.qdrant_http }
-    smokeping       = { backend = "smokeping", port = local.pipeline_constants.service_ports.smokeping_web }
-    "haproxy-stats" = { backend = "haproxy", port = local.pipeline_constants.service_ports.haproxy_stats }
+    plex             = { backend = "plex", port = local.pipeline_constants.media_ports.plex_web }
+    seerr            = { backend = "seerr", port = local.pipeline_constants.media_ports.seerr_web }
+    sonarr           = { backend = "sonarr", port = local.pipeline_constants.media_ports.sonarr_web }
+    radarr           = { backend = "radarr", port = local.pipeline_constants.media_ports.radarr_web }
+    qbittorrent      = { backend = "download-vpn", port = local.pipeline_constants.media_ports.qbittorrent_web }
+    prowlarr         = { backend = "download-vpn", port = local.pipeline_constants.media_ports.prowlarr_web }
+    technitium       = { backend = "technitium-dns", port = local.pipeline_constants.service_ports.technitium_web }
+    pihole           = { backend = "pi-hole", port = local.pipeline_constants.service_ports.pihole_web }
+    phpipam          = { backend = "phpipam", port = local.pipeline_constants.service_ports.phpipam_web }
+    minio            = { backend = "minio", port = local.pipeline_constants.service_ports.minio_console }
+    "object-storage" = { backend = "object-storage", port = local.pipeline_constants.service_ports.object_storage_console }
+    infisical        = { backend = "infisical", port = local.pipeline_constants.service_ports.infisical_api }
+    openbao          = { backend = "openbao1", port = local.pipeline_constants.service_ports.openbao_api }
+    mailpit          = { backend = "mailpit", port = local.pipeline_constants.notification_ports.mailpit_web }
+    ntfy             = { backend = "ntfy", port = local.pipeline_constants.notification_ports.ntfy_http }
+    homeassistant    = { backend = "homeassistant", port = local.pipeline_constants.service_ports.homeassistant_web }
+    openproject      = { backend = "openproject", port = local.pipeline_constants.service_ports.openproject_web }
+    prometheus       = { backend = "prometheus", port = local.pipeline_constants.service_ports.prometheus_web }
+    llm              = { backend = "hermes-chat", port = local.pipeline_constants.service_ports.open_webui_web }
+    ollama           = { backend = "hermes-infer", port = local.pipeline_constants.service_ports.ollama_api }
+    qdrant           = { backend = "qdrant", port = local.pipeline_constants.vector_db_ports.qdrant_http }
+    smokeping        = { backend = "smokeping", port = local.pipeline_constants.service_ports.smokeping_web }
+    "haproxy-stats"  = { backend = "haproxy", port = local.pipeline_constants.service_ports.haproxy_stats }
   }
 
   # Proxmox cluster UI apex backend pool. Every commissioned node's web UI is

--- a/locals.tf
+++ b/locals.tf
@@ -161,10 +161,19 @@ locals {
     if contains(coalesce(try(v.tags, null), []), "apt-cache")
   }
 
-  # MinIO object storage containers (minio tag)
+  # MinIO object storage containers (minio tag).
+  # DEPRECATED: replaced by object_storage_container_ids (RustFS). Kept during
+  # the migration soak so MinIO stays writable as the rollback path; remove
+  # together with the minio block in deployment.json after cutover is stable.
   minio_container_ids = {
     for k, v in var.containers : k => v.vm_id
     if contains(coalesce(try(v.tags, null), []), "minio")
+  }
+
+  # Object storage containers (object-storage tag) — RustFS, MinIO replacement.
+  object_storage_container_ids = {
+    for k, v in var.containers : k => v.vm_id
+    if contains(coalesce(try(v.tags, null), []), "object-storage")
   }
 
   # Infisical secrets-management containers (infisical tag)

--- a/main.tf
+++ b/main.tf
@@ -216,8 +216,11 @@ module "firewall" {
   # that gets license-telemetry HTTPS egress
   cribl_edge_container_ids = local.cribl_edge_container_ids
 
-  # MinIO object storage containers (minio tag)
+  # MinIO object storage (minio tag) — DEPRECATED, kept for the migration soak.
   minio_container_ids = local.minio_container_ids
+
+  # Object storage (object-storage tag) — RustFS, MinIO replacement.
+  object_storage_container_ids = local.object_storage_container_ids
 
   # Infisical secrets-management containers (infisical tag)
   infisical_container_ids = local.infisical_container_ids

--- a/modules/firewall/container_rules.tf
+++ b/modules/firewall/container_rules.tf
@@ -348,6 +348,46 @@ resource "proxmox_virtual_environment_firewall_rules" "minio_container" {
   depends_on = [proxmox_virtual_environment_firewall_options.minio_container]
 }
 
+# Object storage containers (RustFS — S3 API 9000, Console 9001)
+
+resource "proxmox_virtual_environment_firewall_options" "object_storage_container" {
+  for_each = var.object_storage_container_ids
+
+  node_name     = var.node_name
+  container_id  = each.value
+  enabled       = local.firewall_defaults.enabled
+  input_policy  = local.firewall_defaults.input_policy
+  output_policy = local.firewall_defaults.output_policy
+  log_level_in  = local.firewall_defaults.log_level_in
+  log_level_out = local.firewall_defaults.log_level_out
+
+  depends_on = [proxmox_virtual_environment_cluster_firewall.main]
+}
+
+resource "proxmox_virtual_environment_firewall_rules" "object_storage_container" {
+  for_each = var.object_storage_container_ids
+
+  node_name    = var.node_name
+  container_id = each.value
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.internal_access.name
+    comment        = "Internal access (SSH, ICMP)"
+  }
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.object_storage_services.name
+    comment        = "Object storage services (TCP/9000 S3 API, TCP/9001 Console)"
+  }
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.outbound_internal.name
+    comment        = "Outbound to internal only"
+  }
+
+  depends_on = [proxmox_virtual_environment_firewall_options.object_storage_container]
+}
+
 # Infisical container firewall resources live in modules/firewall/infisical_rules.tf
 # (extracted so container_rules.tf stays under the shared _file-size workflow's 12 KB error
 # threshold).

--- a/modules/firewall/container_rules.tf
+++ b/modules/firewall/container_rules.tf
@@ -348,45 +348,7 @@ resource "proxmox_virtual_environment_firewall_rules" "minio_container" {
   depends_on = [proxmox_virtual_environment_firewall_options.minio_container]
 }
 
-# Object storage containers (RustFS — S3 API 9000, Console 9001)
-
-resource "proxmox_virtual_environment_firewall_options" "object_storage_container" {
-  for_each = var.object_storage_container_ids
-
-  node_name     = var.node_name
-  container_id  = each.value
-  enabled       = local.firewall_defaults.enabled
-  input_policy  = local.firewall_defaults.input_policy
-  output_policy = local.firewall_defaults.output_policy
-  log_level_in  = local.firewall_defaults.log_level_in
-  log_level_out = local.firewall_defaults.log_level_out
-
-  depends_on = [proxmox_virtual_environment_cluster_firewall.main]
-}
-
-resource "proxmox_virtual_environment_firewall_rules" "object_storage_container" {
-  for_each = var.object_storage_container_ids
-
-  node_name    = var.node_name
-  container_id = each.value
-
-  rule {
-    security_group = proxmox_virtual_environment_cluster_firewall_security_group.internal_access.name
-    comment        = "Internal access (SSH, ICMP)"
-  }
-
-  rule {
-    security_group = proxmox_virtual_environment_cluster_firewall_security_group.object_storage_services.name
-    comment        = "Object storage services (TCP/9000 S3 API, TCP/9001 Console)"
-  }
-
-  rule {
-    security_group = proxmox_virtual_environment_cluster_firewall_security_group.outbound_internal.name
-    comment        = "Outbound to internal only"
-  }
-
-  depends_on = [proxmox_virtual_environment_firewall_options.object_storage_container]
-}
+# Object storage container firewall resources: modules/firewall/object_storage_rules.tf
 
 # Infisical container firewall resources live in modules/firewall/infisical_rules.tf
 # (extracted so container_rules.tf stays under the shared _file-size workflow's 12 KB error

--- a/modules/firewall/locals.tf
+++ b/modules/firewall/locals.tf
@@ -104,6 +104,11 @@ locals {
     { proto = "tcp", dport = tostring(local.svc_ports.minio_console), source = local.internal_src, comment = "MinIO Console from internal" },
   ]
 
+  object_storage_services_rules = [
+    { proto = "tcp", dport = tostring(local.svc_ports.object_storage_s3), source = local.internal_src, comment = "Object storage (RustFS) S3 API from internal" },
+    { proto = "tcp", dport = tostring(local.svc_ports.object_storage_console), source = local.internal_src, comment = "Object storage (RustFS) Console from internal" },
+  ]
+
   infisical_services_rules = [
     { proto = "tcp", dport = tostring(local.svc_ports.infisical_api), source = local.internal_src, comment = "Infisical API/Web from internal" },
   ]

--- a/modules/firewall/object_storage_rules.tf
+++ b/modules/firewall/object_storage_rules.tf
@@ -1,0 +1,42 @@
+# Object storage (RustFS) container firewall resources. Extracted from
+# container_rules.tf so that file stays under the shared _file-size workflow's
+# 12 KB error threshold (same pattern as infisical_rules.tf). S3 API on 9000,
+# Console on 9001 — both internal-only via the object-storage-svc group.
+
+resource "proxmox_virtual_environment_firewall_options" "object_storage_container" {
+  for_each = var.object_storage_container_ids
+
+  node_name     = var.node_name
+  container_id  = each.value
+  enabled       = local.firewall_defaults.enabled
+  input_policy  = local.firewall_defaults.input_policy
+  output_policy = local.firewall_defaults.output_policy
+  log_level_in  = local.firewall_defaults.log_level_in
+  log_level_out = local.firewall_defaults.log_level_out
+
+  depends_on = [proxmox_virtual_environment_cluster_firewall.main]
+}
+
+resource "proxmox_virtual_environment_firewall_rules" "object_storage_container" {
+  for_each = var.object_storage_container_ids
+
+  node_name    = var.node_name
+  container_id = each.value
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.internal_access.name
+    comment        = "Internal access (SSH, ICMP)"
+  }
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.object_storage_services.name
+    comment        = "Object storage services (TCP/9000 S3 API, TCP/9001 Console)"
+  }
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.outbound_internal.name
+    comment        = "Outbound to internal only"
+  }
+
+  depends_on = [proxmox_virtual_environment_firewall_options.object_storage_container]
+}

--- a/modules/firewall/security_groups.tf
+++ b/modules/firewall/security_groups.tf
@@ -267,6 +267,23 @@ resource "proxmox_virtual_environment_cluster_firewall_security_group" "minio_se
   }
 }
 
+resource "proxmox_virtual_environment_cluster_firewall_security_group" "object_storage_services" {
+  name    = "object-storage-svc"
+  comment = "Object storage (RustFS): S3 API (9000) and Console (9001) from internal networks"
+
+  dynamic "rule" {
+    for_each = local.object_storage_services_rules
+    content {
+      type    = "in"
+      action  = "ACCEPT"
+      proto   = rule.value.proto
+      dport   = rule.value.dport
+      source  = rule.value.source
+      comment = rule.value.comment
+    }
+  }
+}
+
 resource "proxmox_virtual_environment_cluster_firewall_security_group" "infisical_services" {
   name    = "infisical-svc"
   comment = "Infisical API/Web from internal networks (HAProxy front-ends TLS termination on its own ports)"

--- a/modules/firewall/variables.tf
+++ b/modules/firewall/variables.tf
@@ -58,7 +58,13 @@ variable "cribl_edge_container_ids" {
 }
 
 variable "minio_container_ids" {
-  description = "Map of MinIO container names to their IDs"
+  description = "Map of MinIO container names to their IDs (DEPRECATED — kept during the RustFS migration soak; remove after object-storage cutover)"
+  type        = map(number)
+  default     = {}
+}
+
+variable "object_storage_container_ids" {
+  description = "Map of object storage (RustFS) container names to their IDs"
   type        = map(number)
   default     = {}
 }

--- a/tests/firewall_filtering.tftest.hcl
+++ b/tests/firewall_filtering.tftest.hcl
@@ -352,6 +352,11 @@ run "object_storage_tagged_container_in_object_storage_ids" {
     condition     = !contains(keys(local.pipeline_container_ids), "object-storage")
     error_message = "Container with 'object-storage' tag must NOT be in pipeline_container_ids"
   }
+
+  assert {
+    condition     = !contains(keys(local.notification_container_ids), "object-storage")
+    error_message = "Container with 'object-storage' tag must NOT be in notification_container_ids"
+  }
 }
 
 # --- infisical_container_ids tests ---

--- a/tests/firewall_filtering.tftest.hcl
+++ b/tests/firewall_filtering.tftest.hcl
@@ -315,6 +315,45 @@ run "minio_tagged_container_in_minio_ids" {
   }
 }
 
+# --- object_storage_container_ids tests ---
+
+run "object_storage_tagged_container_in_object_storage_ids" {
+  command = plan
+
+  variables {
+    containers = {
+      "object-storage" = {
+        vm_id         = 202000
+        hostname      = "object-storage"
+        vlan          = "siem"
+        dhcp          = true
+        reserved_host = 20
+        tags          = ["terraform", "container", "object-storage", "storage", "infrastructure"]
+      }
+    }
+  }
+
+  assert {
+    condition     = contains(keys(local.object_storage_container_ids), "object-storage")
+    error_message = "Container with 'object-storage' tag must be in object_storage_container_ids"
+  }
+
+  assert {
+    condition     = local.object_storage_container_ids["object-storage"] == 202000
+    error_message = "object_storage_container_ids['object-storage'] should be vm_id 202000"
+  }
+
+  assert {
+    condition     = !contains(keys(local.minio_container_ids), "object-storage")
+    error_message = "Container with 'object-storage' tag must NOT be in minio_container_ids"
+  }
+
+  assert {
+    condition     = !contains(keys(local.pipeline_container_ids), "object-storage")
+    error_message = "Container with 'object-storage' tag must NOT be in pipeline_container_ids"
+  }
+}
+
 # --- infisical_container_ids tests ---
 
 run "infisical_tagged_container_in_infisical_ids" {


### PR DESCRIPTION
## Why

MinIO's free/community edition is end-of-life — upstream archived the open-source repository in Feb 2026 (console removed May 2025, community binaries stopped Oct 2025). This repo runs a `minio` LXC as the homelab's S3-compatible object store (Splunk add-on artifacts + internal artifact mirror). This is **step 1** of migrating that workload to **RustFS** under a neutral `object-storage` name.

A throwaway RustFS spike confirmed (via `aws s3api`) that it covers everything the current workload needs: bucket versioning + history, `NoncurrentVersionExpiration` lifecycle, anonymous public-read policy with working unauthenticated GET, and object tagging.

## What

Adds the `object-storage` (RustFS) guest **alongside** the existing `minio` guest — a deliberate dual-run so MinIO stays the writable rollback path during the soak. Both are removed together after cutover.

- **constants**: `object_storage_s3` / `object_storage_console` ports (kept next to `minio_*` during soak)
- **locals + firewall module**: `object_storage_container_ids`, an `object-storage-svc` security group (S3 API + Console, internal-only), and container firewall rules
- **ingress**: front the RustFS console via Traefik
- **tests**: object-storage tag filtering + mutual-exclusion assertions

## Placement

- VMID **202000** — tier-2 (storage) positional ID per the numbering scheme
- Colocated on the existing **VLAN 20** (where Splunk, its main consumer, lives — no new VLAN)
- `dhcp` + `reserved_host` (positional IDs overflow `/24` derivation), referenced by hostname

## Not in this PR / follow-ups

- The container **definition** lives in the gitignored `deployment.json` (pre-apply step, not committed).
- A deterministic DHCP reservation for the guest must be added downstream (tofu-unifi).
- The RustFS install **ansible role** (downstream apps repo), data migration, consumer repoint, soak, and full MinIO decommission are subsequent phases.
- RustFS is **beta** — pinned explicitly in the role; the dual-run soak is the safety net.

## Verification

`tofu fmt -check`, `tofu validate`, and the full `tofu test` suite (103 passed) are green locally; CI re-runs them. Credentialed `plan`/`apply` are gated and run separately.