### PR TITLE
feat(ci): dispatch downstream revalidation on release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,3 +14,16 @@ jobs:
     uses: dryvist/.github/.github/workflows/_release-please.yml@main
     secrets:
       GH_ACTION_RELEASE_PLEASE_PRIVATE_KEY: ${{ secrets.GH_ACTION_RELEASE_PLEASE_PRIVATE_KEY }}
+
+  # On an actual release (not every push), fan out a real-time
+  # repository_dispatch so each downstream consumer re-validates against the
+  # freshly published inventory. Consumers are listed in the repo-level
+  # DISPATCH_CONSUMERS variable; auth + dispatch live in the shared workflow.
+  dispatch-consumers:
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    permissions: {}
+    uses: dryvist/.github/.github/workflows/_dispatch-flake-consumers.yml@main
+    with:
+      event_type: upstream-released
+    secrets: inherit


### PR DESCRIPTION
## What

When this repo cuts a release, fan out a real-time `repository_dispatch` (`event_type: upstream-released`) to the downstream ansible consumers so each re-validates against the freshly published inventory. New `dispatch-consumers` job, gated on the release actually being created; auth + fan-out live in the shared `_dispatch-flake-consumers.yml`.

This implements the "downstream gets a real-time notification on upstream version update" requirement as a **freshness/CD trigger** (re-run validation), not a dependency bump — the ansible repos consume the inventory as a runtime S3 artifact, so there is no version/lock to bump.

## Merge order / preconditions

- **Merge dryvist/.github#47 first** — it adds the `release_created` output and the `event_type` input this job relies on.
- Repo variable `DISPATCH_CONSUMERS` is set to the three ansible consumers (done via CLI).
- The release GitHub App must be installed on the consumer repos with `contents:write` (it already dispatches org-wide for the nix-* repos).

## Consumer listeners (separate PRs)

- ansible-proxmox-apps / ansible-splunk → `_data-contract.yml` (inventory schema check)
- ansible-proxmox → `molecule.yml` (made callable)

## Notes

- The dispatch job runs only on `push: main` (release path), never on PRs, so this PR's own CI is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)