### PR TITLE
feat(ingress): front Splunk management API (8089) at splunk-mgmt

### DIFF
--- a/ingress.tf
+++ b/ingress.tf
@@ -72,6 +72,18 @@ locals {
         # Consumers default scheme=http / insecure_tls=false when absent.
         scheme       = "https"
         insecure_tls = true
+      },
+      {
+        # Splunk management / REST API (splunkd, 8089) fronted at
+        # splunk-mgmt.<domain>. Single label deliberately: the *.<domain>
+        # wildcard cert covers splunk-mgmt.<domain> but NOT a nested
+        # mgmt.splunk.<domain>. splunkd's mgmt port is HTTPS self-signed, so
+        # same https + skip-verify backend as the web route above.
+        name         = "splunk-mgmt"
+        ip           = split("/", local.splunk_derived_ip)[0]
+        port         = local.pipeline_constants.service_ports.splunk_mgmt
+        scheme       = "https"
+        insecure_tls = true
       }
     ],
     # Proxmox cluster UI apex (the ingress subdomain apex), load-balanced.


### PR DESCRIPTION
## Why

The Splunk management / REST API (splunkd, 8089) is only reachable directly at
`https://<splunk-ip>:8089` with a **self-signed** cert. This adds a Traefik
ingress so it is reachable at `https://splunk-mgmt.<domain>` with the real
Let's Encrypt wildcard cert — convenient for tools/MCP clients that reject
self-signed certs, and consistent with how the Splunk web UI (8000) is fronted.

## What

- One new row in the tofu-owned `ingress` table (the single source the
  `traefik` and `technitium_dns` roles consume): `splunk-mgmt` → the Splunk VM
  IP, port `splunk_mgmt` (8089), `scheme=https`, `insecure_tls=true` (splunkd
  mgmt is HTTPS self-signed, same backend treatment as the web route).

## Name choice (deliberate)

`splunk-mgmt.<domain>` is a **single label** under the subdomain. The
`*.<domain>` wildcard cert matches exactly one label, so it covers
`splunk-mgmt.<domain>` but would **not** cover a nested `mgmt.splunk.<domain>`
(that would throw TLS errors). No cert changes needed.

## Activation (post-merge)

`terragrunt apply` republishes the inventory with the new row, then a converge
of the `traefik` + `technitium_dns` roles creates the router and the DNS A
record (overwriting a pre-existing orphan `splunk-mgmt` record that pointed at
an unused address).

## Verification

- `tofu fmt` clean, `tofu validate` passes.
- Post-activation: `splunk-mgmt.<domain>` resolves to Traefik; `curl` returns
  the splunkd REST API over a valid wildcard cert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)