### PR TITLE
feat(storage): document the appdata dataset for persistent app config

### DIFF
--- a/deployment.json.example
+++ b/deployment.json.example
@@ -43,7 +43,9 @@
             "backups": { "quota": "1T", "properties": { "compression": "zstd" } },
             "databases": { "quota": "1T", "nfs_export": "ro=@10.0.0.0/8", "properties": { "recordsize": "16K", "atime": "off", "compression": "zstd" } },
             "media/tv": { "quota": "2T", "properties": { "recordsize": "1M", "compression": "zstd" } },
-            "media/movies": { "quota": "2T", "properties": { "recordsize": "1M", "compression": "zstd" } }
+            "media/movies": { "quota": "2T", "properties": { "recordsize": "1M", "compression": "zstd" } },
+            "appdata": { "properties": { "recordsize": "16K", "atime": "off", "compression": "zstd" } },
+            "appdata/plex": {}
           }
         },
         "example-nvme": {

--- a/deployment.json.example
+++ b/deployment.json.example
@@ -44,7 +44,7 @@
             "databases": { "quota": "1T", "nfs_export": "ro=@10.0.0.0/8", "properties": { "recordsize": "16K", "atime": "off", "compression": "zstd" } },
             "media/tv": { "quota": "2T", "properties": { "recordsize": "1M", "compression": "zstd" } },
             "media/movies": { "quota": "2T", "properties": { "recordsize": "1M", "compression": "zstd" } },
-            "appdata": { "properties": { "recordsize": "16K", "atime": "off", "compression": "zstd" } },
+            "appdata": { "quota": "100G", "properties": { "recordsize": "16K", "atime": "off", "compression": "zstd" } },
             "appdata/plex": {}
           }
         },


### PR DESCRIPTION
## What

Adds an `appdata` dataset (parent + an `appdata/plex` child) to the `node_storage` example in `deployment.json.example`.

## Why

Application **config/state** (Plex identity + watch history, the *arrs' configs, qBittorrent's settings) lives under each app's home dir — on the **disposable LXC rootfs** by default, so a container rebuild wipes it (Plex resets to a brand-new server, etc.). `bulk/appdata` is the correct home for this class of data:

- distinct from `databases` (database engines) and `media` (the re-acquirable library);
- bind-mounted into each app by the ansible `media_lxc_features` role (dryvist/ansible-proxmox#286);
- snapshotted (sanoid `critical`, hourly) + replicated to the DR node, with one child per app (`appdata/plex`, future `appdata/sonarr`, …).

This is the schema/example side; the realization (mount + ownership + snapshot/replication) is in dryvist/ansible-proxmox#286, with a loud persistence guard in dryvist/ansible-proxmox-apps#461.

🤖 Generated with [Claude Code](https://claude.com/claude-code)