### PR TITLE
fix(ingress): drop the dead pi-hole route (no Pi-hole app on that backend)

### DIFF
--- a/constants.tf
+++ b/constants.tf
@@ -47,7 +47,6 @@ locals {
       # every port lives in one place and the ingress table (below) references
       # constants, never literals.
       technitium_web    = 5380
-      pihole_web        = 80
       phpipam_web       = 80
       homeassistant_web = 8123
       openproject_web   = 80

--- a/ingress.tf
+++ b/ingress.tf
@@ -17,7 +17,6 @@ locals {
     qbittorrent      = { backend = "download-vpn", port = local.pipeline_constants.media_ports.qbittorrent_web }
     prowlarr         = { backend = "download-vpn", port = local.pipeline_constants.media_ports.prowlarr_web }
     technitium       = { backend = "technitium-dns", port = local.pipeline_constants.service_ports.technitium_web }
-    pihole           = { backend = "pi-hole", port = local.pipeline_constants.service_ports.pihole_web }
     phpipam          = { backend = "phpipam", port = local.pipeline_constants.service_ports.phpipam_web }
     minio            = { backend = "minio", port = local.pipeline_constants.service_ports.minio_console }
     "object-storage" = { backend = "object-storage", port = local.pipeline_constants.service_ports.object_storage_console }


### PR DESCRIPTION
The `pihole` ingress route fronts a backend that runs no Pi-hole web app on
:80, so Traefik returns 502 for it permanently — a dangling route in the
single source of truth. Remove the route and its now-orphaned `pihole_web`
constant (no other in-repo or downstream consumer).

Scope is the ingress route only. The `dns_servers` resolver list keeps its
secondary entry — that backend still answers DNS as the HA pair member; the
cosmetic relabel of that container is deferred.
