### PR TITLE
docs(architecture): media on unified bulk/data; retire pve1 rpool/data/* refs

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -205,16 +205,18 @@ Notable per-container facts:
   internal notifications.
 - `download-vpn` is an unprivileged LXC with `/dev/net/tun` passed through
   (`device_passthrough`) so WireGuard can create `wg0` inside the container.
-  `rpool/data/downloads` and `rpool/data/media` are bind-mounted from the media-node host
-  (size-less `mount_points`); the `ansible-proxmox` `zfs_pools` role provisions
-  these datasets ahead of LXC creation. Egress is locked to the VPN by an in-LXC
+  The unified `bulk/data` dataset is bind-mounted from the media-node host as
+  `/data` (size-less `mount_points`) — a single filesystem so torrents and the
+  library hardlink with zero duplication; the `ansible-proxmox` `zfs_pools` role
+  provisions the dataset and `lxc_media_features` applies the mount ahead of use.
+  Egress is locked to the VPN by an in-LXC
   nftables killswitch (config + continuous validation owned by
   `ansible-proxmox-apps` `download_vpn` role); Proxmox-level firewall is
   intentionally not applied to the media pool — the killswitch is the security
   boundary.
 - `sonarr`, `radarr`, `plex` are LAN-only (no VPN); they reach Prowlarr +
-  qBittorrent on `download-vpn` over the LAN and read/write the same
-  bind-mounted `rpool/data/*` datasets.
+  qBittorrent on `download-vpn` over the LAN and read/write the same unified
+  `bulk/data` (`/data`) dataset.
 - `traefik` (VMID 101) is the HTTPS reverse-proxy / TLS ingress on the
   management VLAN (VLAN 5), co-located with `haproxy`; backends on other VLANs
   are reached via inter-VLAN routing (UniFi allow rules per UI port). It

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -208,7 +208,7 @@ Notable per-container facts:
   The unified `bulk/data` dataset is bind-mounted from the media-node host as
   `/data` (size-less `mount_points`) — a single filesystem so torrents and the
   library hardlink with zero duplication; the `ansible-proxmox` `zfs_pools` role
-  provisions the dataset and `lxc_media_features` applies the mount ahead of use.
+  provisions the dataset and `media_lxc_features` applies the mount ahead of use.
   Egress is locked to the VPN by an in-LXC
   nftables killswitch (config + continuous validation owned by
   `ansible-proxmox-apps` `download_vpn` role); Proxmox-level firewall is


### PR DESCRIPTION
## What
Updates `docs/ARCHITECTURE.md` to describe the as-built v2 media layout. The v1 `pve1 rpool/data/{downloads,media}` datasets were retired and **destroyed 2026-06-17** after confirming pve2 `bulk/data` is a complete file-level superset of the old library; ~810 G reclaimed on pve1 (rpool 32% → 9%).

## Changes
- `download-vpn` bullet: bind-mounts the unified `bulk/data` as `/data` (single filesystem → hardlinks, zero duplication); `zfs_pools` provisions it, `lxc_media_features` applies the mount.
- `sonarr`/`radarr`/`plex` bullet: read/write the same unified `bulk/data` (`/data`) instead of `rpool/data/*`.

## Notes
- The live (gitignored) `deployment.json` was also updated: pve1 `node_storage` rpool block removed, `_media_comment` rewritten to v2. A `terragrunt apply` + inventory republish (credentialed session) is needed to propagate that to the published inventory.
- Companion docs-starlight update in dryvist/docs-starlight#43.

## Verification
- No remaining v1-layout refs in the doc (grep clean). markdownlint/gitleaks/pre-commit pass.