### PR TITLE
fix: use generic DOPPLER_TOKEN secret, drop vault-specific names

### DIFF
--- a/.github/workflows/servarr-config-drift.yml
+++ b/.github/workflows/servarr-config-drift.yml
@@ -39,10 +39,10 @@ jobs:
           GATE_MESSAGE: >-
             SERVARR_DRIFT_ENABLED is not 'true' -- scheduled *arr config drift
             detection is OFF, so out-of-band changes to Sonarr/Radarr go
-            unnoticed. Provision the iac-conf-mgmt/prd Doppler keys and repo
-            secret/variable (see servarr-config/README.md), then set the
-            variable to enable. Disable this schedule intentionally if drift
-            detection is meant to be off.
+            unnoticed. Provision the Doppler service token (repo secret
+            DOPPLER_TOKEN) and repo secret/variable (see
+            servarr-config/README.md), then set the variable to enable. Disable
+            this schedule intentionally if drift detection is meant to be off.
         run: |
           echo "::notice::${GATE_MESSAGE}"
 
@@ -69,9 +69,7 @@ jobs:
         id: doppler
         uses: dopplerhq/secrets-fetch-action@v2
         with:
-          doppler-token: ${{ secrets.GH_ACTION_DOPPLER_IAC_CONF_MGMT }}
-          doppler-project: iac-conf-mgmt
-          doppler-config: prd
+          doppler-token: ${{ secrets.DOPPLER_TOKEN }}
 
       - name: OpenTofu init (S3 backend)
         env:

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Config is split across three layers:
 | ------ | -------- | ----------- |
 | `deployment.json` | Container/VM definitions, pools, node placement | Edit directly and commit |
 | `terraform.sops.json` | Per-VLAN network CIDRs, domain, SSH key paths | Decrypt with SOPS, edit, re-encrypt |
-| Doppler (`iac-conf-mgmt/prd`) | `PROXMOX_VE_*`, SSH key content, credentials | Doppler web UI or CLI |
+| Doppler | `PROXMOX_VE_*`, SSH key content, credentials | Doppler web UI or CLI |
 
 `terraform.tfvars` is gitignored and must not exist — it silently overrides
 `deployment.json` via Terraform variable precedence.

--- a/aws-infra/README.md
+++ b/aws-infra/README.md
@@ -35,7 +35,7 @@ terraform-proxmox/
 
 - [Nix](https://nixos.org/download/) with flakes enabled (provides Terraform/Terragrunt via nix-devenv)
 - [aws-vault](https://github.com/99designs/aws-vault) with `tf-proxmox` profile configured
-- [Doppler CLI](https://docs.doppler.com/docs/install-cli) configured for your Doppler config
+- [Doppler CLI](https://docs.doppler.com/docs/install-cli) configured for `infra-project/prd`
 - Route53 hosted zone for the Proxmox domain
 
 ## Usage

--- a/aws-infra/README.md
+++ b/aws-infra/README.md
@@ -35,7 +35,7 @@ terraform-proxmox/
 
 - [Nix](https://nixos.org/download/) with flakes enabled (provides Terraform/Terragrunt via nix-devenv)
 - [aws-vault](https://github.com/99designs/aws-vault) with `tf-proxmox` profile configured
-- [Doppler CLI](https://docs.doppler.com/docs/install-cli) configured for `iac-conf-mgmt` project
+- [Doppler CLI](https://docs.doppler.com/docs/install-cli) configured for your Doppler config
 - Route53 hosted zone for the Proxmox domain
 
 ## Usage

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -107,7 +107,7 @@ LXC containers in the `logging` resource pool — no Docker Swarm in this path.
 ```mermaid
 flowchart TD
     subgraph Runtime["Runtime Secrets (Active)"]
-        DOP[Doppler<br/>Project: iac-conf-mgmt]
+        DOP[Doppler]
         AV[aws-vault<br/>Profile: terraform]
         KC[macOS Keychain<br/>ai-secrets keychain]
     end

--- a/docs/SECRETS_ROADMAP.md
+++ b/docs/SECRETS_ROADMAP.md
@@ -17,12 +17,12 @@ Doppler is the primary secrets manager for all runtime credentials.
 
 **Repositories using Doppler:**
 
-| Repository | Doppler Project | Secrets Managed |
-| --- | --- | --- |
-| terraform-proxmox | iac-conf-mgmt | `PROXMOX_VE_*`, `SPLUNK_*` |
-| ansible-proxmox-apps | iac-conf-mgmt | `PROXMOX_*`, `SPLUNK_HEC_TOKEN` |
-| ansible-splunk | iac-conf-mgmt | `SPLUNK_*`, `PROXMOX_*` |
-| ansible-proxmox | iac-conf-mgmt | `PROXMOX_*` |
+| Repository | Secrets Managed |
+| --- | --- |
+| terraform-proxmox | `PROXMOX_VE_*`, `SPLUNK_*` |
+| ansible-proxmox-apps | `PROXMOX_*`, `SPLUNK_HEC_TOKEN` |
+| ansible-splunk | `SPLUNK_*`, `PROXMOX_*` |
+| ansible-proxmox | `PROXMOX_*` |
 
 **Strengths:**
 

--- a/servarr-config/README.md
+++ b/servarr-config/README.md
@@ -96,12 +96,12 @@ variable `SERVARR_DRIFT_ENABLED` and these secrets, supplied via the same
 | Where | Key | Note |
 | --- | --- | --- |
 | Repo variable | `SERVARR_DRIFT_ENABLED` | set to `true` to enable |
-| Repo secret | `GH_ACTION_DOPPLER_IAC_CONF_MGMT` | Doppler service token, read `iac-conf-mgmt/prd` |
-| Doppler `iac-conf-mgmt/prd` | `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` | the **read-only** AWS account — the read counterpart of the `tf-proxmox` write role (one read role per write role). Plan runs `-lock=false`, so it needs S3 read only, no DynamoDB |
-| Doppler `iac-conf-mgmt/prd` | `SONARR_URL`, `SONARR_API_KEY`, `RADARR_URL`, `RADARR_API_KEY` | *arr endpoints + keys |
-| Doppler `iac-conf-mgmt/prd` | `QBITTORRENT_HOST`, `QBITTORRENT_ADMIN_PASSWORD` | download-client check |
-| Doppler `iac-conf-mgmt/prd` | `AWS_ACCOUNT_ID` | already present; builds the bucket name (no aws CLI on the runner) |
-| Doppler `iac-conf-mgmt/prd` | `NTFY_BASE_URL` | optional; without it, the job failure is the only signal |
+| Repo secret | `DOPPLER_TOKEN` | Doppler service token (project + config scoped) |
+| Doppler | `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` | the **read-only** AWS account — the read counterpart of the `tf-proxmox` write role (one read role per write role). Plan runs `-lock=false`, so it needs S3 read only, no DynamoDB |
+| Doppler | `SONARR_URL`, `SONARR_API_KEY`, `RADARR_URL`, `RADARR_API_KEY` | *arr endpoints + keys |
+| Doppler | `QBITTORRENT_HOST`, `QBITTORRENT_ADMIN_PASSWORD` | download-client check |
+| Doppler | `AWS_ACCOUNT_ID` | already present; builds the bucket name (no aws CLI on the runner) |
+| Doppler | `NTFY_BASE_URL` | optional; without it, the job failure is the only signal |
 
 The read-only AWS account is the one genuinely new principal. It can read state
 (which contains the *arr keys), so keep it read-only — one shared read role

--- a/vault-secrets/README.md
+++ b/vault-secrets/README.md
@@ -32,7 +32,7 @@ Outputs expose only non-sensitive proof (`demo_secret_path`,
 
 - [Nix](https://nixos.org/download/) with flakes enabled (provides Terraform/Terragrunt via nix-devenv)
 - [aws-vault](https://github.com/99designs/aws-vault) with `tf-proxmox` profile configured (for the S3 state backend)
-- [Doppler CLI](https://docs.doppler.com/docs/install-cli) configured for your Doppler config
+- [Doppler CLI](https://docs.doppler.com/docs/install-cli) configured for `infra-project/prd`
 - A live OpenBao instance with the KV v2 engine enabled at `mount = "secret"`
 - `VAULT_ADDR`, `VAULT_ROLE_ID`, and `VAULT_SECRET_ID` present in Doppler
 

--- a/vault-secrets/README.md
+++ b/vault-secrets/README.md
@@ -32,7 +32,7 @@ Outputs expose only non-sensitive proof (`demo_secret_path`,
 
 - [Nix](https://nixos.org/download/) with flakes enabled (provides Terraform/Terragrunt via nix-devenv)
 - [aws-vault](https://github.com/99designs/aws-vault) with `tf-proxmox` profile configured (for the S3 state backend)
-- [Doppler CLI](https://docs.doppler.com/docs/install-cli) configured for `iac-conf-mgmt` project
+- [Doppler CLI](https://docs.doppler.com/docs/install-cli) configured for your Doppler config
 - A live OpenBao instance with the KV v2 engine enabled at `mount = "secret"`
 - `VAULT_ADDR`, `VAULT_ROLE_ID`, and `VAULT_SECRET_ID` present in Doppler
 


### PR DESCRIPTION
## What

Replace the vault-specific Doppler references with a generic, single repo secret `DOPPLER_TOKEN`. A Doppler service token is already scoped to one project + config, so neither the project name, the config name, nor a vault-named secret ever need to live in committed files.

## Changes

- **`.github/workflows/servarr-config-drift.yml`**
  - `doppler-token: ${{ secrets.GH_ACTION_DOPPLER_IAC_CONF_MGMT }}` → `${{ secrets.DOPPLER_TOKEN }}`
  - Removed `doppler-project` and `doppler-config` inputs (the service token derives both).
  - Genericized the drift-gate notice wording.
- **Docs / READMEs** (`README.md`, `aws-infra/README.md`, `docs/ARCHITECTURE.md`, `docs/SECRETS_ROADMAP.md`, `servarr-config/README.md`, `vault-secrets/README.md`)
  - Replaced project/config-named Doppler references with generic Doppler wording.
  - Replaced `GH_ACTION_DOPPLER_IAC_CONF_MGMT` in prose with `DOPPLER_TOKEN`.
  - Individual secret KEY names (`RADARR_API_KEY`, etc.) left unchanged.

## Required before / after merge

- **Before merge:** create the repo secret `DOPPLER_TOKEN` (a Doppler service token scoped to the same project + config the old one used). The drift workflow fails without it.
- **After merge:** delete the old `GH_ACTION_DOPPLER_IAC_CONF_MGMT` repo secret.

## Verification

`grep -rn "iac-conf-mgmt\|GH_ACTION_DOPPLER_IAC_CONF_MGMT"` (excluding `.git/`) returns no matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019whZYTbrt4DnoyXVE5gCF9