### PR TITLE
chore(deps): bump pre-commit pre-commit-hooks v4.6.0 → v6.0.0 [routine:quartermaster]

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ default_install_hook_types: [pre-commit, pre-push]
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer


### PR DESCRIPTION
The Quartermaster pre-commit pin bump.

## Hook

`https://github.com/pre-commit/pre-commit-hooks` — `v4.6.0` → `v6.0.0` (latest release).

## Why now

This consumer's pinned `rev:` was 2 major versions behind upstream. Renovate is not configured to manage `.pre-commit-config.yaml` in this repo (verified — no open Renovate PR for this file).

## Other hooks in this file

Untouched. Only the drifted `rev:` line was modified.

---

## Provenance

- **Generated by:** [The Quartermaster](https://github.com/dryvist/claude-code-routines) — cloud routine, daily at 08:00 UTC.
- **Triggered:** Scheduled run on `2026-06-22`.
- **Why this PR:** `pre-commit/pre-commit-hooks` released `v6.0.0`; this repo was pinned at `v4.6.0` (2 major versions behind) AND no Renovate PR was open for this file.
- **State:** `quartermaster-state` gist — 14-day per-`(repo, hook)` cooldown to avoid churn.
- **Label:** `cloud-routine`