### PR TITLE
fix(firewall): open TCP 9201 on cribl_stream containers for prometheus_rw

### DIFF
--- a/constants.tf
+++ b/constants.tf
@@ -27,10 +27,12 @@ locals {
       cribl_edge_api    = 9420
       cribl_stream_api  = 9000
       # Cribl-to-Cribl (S2S/TCP-JSON) ingestion: remote Edge nodes -> HAProxy -> Stream
-      cribl_s2s     = 10300
-      apt_cacher_ng = 3142
-      minio_api     = 9000
-      minio_console = 9001
+      cribl_s2s = 10300
+      # Cribl Stream Prometheus remote_write receiver (internal-only; no Traefik/DNS)
+      cribl_prometheus_rw = 9201
+      apt_cacher_ng       = 3142
+      minio_api           = 9000
+      minio_console       = 9001
       # Object storage (RustFS) — replaces MinIO. Both kept during the migration
       # soak; remove the minio_* pair once object-storage cutover is stable.
       object_storage_s3      = 9000

--- a/modules/firewall/locals.tf
+++ b/modules/firewall/locals.tf
@@ -97,6 +97,7 @@ locals {
   cribl_stream_services_rules = [
     { proto = "tcp", dport = tostring(local.svc_ports.cribl_stream_api), source = local.internal_src, comment = "Cribl Stream API from internal" },
     { proto = "tcp", dport = tostring(local.svc_ports.cribl_s2s), source = local.internal_src, comment = "Cribl S2S input (HAProxy -> Stream) from internal" },
+    { proto = "tcp", dport = tostring(local.svc_ports.cribl_prometheus_rw), source = local.internal_src, comment = "Prometheus remote_write receiver from internal" },
   ]
 
   minio_services_rules = [


### PR DESCRIPTION
## Summary

- Prometheus CT 195 (`10.0.20.195`) attempts to POST remote_write data to Cribl Stream CT 182 (`10.0.25.182:9201`), but all TCP SYNs are dropped by the Proxmox CT firewall — port 9201 was never in any security group.
- Add `cribl_prometheus_rw = 9201` to `pipeline_constants.service_ports` (single source of truth).
- Add TCP-9201-from-internal rule to `cribl_stream_services_rules` in the firewall module.

## Why `service_ports` and not `locals.tf` directly

Every port literal goes in `constants.tf` so all consumers reference the same name. This one is internal-only (no Traefik ingress or DNS), but it still belongs here per the repo convention.

## Test plan

- [ ] `terragrunt plan` shows only 2 firewall rule additions (cribl-stream-01 + cribl-stream-02), no unexpected diffs
- [ ] `terragrunt apply` merges cleanly
- [ ] After apply: `ss -tlnp` on CT 195 (prometheus) shows connections to 10.0.25.182:9201 leave `SYN-SENT` and complete
- [ ] `prometheus_remote_storage_succeeded_samples_total` increments
- [ ] Splunk `index=netmon` receives events

> **Requires `aws-vault exec tf-proxmox -- claude` session** to run `terragrunt plan/apply` — see `~/CLAUDE.local.md` AWS state-backend rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)