### PR TITLE
fix(docs): rename netmon metric index to netmon_metrics

### DIFF
--- a/constants.tf
+++ b/constants.tf
@@ -74,8 +74,8 @@ locals {
       irtt               = 2112
       # Per-uplink network diagnosis (CT netmon-*, mgmt VLAN, Docker-in-LXC): the
       # satellite gRPC exporter scraped by each prober's Telegraf, alongside DOCSIS
-      # modem SNMP and native active probes. Pushes to Cribl -> Splunk netmon
-      # index. See docs/NETWORK_DIAGNOSIS.md.
+      # modem SNMP and native active probes. Pushes to Cribl -> Splunk
+      # netmon_metrics index. See docs/NETWORK_DIAGNOSIS.md.
       satellite_exporter = 9817
     }
     syslog_port_map = local.syslog_port_map

--- a/docs/NETWORK_DIAGNOSIS.md
+++ b/docs/NETWORK_DIAGNOSIS.md
@@ -25,7 +25,7 @@ Telegraf inputs per prober (all native — no custom scripts):
 - `inputs.http_response` — HTTPS response time
 - `inputs.snmp` — DOCSIS-IF / DOCS-IF3 MIB on a cable modem
 - `inputs.prometheus` — scrapes the satellite gRPC exporter and the speedtest-exporter
-- `outputs.http` — Splunk-HEC format → Cribl Edge → Cribl Stream → Splunk `netmon` index
+- `outputs.http` — Splunk-HEC format → Cribl Edge → Cribl Stream → Splunk `netmon_metrics` index
 
 ```mermaid
 flowchart LR
@@ -33,7 +33,7 @@ flowchart LR
   S[netmon-sat] -->|policy route| WB[(uplink B)]
   C --> CE[Cribl Edge]
   S --> CE
-  CE --> CS[Cribl Stream] --> NM[(Splunk netmon index)]
+  CE --> CS[Cribl Stream] --> NM[(Splunk netmon_metrics index)]
 ```
 
 ## Implementation choices
@@ -51,7 +51,7 @@ A device diagnostic IP (commonly `192.168.100.1`) is shared across uplinks, so a
 per prober (owned by `tofu-unifi`) provides that. Until those routes apply, a prober measures the
 default-route uplink only; the per-link source counters still populate.
 
-## Splunk: the `netmon` index
+## Splunk: the `netmon_metrics` index
 
 Defined in [`SPLUNK_INDEXES.md`](./SPLUNK_INDEXES.md); created by the `ansible-splunk` role. Probe
 data is high-volume, so the index uses **90-day** retention — separate from the 365-day
@@ -61,9 +61,9 @@ security-log indexes.
 
 | Work | Repo |
 | --- | --- |
-| netmon LXC definitions, `netmon` index doc, ports | terraform-proxmox (this) |
+| netmon LXC definitions, `netmon_metrics` index doc, ports | terraform-proxmox (this) |
 | Telegraf + exporter + SmokePing container config | ansible-proxmox-apps |
-| `netmon` Splunk index creation | ansible-splunk |
+| `netmon_metrics` Splunk index creation | ansible-splunk |
 | Per-uplink source-IP policy routes | tofu-unifi (gated apply) |
 
 ## Prerequisites and caveats

--- a/docs/SPLUNK_INDEXES.md
+++ b/docs/SPLUNK_INDEXES.md
@@ -6,14 +6,14 @@ This document defines the Splunk indexes used in the logging pipeline, their pur
 
 ## Index Definitions
 
-| Index    | Purpose                   | Sources                        | Retention |
-| -------- | ------------------------- | ------------------------------ | --------- |
-| unifi    | UniFi network device logs | Network devices, switches, APs | 365 days  |
-| os       | Operating system logs     | Linux, macOS, Windows hosts    | 365 days  |
-| firewall | Firewall logs             | Palo Alto, Cisco ASA           | 365 days  |
-| network  | General network logs      | Switches, routers, other       | 365 days  |
-| netmon   | Per-WAN network diagnosis | Probes, DOCSIS SNMP, satellite | 90 days   |
-| netflow  | UniFi NetFlow/IPFIX flows | UniFi gateway (IPFIX 2055)     | 90 days   |
+| Index          | Purpose                   | Sources                        | Retention |
+| -------------- | ------------------------- | ------------------------------ | --------- |
+| unifi          | UniFi network device logs | Network devices, switches, APs | 365 days  |
+| os             | Operating system logs     | Linux, macOS, Windows hosts    | 365 days  |
+| firewall       | Firewall logs             | Palo Alto, Cisco ASA           | 365 days  |
+| network        | General network logs      | Switches, routers, other       | 365 days  |
+| netmon_metrics | Per-WAN network diagnosis | Probes, DOCSIS SNMP, satellite | 90 days   |
+| netflow        | UniFi NetFlow/IPFIX flows | UniFi gateway (IPFIX 2055)     | 90 days   |
 
 ## Index Configuration
 
@@ -89,13 +89,13 @@ frozenTimePeriodInSecs = 31536000
 - Port status changes
 - General network telemetry
 
-### netmon
+### netmon_metrics
 
 ```ini
-[netmon]
-homePath = $SPLUNK_DB/netmon/db
-coldPath = $SPLUNK_DB/netmon/colddb
-thawedPath = $SPLUNK_DB/netmon/thaweddb
+[netmon_metrics]
+homePath = $SPLUNK_DB/netmon_metrics/db
+coldPath = $SPLUNK_DB/netmon_metrics/colddb
+thawedPath = $SPLUNK_DB/netmon_metrics/thaweddb
 maxTotalDataSizeMB = 51200
 frozenTimePeriodInSecs = 7776000
 ```
@@ -127,7 +127,7 @@ frozenTimePeriodInSecs = 7776000
 ## Retention Policy
 
 Security-log indexes use a **365-day retention** period (`frozenTimePeriodInSecs = 31536000`).
-The `netmon` diagnostics and `netflow` flow-record indexes are the exceptions at **90 days**
+The `netmon_metrics` diagnostics and `netflow` flow-record indexes are the exceptions at **90 days**
 (`7776000`) — a troubleshooting / volume horizon, not a compliance window.
 
 **Rationale**:
@@ -138,34 +138,34 @@ The `netmon` diagnostics and `netflow` flow-record indexes are the exceptions at
 
 ## Size Limits
 
-Security-log indexes are limited to **100GB** each (`maxTotalDataSizeMB = 102400`); the `netmon`
+Security-log indexes are limited to **100GB** each (`maxTotalDataSizeMB = 102400`); the `netmon_metrics`
 diagnostics and `netflow` flow indexes are each capped at **50GB** (`51200`).
 
 **Capacity planning**:
 
-- Total: 500GB across 6 indexes (4 × 100GB security + netmon 50GB + netflow 50GB)
+- Total: 500GB across 6 indexes (4 × 100GB security + netmon_metrics 50GB + netflow 50GB)
 - Splunk VM disk: 500GB allocated
 - Caps now equal the 500GB VM disk — grow the VM disk (leaving ~50GB for Splunk internal
   indexes) before onboarding the broader host/container/firewall log sources
 
 ## Source Type Mapping
 
-| Source Type    | Index    | Description            |
-| -------------- | -------- | ---------------------- |
-| unifi:usg      | unifi    | UniFi Security Gateway |
-| unifi:switch   | unifi    | UniFi switches         |
-| unifi:ap       | unifi    | UniFi access points    |
-| syslog:linux   | os       | Linux syslog           |
-| syslog:macos   | os       | macOS syslog           |
-| syslog:windows | os       | Windows Event Log      |
-| pan:traffic    | firewall | Palo Alto traffic      |
-| pan:threat     | firewall | Palo Alto threats      |
-| cisco:asa      | firewall | Cisco ASA              |
-| syslog:network | network  | Generic network        |
-| netmon:probe   | netmon   | Telegraf active probes |
-| netmon:docsis  | netmon   | Cable modem SNMP       |
-| netmon:sat     | netmon   | satellite uplink probe |
-| ipfix          | netflow  | UniFi NetFlow/IPFIX    |
+| Source Type    | Index          | Description            |
+| -------------- | -------------- | ---------------------- |
+| unifi:usg      | unifi          | UniFi Security Gateway |
+| unifi:switch   | unifi          | UniFi switches         |
+| unifi:ap       | unifi          | UniFi access points    |
+| syslog:linux   | os             | Linux syslog           |
+| syslog:macos   | os             | macOS syslog           |
+| syslog:windows | os             | Windows Event Log      |
+| pan:traffic    | firewall       | Palo Alto traffic      |
+| pan:threat     | firewall       | Palo Alto threats      |
+| cisco:asa      | firewall       | Cisco ASA              |
+| syslog:network | network        | Generic network        |
+| netmon:probe   | netmon_metrics | Telegraf active probes |
+| netmon:docsis  | netmon_metrics | Cable modem SNMP       |
+| netmon:sat     | netmon_metrics | satellite uplink probe |
+| ipfix          | netflow        | UniFi NetFlow/IPFIX    |
 
 ## HEC Token Configuration
 
@@ -196,7 +196,7 @@ splunk_indexes:
   - name: network
     maxTotalDataSizeMB: 102400
     frozenTimePeriodInSecs: 31536000
-  - name: netmon
+  - name: netmon_metrics
     maxTotalDataSizeMB: 51200
     frozenTimePeriodInSecs: 7776000
   - name: netflow


### PR DESCRIPTION
## Why

`netmon` is a metric-datatype Splunk index that violates the `{name}_metrics` naming convention. Docs/comments in this repo (the infra source of truth) should match the renamed index. Code changes live in `dryvist/ansible-splunk` (index def) and `dryvist/ansible-proxmox-apps` (Cribl repoint + null-value coercion).

## What

- `docs/SPLUNK_INDEXES.md`: index name, stanza, paths, retention/size notes, source-type mapping; tables realigned for markdownlint (MD060).
- `docs/NETWORK_DIAGNOSIS.md`: index references in prose + the mermaid sink.
- `constants.tf`: comment reference.

Prober hostnames (`netmon-cable`/`netmon-sat`), the container tag, and sourcetype names (`netmon:probe`, etc.) intentionally keep the `netmon` name — only the **index** is renamed. Docs-only; no resource/contract change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)