### PR TITLE
docs(secrets): document Proton Pass as an exploratory future root-of-trust

### DIFF
--- a/.proton-pass.refs.json
+++ b/.proton-pass.refs.json
@@ -1,0 +1,13 @@
+{
+  "_comment": "Proton Pass secret-zero reference manifest. Paths ONLY — never secret values (analogous to .sops.yaml holding only the public key). Every repo/agent resolves the same pass:// references via the Proton Pass CLI. See docs/PROTON_PASS_STRATEGY.md.",
+  "_format": "pass://<vault>/<item>/<field>",
+  "references": {
+    "sops_age_key": "pass://infra/sops-age/keys.txt"
+  },
+  "_planned": {
+    "_comment": "Reserved for Tier 2/4 rollout — not consumed by PR-1. Uncomment and populate as OpenBao / CI OIDC land.",
+    "openbao_approle": "pass://infra/openbao/approle",
+    "openbao_unseal": "pass://infra/openbao/unseal-keys",
+    "aws_bootstrap": "pass://infra/aws-bootstrap/credentials"
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,18 @@ doppler run -- terragrunt apply
 doppler run -- terragrunt show
 ```
 
+Exploratory (not implemented): a Proton Pass bootstrap path is being explored so
+a fresh host (including Linux cloud agents) can materialize the SOPS age key and
+decrypt `terraform.sops.json` off-macOS:
+
+```bash
+./scripts/secrets-bootstrap.sh   # idempotent; no-clobber; writes nothing to git
+```
+
+Proton Pass as a cross-repo root-of-trust (Tier 0) + AI-agent keychain (Tier 1)
+is a proposed future direction only — not the current design. See
+[`docs/PROTON_PASS_STRATEGY.md`](./docs/PROTON_PASS_STRATEGY.md).
+
 The BPG Proxmox provider reads `PROXMOX_VE_*` env vars directly — no
 `--name-transformer` needed. The Nix shell activates via direnv (`.envrc`).
 
@@ -60,6 +72,11 @@ locals.tf derivations    (computed)             — management_network, splunk_n
   `domain`, `vm_ssh_public_key_path`, `vm_ssh_private_key_path`,
   `proxmox_ssh_username`. Decrypted automatically by Terragrunt.
 - Doppler — credentials at runtime (provider auth + SSH key content).
+- The SOPS **age private key** is set up per host today (`age-keygen`). An
+  exploratory proposal would source it from Proton Pass
+  (`pass://infra/sops-age/keys.txt`) via `scripts/secrets-bootstrap.sh` to give it
+  a portable home so SOPS decryption works on Linux/cloud agents too — not yet
+  implemented.
 - `management_network` and `splunk_network` are derived in `locals.tf` and
   must never be set manually.
 
@@ -160,6 +177,7 @@ For slow operations and "context deadline exceeded" debugging:
 | --- | --- |
 | Architecture (canonical) | [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md) |
 | Secrets roadmap | [`docs/SECRETS_ROADMAP.md`](./docs/SECRETS_ROADMAP.md) |
+| Proton Pass (exploratory future root-of-trust + AI keychain) | [`docs/PROTON_PASS_STRATEGY.md`](./docs/PROTON_PASS_STRATEGY.md) |
 | SOPS / age setup | [`docs/SOPS_SETUP.md`](./docs/SOPS_SETUP.md) |
 | Network-quality monitoring (SmokePing) | [`docs/SMOKEPING.md`](./docs/SMOKEPING.md) |
 | Honeypots / deception fabric + phone alerting | [`docs/HONEYPOTS.md`](./docs/HONEYPOTS.md) |

--- a/README.md
+++ b/README.md
@@ -26,6 +26,18 @@ Doppler (provider secrets). Run all commands through the wrapper:
 aws-vault exec tf-proxmox -- doppler run -- terragrunt <COMMAND>
 ```
 
+Exploratory (not implemented): a Proton Pass bootstrap path is being explored to
+materialize the SOPS age key on fresh hosts (incl. Linux cloud agents), so the
+wrapper can decrypt `terraform.sops.json` anywhere:
+
+```bash
+./scripts/secrets-bootstrap.sh   # idempotent; writes ~/.config/sops/age/keys.txt if absent
+```
+
+Today the age key is set up per host via `age-keygen` (see
+[docs/SOPS_SETUP.md](./docs/SOPS_SETUP.md)); the Proton Pass proposal is in
+[docs/PROTON_PASS_STRATEGY.md](./docs/PROTON_PASS_STRATEGY.md).
+
 Common operations:
 
 ```bash
@@ -74,6 +86,7 @@ The full suite runs automatically in CI on every PR.
 | --- | ------- |
 | [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md) | Pipeline architecture and IP derivation |
 | [docs/SOPS_SETUP.md](./docs/SOPS_SETUP.md) | SOPS + age setup, Doppler integration |
+| [docs/PROTON_PASS_STRATEGY.md](./docs/PROTON_PASS_STRATEGY.md) | Exploratory: Proton Pass as a future root-of-trust + AI-agent keychain |
 | [TROUBLESHOOTING.md](./TROUBLESHOOTING.md) | Operational guidance, timeout/debug logging |
 
 ## License

--- a/docs/INFISICAL_PLANNING.md
+++ b/docs/INFISICAL_PLANNING.md
@@ -2,11 +2,21 @@
 
 <!-- DO NOT DELETE - Active planning document -->
 
+> **ℹ️ Domain-split with OpenBao.** The roadmap splits the credential plane into
+> two domain-split systems with **no sync between them**: **OpenBao** (the Vault
+> fork in `aws-infra/modules/openbao-unseal`) is the machine/IaC/dynamic-secrets
+> engine, and **Infisical** (this document) is the human UI + developer
+> integration hub. OpenBao's seal key stays in the **Doppler tier-0 kernel** — see
+> [SECRETS_ROADMAP.md](./SECRETS_ROADMAP.md). A cross-platform secret-zero home in
+> Proton Pass is **exploratory only** (not implemented) —
+> [PROTON_PASS_STRATEGY.md](./PROTON_PASS_STRATEGY.md).
+
 Self-hosted Infisical deployment on Proxmox infrastructure.
 
 **Status:** IN PROGRESS — Phase 1 deploy (LXC + firewall landing via
 `terraform-proxmox`; Ansible role + HAProxy frontend land via
-`ansible-proxmox-apps` PR 3).
+`ansible-proxmox-apps` PR 3). Scoped to the human UI + developer hub role,
+domain-split from OpenBao (see banner).
 
 ## Phase 1 — concrete values
 

--- a/docs/PROTON_PASS_STRATEGY.md
+++ b/docs/PROTON_PASS_STRATEGY.md
@@ -1,0 +1,183 @@
+# Proton Pass — Secrets Root-of-Trust & AI-Agent Keychain (Exploratory)
+
+> **Status: Exploratory — NOT implemented.** This is a proposed future direction,
+> not the current design. Today the tier-0 kernel (including the OpenBao
+> `OPENBAO_STATIC_SEAL_KEY`) lives in **Doppler**, and AI-agent keys live in the
+> `ai-secrets` **macOS Keychain**. Nothing below is in production; adopt only if
+> the cross-platform secret-zero and per-agent-token gaps become blocking. The
+> current, authoritative design is in [SECRETS_ROADMAP.md](./SECRETS_ROADMAP.md).
+
+Cross-repo *proposal* for using the **Proton Pass CLI** as a portable,
+end-to-end-encrypted **root-of-trust** for the Proxmox homelab ecosystem, and as
+an **auditable keychain for AI agents**.
+
+> Companion to [SECRETS_ROADMAP.md](./SECRETS_ROADMAP.md). This document owns the
+> exploratory Proton Pass tier; the roadmap owns the overall picture.
+
+## Why Proton Pass, and only for this
+
+The secrets stack has sprawled to five active systems (Doppler, aws-vault,
+a separate `ai-secrets` macOS Keychain, SOPS+age, GitHub Actions tokens) plus two
+planned (Infisical, OpenBao). Three concrete problems motivate this:
+
+1. **Several stores are macOS-only.** aws-vault's Keychain backend and the
+   `ai-secrets` Keychain do not exist on the Linux **cloud agents** this repo now
+   runs in. Anything bootstrapped from them is unavailable off-Mac.
+2. **The age private key has no documented home.** `~/.config/sops/age/keys.txt`
+   is "generate it, don't commit it" — there is no portable, backed-up,
+   recoverable source of truth for the one key that decrypts all committed config.
+3. **No story for many AI agents.** A growing fleet of Claude Code / cloud agents
+   shares one keychain entry: no per-agent scoping, expiry, revocation, or audit.
+
+Proton Pass CLI (GA, GPLv3, cross-platform — Linux/macOS/Windows) is used **only**
+where it is genuinely best:
+
+- **Tier 0 — root-of-trust:** holds every long-lived *secret-zero* in one
+  portable, e2e-encrypted, audited vault, reachable identically on a laptop or a
+  Linux cloud agent.
+- **Tier 1 — AI-agent keychain:** Proton Pass **AI Access Tokens** give each agent
+  a read-only, expiring, reason-tagged, individually-revocable, logged credential.
+
+Proton Pass is deliberately **not** the rotation engine or runtime injector — it
+has **no native rotation** and **no service-account REST API** (PATs are
+user-scoped). Those jobs belong to OpenBao and Doppler/SOPS respectively.
+
+## Target architecture (tiers)
+
+```mermaid
+flowchart TD
+    subgraph T0["Tier 0 — Proton Pass: ROOT OF TRUST (secret-zero) — EXPLORATORY"]
+        AGE[age private key<br/>keys.txt]
+        AWSB[AWS bootstrap creds<br/>/ OIDC config]
+        GH[GitHub App keys<br/>GH_AW_*]
+        DOP[Doppler service token<br/>transitional]
+    end
+    subgraph DKERNEL["Doppler tier-0 kernel — CURRENT (unchanged)"]
+        SEAL[OPENBAO_STATIC_SEAL_KEY<br/>+ VAULT approle id]
+    end
+    subgraph T1["Tier 1 — Proton Pass: AI ACCESS TOKENS"]
+        AIT[one token per agent<br/>read-only · expiring · revocable · logged]
+    end
+    subgraph T2["Tier 2 — OpenBao: ROTATION / RUNTIME (auto-rotated)"]
+        PVE[Proxmox API tokens]
+        AWSD[AWS dynamic creds]
+        APP[SPLUNK_* / app secrets]
+    end
+    subgraph T3["Tier 3 — SOPS + age: git-committed deploy config"]
+        SOPSF[terraform.sops.json]
+    end
+    subgraph T4["Tier 4 — CI"]
+        OIDC[GitHub OIDC for AWS]
+        SYNC[engine-synced repo secrets]
+    end
+
+    AGE --> SOPSF
+    SEAL --> T2
+    AWSB --> T4
+    AIT --> Agents[Claude Code / cloud agents]
+    T2 --> Consumers[Terraform / Ansible runtime]
+    DOP -.transitional.-> Consumers
+```
+
+**If adopted, Proton Pass would own Tier 0 + Tier 1 only.** The OpenBao seal key
+stays in the **Doppler tier-0 kernel** (a cold cluster must be able to unseal
+itself without Proton), and Tiers 2–4 already track the roadmap's reconciled
+destination.
+
+## The `pass://` reference convention
+
+Every secret-zero item is addressed by a stable reference, committed (paths only,
+no values) in [`.proton-pass.refs.json`](../.proton-pass.refs.json) at the repo
+root — analogous to `.sops.yaml` holding only the public key. Format:
+
+```text
+pass://<vault>/<item>/<field>
+```
+
+All repos and agents resolve the **same** references, so there is one canonical
+location per secret. Retrieval uses the Proton Pass CLI:
+
+| Need | Command (confirm flags against the CLI docs¹) |
+| --- | --- |
+| Fetch one field to stdout/file | `pass read "pass://infra/sops-age/keys.txt"` |
+| Inject secrets as env for a command | `pass run -- <command>` |
+| Expand a template file | `pass inject -i tmpl -o out` |
+| Machine-readable output | append `--output json` |
+
+¹ Command/flag names follow the official docs at
+<https://protonpass.github.io/pass-cli/>. Treat that as the source of truth and
+adjust the wrapper script if a subcommand differs.
+
+## AI Access Token policy (Tier 1)
+
+Replaces the shared `ai-secrets` macOS Keychain entry. For every AI agent:
+
+- **One token per agent identity** (per Claude Code instance / cloud-agent fleet
+  member) — never a shared token.
+- **Read-only**, scoped to the **minimum** vault/items the agent needs.
+- **Mandatory expiry ≤ 90 days** (Proton enforces expiry; we set the policy).
+- **Reason-tagged** on every access; **activity logged** centrally.
+- **Revocable immediately** — compromise or offboarding revokes one token, not the
+  fleet.
+
+Because the account is **Proton Family/Unlimited**, minting tokens is **unlimited
+and free** — there is no per-agent or per-repo seat cost. This is the direct
+answer to the "lots of AIs / accounts / integrations / repos" limit concern.
+
+## Rotation strategy
+
+Proton Pass holds the *bootstrap* secret for each system; rotation of the live
+credentials is owned by the engine, not the vault.
+
+| Secret | Mechanism | Cadence |
+| --- | --- | --- |
+| Proxmox API tokens | OpenBao + scripted create/delete via Proxmox API → written to engine | 30–90d |
+| AWS access | GitHub OIDC (CI) + OpenBao AWS dynamic creds — no static keys | short TTL / on-demand |
+| age private key | `sops updatekeys` then update the Proton item | on personnel/device change |
+| AI agent tokens | Proton AI Access Tokens, mandatory expiry | ≤90d auto-expire |
+| Proton PATs | scoped per vault/item, mandatory expiry | ≤1y |
+
+## Affordability & limits
+
+- **No per-agent / per-repo cost.** One Family/Unlimited account mints unlimited
+  scoped PATs + AI Access Tokens. Avoids Doppler/1Password per-seat scaling as
+  agents and repos multiply.
+- **Free engines.** OpenBao (self-hosted), SOPS, and GitHub OIDC carry the
+  rotation/runtime plane at $0 software cost.
+- **Net.** The only paid component (Proton, already owned) covers the human +
+  AI-agent root-of-trust; everything that scales with repo/agent count is free.
+
+## Reconciliation with the existing roadmap
+
+This proposal does **not** alter the current roadmap; it would layer on top of it
+if adopted:
+
+- **OpenBao and Infisical stay domain-split** per the roadmap — OpenBao is the
+  machine/IaC/dynamic-secrets engine, Infisical the human UI + developer hub, with
+  no sync between them. This document does not supersede either.
+- **The OpenBao seal key stays in the Doppler tier-0 kernel**, unchanged. Proton
+  Pass would never hold it.
+- **`ai-secrets` macOS Keychain remains the current AI-agent store.** Tier 1 AI
+  Access Tokens are a *candidate* cross-platform + audited successor, not a live
+  replacement.
+- **SOPS+age and Doppler are unchanged.** The only thing this proposal would move
+  is the age key's *home* (into Proton Pass) — and only if adopted.
+
+## Rollout sequence (only if adopted)
+
+1. **Foundation.** Proton Pass becomes a portable home for the age key and other
+   secret-zero; [`scripts/secrets-bootstrap.sh`](../scripts/secrets-bootstrap.sh)
+   materializes it cross-platform; docs updated. No runtime/HCL change.
+2. **Tier 2 — OpenBao on Proxmox** + Proxmox-token rotation job (separate effort;
+   already tracked as PLANNED-FOR-DEPLOY in the roadmap).
+3. **Tier 4 — GitHub OIDC for AWS** + engine-synced repo secrets (retire
+   `secrets-sync`).
+4. **Per-repo rollout** of the bootstrap + AI-token model to `ansible-proxmox*`,
+   `ansible-splunk`, `terraform-aws*`.
+
+## References
+
+- Proton Pass CLI docs — <https://protonpass.github.io/pass-cli/>
+- Proton Pass CLI source (GPLv3) — <https://github.com/protonpass/pass-cli>
+- Proton Pass AI Access Tokens — <https://proton.me/blog/pass-access-tokens>
+- OpenBao — <https://openbao.org/>

--- a/docs/SECRETS_ROADMAP.md
+++ b/docs/SECRETS_ROADMAP.md
@@ -67,6 +67,10 @@ API keys for Claude Code and AI agents stored in a dedicated keychain.
 - Retrieved at runtime by Claude Code plugins
 - Never stored in files or environment variables
 
+> A cross-platform successor for this store (Proton Pass AI Access Tokens) is
+> being **explored** — see the exploratory entry under *Under Consideration*. It
+> is not implemented; the `ai-secrets` keychain remains the current store.
+
 ## Planned
 
 ### ACTIVE: SOPS + Age (Git-Committed Encrypted Deployment Config)
@@ -189,6 +193,38 @@ cloud-native workloads.
 
 **Decision:** On hold. Revisit if GCP workloads are added to the ecosystem.
 
+### EXPLORATORY: Proton Pass (Potential Future Tier-0 Root-of-Trust + AI Keychain)
+
+<!-- Exploratory only — NOT implemented. Does not change the current design. -->
+
+Proton Pass is being **explored** as a possible future, cross-platform,
+end-to-end-encrypted home for long-lived *secret-zero*, and as an auditable
+keychain for AI agents. It is **not implemented** and does **not** supersede the
+current design. Doppler remains the tier-0 kernel (including the
+`OPENBAO_STATIC_SEAL_KEY`), and the `ai-secrets` macOS Keychain remains the
+current AI-agent key store. Full exploratory design in
+[PROTON_PASS_STRATEGY.md](./PROTON_PASS_STRATEGY.md).
+
+**What it could offer (if adopted):**
+
+- **Cross-platform secret-zero home** — reachable identically on a laptop or a
+  Linux cloud agent, where the macOS Keychain and aws-vault Keychain backends do
+  not exist. A candidate portable home for the SOPS age private key, materialized
+  by `./scripts/secrets-bootstrap.sh`; references tracked in
+  `.proton-pass.refs.json`.
+- **Per-agent AI Access Tokens** — one read-only, expiring (≤90d), reason-tagged,
+  individually-revocable, logged token per agent, replacing the single shared
+  keychain entry. Unlimited/free minting on a Proton Family/Unlimited account.
+
+**Explicitly out of scope:** Proton Pass is not a rotation engine or runtime
+injector (no native rotation, no service-account REST API). It would **not** hold
+the OpenBao seal key — that stays in Doppler tier-0 so a cold cluster can always
+unseal itself. Rotation stays with OpenBao; runtime injection stays with
+Doppler/SOPS.
+
+**Decision:** Exploratory only. No adoption committed. Revisit if the
+cross-platform secret-zero and per-agent-token gaps become blocking.
+
 ## Secrets Flow Summary
 
 ```text
@@ -217,6 +253,12 @@ OpenBao (planned-for-deploy) — machine/IaC secrets engine
 
 Infisical (planned) — human UI + developer integration hub
 └── Self-hosted ───────→ domain-split from OpenBao (no sync)
+
+Proton Pass (EXPLORATORY — not implemented; see PROTON_PASS_STRATEGY.md)
+╌╌ Tier 0 ╌╌╌╌╌╌╌╌╌╌╌╌╌⤍ potential future cross-platform secret-zero home
+╌╌ └╌ age private key ╌⤍ candidate portable home for the SOPS age key
+╌╌ Tier 1 ╌╌╌╌╌╌╌╌╌╌╌╌╌⤍ potential per-agent AI Access Tokens (replace ai-secrets)
+   (would NOT hold the OpenBao seal key — that stays in Doppler tier-0)
 ```
 
 ## Migration Path
@@ -235,4 +277,9 @@ Future:    OpenBao (self-hosted) as the machine/IaC/dynamic-secrets engine
            Infisical (self-hosted) as the human UI + developer integration hub
            Doppler retains the tier-0 kernel (incl. OpenBao seal key) + fallback
            SOPS/Age continues for git-committed deployment config
+
+Exploratory (not implemented): Proton Pass as a potential future cross-platform
+           secret-zero home (SOPS age key + per-agent AI Access Tokens). Would
+           not change the Doppler tier-0 kernel or the OpenBao seal-key location.
+           See PROTON_PASS_STRATEGY.md.
 ```

--- a/docs/SOPS_SETUP.md
+++ b/docs/SOPS_SETUP.md
@@ -82,6 +82,13 @@ mkdir -p ~/.config/sops/age
 age-keygen -o ~/.config/sops/age/keys.txt
 ```
 
+> **Exploratory (not implemented):** a proposal would give the age **private**
+> key a portable, backed-up home in **Proton Pass**
+> (`pass://infra/sops-age/keys.txt`) so SOPS decryption works on Linux/cloud
+> agents (not just macOS), materialized by `./scripts/secrets-bootstrap.sh`. See
+> [PROTON_PASS_STRATEGY.md](./PROTON_PASS_STRATEGY.md). Until adopted, set the key
+> up per host with `age-keygen` as above.
+
 Note the public key printed to stdout (starts with `age1...`).
 
 Update `.sops.yaml` with your public key:
@@ -133,13 +140,24 @@ documentation for Doppler project/config details.
 
 To re-encrypt the SOPS file with a new age key:
 
-1. Update `.sops.yaml` with the new public key.
-2. Run `sops updatekeys terraform.sops.json` to re-encrypt with the new key.
-3. Commit both the re-encrypted `terraform.sops.json` and updated `.sops.yaml`.
+1. Generate the new keypair (`age-keygen -o ~/.config/sops/age/keys.txt`).
+2. Update `.sops.yaml` with the new public key.
+3. Run `sops updatekeys terraform.sops.json` to re-encrypt with the new key.
+4. Commit both the re-encrypted `terraform.sops.json` and updated `.sops.yaml`.
+5. Distribute the new private key to other hosts by your usual secure means.
+
+> **Exploratory (not implemented):** if the Proton Pass proposal is adopted,
+> steps 1 and 5 would instead store the private key at
+> `pass://infra/sops-age/keys.txt` and other hosts would pick it up via
+> `./scripts/secrets-bootstrap.sh` (removing any stale local `keys.txt` first).
+> See [PROTON_PASS_STRATEGY.md](./PROTON_PASS_STRATEGY.md).
 
 ## Security Notes
 
-- The age private key (`keys.txt`) must **never** be committed to git
+- The age private key (`keys.txt`) must **never** be committed to git (an
+  exploratory proposal would give it a portable home in Proton Pass —
+  `pass://infra/sops-age/keys.txt`, materialized by
+  `./scripts/secrets-bootstrap.sh`; not yet implemented)
 - The `.sops.yaml` file contains only the **public** key (safe to commit)
 - `terraform.sops.json` is safe to commit once encrypted (values are ciphertext)
 - `deployment.json` is **not committed** — it is the private input in the on-prem

--- a/scripts/secrets-bootstrap.sh
+++ b/scripts/secrets-bootstrap.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Materialize "secret-zero" from Proton Pass (the root-of-trust) onto the current
+# host so the rest of the toolchain works — most importantly the SOPS age private
+# key, which has no other portable home and which Linux cloud agents otherwise
+# lack entirely.
+#
+# This is the BOOTSTRAP layer that runs BEFORE the usual wrapper. It does not
+# touch runtime credentials (Doppler still injects those) and writes nothing to
+# git. It is idempotent: an existing key is left untouched, never clobbered.
+#
+#   Tier 0 (Proton Pass)  ->  this script  ->  ~/.config/sops/age/keys.txt
+#                                            ->  SOPS decrypt works on any host
+#
+# References are resolved from .proton-pass.refs.json (committed, paths only — no
+# secret values). See docs/PROTON_PASS_STRATEGY.md.
+#
+# Manual run:  ./scripts/secrets-bootstrap.sh
+# Full flow:   ./scripts/secrets-bootstrap.sh && \
+#                aws-vault exec tf-proxmox -- doppler run -- terragrunt plan
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "$REPO_ROOT"
+
+REFS_FILE="${PROTON_PASS_REFS:-$REPO_ROOT/.proton-pass.refs.json}"
+AGE_KEY_PATH="${SOPS_AGE_KEY_FILE:-$HOME/.config/sops/age/keys.txt}"
+
+# Hard requirements — fail loudly, like the ${VAR:?} guards in sync-inventory.sh.
+command -v pass >/dev/null 2>&1 || {
+  echo "secrets-bootstrap: Proton Pass CLI ('pass') not found on PATH." >&2
+  echo "  Install: https://protonpass.github.io/pass-cli/get-started/installation/" >&2
+  exit 1
+}
+command -v jq >/dev/null 2>&1 || { echo "secrets-bootstrap: 'jq' not found (provided by the Nix shell)." >&2; exit 1; }
+[[ -f "$REFS_FILE" ]] || { echo "secrets-bootstrap: refs manifest not found: $REFS_FILE" >&2; exit 1; }
+
+# Read a pass:// reference for a logical secret-zero name from the manifest.
+ref_for() { jq -er --arg k "$1" '.references[$k] // empty' "$REFS_FILE"; }
+
+# --- age private key: the one item that unblocks SOPS on non-macOS hosts -------
+if [[ -f "$AGE_KEY_PATH" ]]; then
+  echo "secrets-bootstrap: age key already present at $AGE_KEY_PATH — leaving untouched." >&2
+else
+  age_ref="$(ref_for sops_age_key || true)"
+  [[ -n "$age_ref" ]] || { echo "secrets-bootstrap: no 'sops_age_key' reference in $REFS_FILE" >&2; exit 1; }
+  mkdir -p "$(dirname "$AGE_KEY_PATH")"
+  # umask 077 so the key file is created 0600 from the start; secret never echoed.
+  ( umask 077 && pass read "$age_ref" > "$AGE_KEY_PATH" )
+  chmod 0600 "$AGE_KEY_PATH"
+  echo "secrets-bootstrap: wrote age key to $AGE_KEY_PATH (mode 0600)." >&2
+fi
+
+# --- additional secret-zero (optional) -----------------------------------------
+# Extend here as Tier 2/4 land — e.g. export OpenBao approle or AWS bootstrap from
+# their references. Kept minimal for PR-1; nothing else is required to make SOPS
+# and the existing wrapper work cross-platform.
+
+echo "secrets-bootstrap: done." >&2


### PR DESCRIPTION
Document Proton Pass CLI as an **EXPLORATORY (not implemented)** future direction:
a cross-platform, e2e-encrypted candidate root-of-trust (Tier 0) for secret-zero
and an auditable AI-agent keychain (Tier 1). It is not a rotation engine or
runtime injector (which it cannot be), and it does **not** change the current
design.

Ground truth: the current, authoritative design stays as-is —
- Doppler remains the **tier-0 kernel** (including `OPENBAO_STATIC_SEAL_KEY`,
  which stays OUT of OpenBao so a cold cluster can always unseal itself).
- OpenBao (planned-for-deploy, machine/IaC engine) and Infisical (planned, human
  UI + developer hub) remain **domain-split** with no supersession.
- The `ai-secrets` macOS Keychain remains the current AI-agent key store.
- The SOPS age key is still set up per host via `age-keygen`.

Changes:
- docs/PROTON_PASS_STRATEGY.md: exploratory cross-repo proposal with a "not
  implemented" status banner — tier model, `pass://` reference convention, AI
  Access Token policy, rotation strategy, affordability/limits, mermaid diagram.
  The OpenBao seal key is removed from the Proton Tier-0 diagram and shown
  staying in the Doppler tier-0 kernel.
- scripts/secrets-bootstrap.sh: bootstrap tooling that WOULD materialize the SOPS
  age key from Proton Pass (0600, idempotent, no-clobber, no secrets to git) if
  the proposal is adopted.
- .proton-pass.refs.json: committed paths-only reference manifest (no values).
- SECRETS_ROADMAP.md: keeps Doppler tier-0 + OpenBao + Infisical as current
  reality; adds Proton Pass under "Under Consideration" as EXPLORATORY, with a
  dashed "future" annotation in the flow diagram and migration path.
- INFISICAL_PLANNING.md: banner clarifies the OpenBao/Infisical domain-split (no
  supersession) and that the seal key stays in Doppler tier-0.
- SOPS_SETUP.md / README.md / AGENTS.md: keep per-host `age-keygen` as the
  current path; present the Proton Pass bootstrap as exploratory/proposed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016gLCbqHFDwwH1ZkoANg3aB