### PR TITLE
feat(proxmox-container): derive Docker-in-LXC features from the docker tag

### DIFF
--- a/modules/proxmox-container/locals.tf
+++ b/modules/proxmox-container/locals.tf
@@ -1,0 +1,23 @@
+# Docker-in-LXC feature derivation.
+#
+# A container tagged `docker` runs Docker inside the LXC, which requires the
+# `nesting` + `keyctl` features, plus `fuse` for the fuse-overlayfs storage driver
+# this homelab uses on ZFS-backed LXCs (the ansible-proxmox-apps registry-mirror
+# play sets storage-driver=fuse-overlayfs). Derive all three from the tag so every
+# docker guest gets the full set automatically instead of hand-declaring them per
+# container — they had drifted (some nesting+keyctl+fuse, some only nesting, some
+# none, while live containers carried features applied out-of-band by pct/Ansible).
+#
+# The tag only ever ADDS: any explicitly-declared feature still applies (logical OR),
+# so a non-docker container is unaffected and a docker container that already
+# declared the full set sees no change.
+locals {
+  effective_features = {
+    for k, c in var.containers : k => {
+      nesting = c.features.nesting || contains(c.tags, "docker")
+      keyctl  = c.features.keyctl || contains(c.tags, "docker")
+      fuse    = c.features.fuse || contains(c.tags, "docker")
+      mount   = c.features.mount
+    }
+  }
+}

--- a/modules/proxmox-container/main.tf
+++ b/modules/proxmox-container/main.tf
@@ -139,16 +139,23 @@ resource "proxmox_virtual_environment_container" "containers" {
     type             = each.value.os_type
   }
 
-  # Container features (nesting for Docker, keyctl for overlay fs)
-  # Only emit features block when any non-default value is set.
-  # Creating privileged containers with a features block requires root@pam.
+  # Container features. nesting/keyctl/fuse are DERIVED from the `docker` tag in
+  # locals.tf (local.effective_features) so docker guests get the full Docker-in-LXC
+  # set automatically; explicit per-container features still apply on top.
+  # Only emit the block when any value is set. Creating privileged containers with a
+  # features block requires root@pam.
   dynamic "features" {
-    for_each = (each.value.features.nesting || each.value.features.keyctl || each.value.features.fuse || length(each.value.features.mount) > 0) ? [1] : []
+    for_each = (
+      local.effective_features[each.key].nesting
+      || local.effective_features[each.key].keyctl
+      || local.effective_features[each.key].fuse
+      || length(local.effective_features[each.key].mount) > 0
+    ) ? [1] : []
     content {
-      nesting = each.value.features.nesting
-      keyctl  = each.value.features.keyctl
-      fuse    = each.value.features.fuse
-      mount   = each.value.features.mount
+      nesting = local.effective_features[each.key].nesting
+      keyctl  = local.effective_features[each.key].keyctl
+      fuse    = local.effective_features[each.key].fuse
+      mount   = local.effective_features[each.key].mount
     }
   }
 


### PR DESCRIPTION
## What

Derives LXC `nesting` + `keyctl` + `fuse` from the `docker` tag instead of hand-declaring them per container. New `modules/proxmox-container/locals.tf` computes `local.effective_features` = each container's declared features **OR** the docker-tag-derived set; the `features` dynamic block reads it.

## Why

Docker-in-LXC needs `nesting` + `keyctl`, plus `fuse` for the fuse-overlayfs storage driver this homelab uses on ZFS-backed LXCs. These were hand-declared and had **drifted badly**:

| Guest | Declared features (deployment.json) | Runs Docker? |
|---|---|---|
| mailpit / ntfy / mssql | nesting + keyctl + fuse | yes |
| infisical / idrac-kvm / openproject / qdrant / unifi-metrics | **nesting only** | yes |
| docker-host / **prometheus (CT195)** | **none** | yes |

Meanwhile the live containers carry features applied out-of-band via `pct`/Ansible — e.g. CT195 runs with nesting/keyctl/fuse but declares no features block. Terraform's view and reality diverged (closes the task-#9 gap; CT195 is now reconciled via its `docker` tag).

The tag only ever **ADDs** (logical OR), so non-docker guests are unaffected and docker guests already declaring the full set see no change.

## ⚠️ GATED APPLY — blast radius

A `terragrunt plan` will show feature **additions** on the docker guests that currently lack the full set (CT195 prometheus, docker-host, infisical, idrac-kvm, openproject, qdrant, unifi-metrics). **Changing LXC features may require a container restart** to take effect. Review the plan per-container and apply during a maintenance window; do **not** bundle with unrelated applies, and coordinate the S3/Dynamo lock with other active sessions.

## Validation

- `tofu fmt -check`: clean.
- `tofu validate` (module, `-backend=false`): **Success**.
- Plan/apply intentionally **not** run here — gated on your aws-vault creds + maintenance window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)