### PR TITLE
feat(firewall): add hermes-agent egress group for the autonomous agent LXC

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -224,4 +224,14 @@ locals {
     for k, v in var.containers : k => v.vm_id
     if contains(coalesce(try(v.tags, null), []), "monitoring")
   }
+
+  # Hermes Agent LXC: tagged "hermes-agent". Autonomous agent that runs arbitrary
+  # terminal + web tools; gets internal access + outbound-internal (reach the model
+  # endpoint, DNS, NTP, Splunk logging) + outbound HTTPS for its web tools. The LXC
+  # is the blast-radius boundary. (Hardening follow-up: route egress through a Squid
+  # forward-proxy and replace outbound-internal with a microsegmented allowlist.)
+  hermes_agent_container_ids = {
+    for k, v in var.containers : k => v.vm_id
+    if contains(coalesce(try(v.tags, null), []), "hermes-agent")
+  }
 }

--- a/main.tf
+++ b/main.tf
@@ -234,6 +234,9 @@ module "firewall" {
   # Network-quality monitoring LXC: tagged "monitoring" (SmokePing + speedtest-exporter)
   monitoring_container_ids = local.monitoring_container_ids
 
+  # Hermes Agent LXC: tagged "hermes-agent" (autonomous agent, broad HTTPS egress)
+  hermes_agent_container_ids = local.hermes_agent_container_ids
+
   # Pipeline constants: single source of truth for service ports (DRY)
   pipeline_constants = local.pipeline_constants
 

--- a/modules/firewall/hermes_agent_rules.tf
+++ b/modules/firewall/hermes_agent_rules.tf
@@ -1,0 +1,57 @@
+# =============================================================================
+# Hermes Agent container firewall configuration
+# =============================================================================
+# Extracted into its own file (like monitoring_rules.tf / object_storage_rules.tf)
+# so container_rules.tf stays under the shared _file-size workflow's 12 KB error
+# threshold.
+#
+# The Hermes Agent (NousResearch) is an autonomous agent that runs arbitrary
+# terminal + web tools. The LXC is its blast-radius boundary, so egress matters:
+#   - internal_access  : SSH + ICMP in from internal RFC1918 (management).
+#   - outbound_internal: reach the model endpoint (homelab Ollama on the AI VLAN),
+#                        DNS, NTP, and Splunk logging — RFC1918 only.
+#   - outbound_https   : TCP 443 to anywhere, for the agent's web/search/browser
+#                        tools (Agy review: a 443/53/123-only egress is too tight
+#                        for arbitrary tool-calling).
+#
+# Hardening follow-up (not this PR): route egress through an audited Squid
+# forward-proxy and replace outbound_internal with a microsegmented allowlist so
+# the agent cannot reach arbitrary internal hosts. Tracked in the deployment plan.
+
+resource "proxmox_virtual_environment_firewall_options" "hermes_agent_container" {
+  for_each = var.hermes_agent_container_ids
+
+  node_name     = var.node_name
+  container_id  = each.value
+  enabled       = local.firewall_defaults.enabled
+  input_policy  = local.firewall_defaults.input_policy
+  output_policy = local.firewall_defaults.output_policy
+  log_level_in  = local.firewall_defaults.log_level_in
+  log_level_out = local.firewall_defaults.log_level_out
+
+  depends_on = [proxmox_virtual_environment_cluster_firewall.main]
+}
+
+resource "proxmox_virtual_environment_firewall_rules" "hermes_agent_container" {
+  for_each = var.hermes_agent_container_ids
+
+  node_name    = var.node_name
+  container_id = each.value
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.internal_access.name
+    comment        = "Internal access (SSH, ICMP)"
+  }
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.outbound_internal.name
+    comment        = "Outbound to internal only (model endpoint, DNS, NTP, Splunk logging)"
+  }
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.outbound_https.name
+    comment        = "Outbound HTTPS (TCP 443) for agent web/search/browser tools"
+  }
+
+  depends_on = [proxmox_virtual_environment_firewall_options.hermes_agent_container]
+}

--- a/modules/firewall/variables.tf
+++ b/modules/firewall/variables.tf
@@ -93,6 +93,12 @@ variable "monitoring_container_ids" {
   default     = {}
 }
 
+variable "hermes_agent_container_ids" {
+  description = "Map of Hermes Agent LXC names to IDs (tag-driven). Autonomous agent: internal access + outbound to internal services + outbound HTTPS for its web tools."
+  type        = map(number)
+  default     = {}
+}
+
 variable "management_network" {
   description = "CIDR of management network for SSH/Web access. Configure in terraform.tfvars for your environment."
   type        = string


### PR DESCRIPTION
## What

Adds a tag-driven firewall rule set for a forthcoming **Hermes Agent** LXC
(NousResearch autonomous agent), selected by the `hermes-agent` tag:

- `internal_access` — SSH/ICMP in from internal networks (management)
- `outbound_internal` — egress to internal services only (model endpoint, DNS, NTP, log shipping)
- `outbound_https` — TCP 443 to anywhere, for the agent's web/search/browser tools

## Why

The agent runs arbitrary terminal + web tools, so the LXC is its blast-radius
boundary and egress must be deliberate. A 443/53/123-only "limited egress" is
too tight for arbitrary tool-calling, so broad HTTPS is allowed alongside
internal reach.

## Safety

`for_each` over an empty map → **no resources created until a container is
tagged `hermes-agent`**, so this lands the capability ahead of the container
itself with zero plan impact today. Mirrors the existing per-service rule-file
pattern (`monitoring_rules.tf`, `object_storage_rules.tf`).

`tofu validate` passes.

## Follow-up (separate)

Harden egress through an audited Squid forward-proxy and replace
`outbound_internal` with a microsegmented allowlist so the agent cannot reach
arbitrary internal hosts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)