### PR TITLE
feat(inventory): deployment.json desired-state from a private s3 store (fail-loud)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -37,7 +37,10 @@ aws-vault exec tf-proxmox -- doppler run -- terragrunt apply
 ## HCL Conventions
 
 - Module inputs in `variables.tf`, outputs in `outputs.tf`, providers in `providers.tf`
-- Use `deployment.json` for environment-specific non-secret config
+- Use `deployment.json` for environment-specific non-secret config — note it is
+  **not committed**: the live file lives in the private on-prem `s3` store
+  (`s3://iac-inventory/deployment.json`), fetched by terragrunt via Doppler `S3_*`;
+  the repo holds only `deployment.json.example` as a shape reference
 - Use `terraform.sops.json` for encrypted secrets (edit with `sops terraform.sops.json`)
 - Terragrunt config in `terragrunt.hcl` at each module root
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -37,10 +37,9 @@ aws-vault exec tf-proxmox -- doppler run -- terragrunt apply
 ## HCL Conventions
 
 - Module inputs in `variables.tf`, outputs in `outputs.tf`, providers in `providers.tf`
-- Use `deployment.json` for environment-specific non-secret config — note it is
-  **not committed**: the live file lives in the private on-prem `s3` store
-  (`s3://iac-inventory/deployment.json`), fetched by terragrunt via Doppler `S3_*`;
-  the repo holds only `deployment.json.example` as a shape reference
+- Use `deployment.json` for environment-specific non-secret config — private, not
+  committed, fetched from the on-prem `s3` store (see
+  `agentsmd/rules/infra/deployment-json-source-of-truth.md`)
 - Use `terraform.sops.json` for encrypted secrets (edit with `sops terraform.sops.json`)
 - Terragrunt config in `terragrunt.hcl` at each module root
 

--- a/.gitignore
+++ b/.gitignore
@@ -126,9 +126,8 @@ scripts/timing-results.txt
 .mcp.json
 
 # Live deployment config — contains real node names, VM inventory, and ZFS pool names.
-# The live file lives only in the private on-prem `s3` object store at
-# s3://iac-inventory/deployment.json and is fetched by terragrunt at plan/apply
-# via the Doppler `S3_*` creds. This repo keeps only deployment.json.example.
+# Private desired-state input — lives in the on-prem `s3` store, fetched by terragrunt
+# (see agentsmd/rules/infra/deployment-json-source-of-truth.md). Repo keeps only the example.
 deployment.json
 
 # ---------------------------------------------------------------------

--- a/.gitignore
+++ b/.gitignore
@@ -126,7 +126,9 @@ scripts/timing-results.txt
 .mcp.json
 
 # Live deployment config — contains real node names, VM inventory, and ZFS pool names.
-# Populate from deployment.json.example and keep locally only.
+# The live file lives only in the private on-prem `s3` object store at
+# s3://iac-inventory/deployment.json and is fetched by terragrunt at plan/apply
+# via the Doppler `S3_*` creds. This repo keeps only deployment.json.example.
 deployment.json
 
 # ---------------------------------------------------------------------

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,11 +54,8 @@ locals.tf derivations    (computed)             — management_network, splunk_n
 ```
 
 - `deployment.json` — resource definitions (containers, VMs, pools, sizing).
-  Private and NOT committed: the live file lives only in the on-prem `s3`
-  object store at `s3://iac-inventory/deployment.json`, fetched at plan/apply by
-  terragrunt via the Doppler `S3_*` creds (`DEPLOYMENT_JSON_PATH` overrides with
-  a local file for offline/bootstrap work). The committed `deployment.json.example`
-  is the shape reference only.
+  Private, not committed; fetched from the on-prem `s3` store at plan/apply. See
+  [`deployment-json-source-of-truth`](agentsmd/rules/infra/deployment-json-source-of-truth.md).
 - `terraform.sops.json` — five env-specific values: `network_prefix`,
   `domain`, `vm_ssh_public_key_path`, `vm_ssh_private_key_path`,
   `proxmox_ssh_username`. Decrypted automatically by Terragrunt.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,14 +47,18 @@ The BPG Proxmox provider reads `PROXMOX_VE_*` env vars directly — no
 ## Config-file architecture (single source of truth)
 
 ```text
-deployment.json          (committed, plaintext) — containers, VMs, pools, proxmox_node
+deployment.json          (private s3, fetched)  — containers, VMs, pools, proxmox_node
 terraform.sops.json      (committed, encrypted) — network_prefix, domain, vm_ssh_*_key_path, proxmox_ssh_username
 Doppler env vars         (runtime only)         — PROXMOX_VE_*, SPLUNK_*, SSH key content
 locals.tf derivations    (computed)             — management_network, splunk_network_ips
 ```
 
 - `deployment.json` — resource definitions (containers, VMs, pools, sizing).
-  Committed plaintext, edit directly.
+  Private and NOT committed: the live file lives only in the on-prem `s3`
+  object store at `s3://iac-inventory/deployment.json`, fetched at plan/apply by
+  terragrunt via the Doppler `S3_*` creds (`DEPLOYMENT_JSON_PATH` overrides with
+  a local file for offline/bootstrap work). The committed `deployment.json.example`
+  is the shape reference only.
 - `terraform.sops.json` — five env-specific values: `network_prefix`,
   `domain`, `vm_ssh_public_key_path`, `vm_ssh_private_key_path`,
   `proxmox_ssh_username`. Decrypted automatically by Terragrunt.

--- a/README.md
+++ b/README.md
@@ -45,9 +45,13 @@ Config is split across three layers:
 
 | Source | Contents | How to edit |
 | ------ | -------- | ----------- |
-| `deployment.json` | Container/VM definitions, pools, node placement | Edit directly and commit |
+| `deployment.json` | Container/VM definitions, pools, node placement | Private (not committed): edit a copy, then `aws s3 cp` it to `s3://iac-inventory/deployment.json` in the on-prem `s3` store |
 | `terraform.sops.json` | Per-VLAN network CIDRs, domain, SSH key paths | Decrypt with SOPS, edit, re-encrypt |
 | Doppler | `PROXMOX_VE_*`, SSH key content, credentials | Doppler web UI or CLI |
+
+The live `deployment.json` lives only in the private on-prem `s3` object store;
+terragrunt fetches it at plan/apply via the Doppler `S3_*` creds. The repo keeps
+only `deployment.json.example` as a shape reference.
 
 `terraform.tfvars` is gitignored and must not exist — it silently overrides
 `deployment.json` via Terraform variable precedence.

--- a/README.md
+++ b/README.md
@@ -45,13 +45,9 @@ Config is split across three layers:
 
 | Source | Contents | How to edit |
 | ------ | -------- | ----------- |
-| `deployment.json` | Container/VM definitions, pools, node placement | Private (not committed): edit a copy, then `aws s3 cp` it to `s3://iac-inventory/deployment.json` in the on-prem `s3` store |
+| `deployment.json` | Container/VM definitions, pools, node placement | Private, in the on-prem `s3` store (see [AGENTS.md](AGENTS.md)) |
 | `terraform.sops.json` | Per-VLAN network CIDRs, domain, SSH key paths | Decrypt with SOPS, edit, re-encrypt |
 | Doppler | `PROXMOX_VE_*`, SSH key content, credentials | Doppler web UI or CLI |
-
-The live `deployment.json` lives only in the private on-prem `s3` object store;
-terragrunt fetches it at plan/apply via the Doppler `S3_*` creds. The repo keeps
-only `deployment.json.example` as a shape reference.
 
 `terraform.tfvars` is gitignored and must not exist — it silently overrides
 `deployment.json` via Terraform variable precedence.

--- a/agentsmd/rules/infra/deployment-json-source-of-truth.md
+++ b/agentsmd/rules/infra/deployment-json-source-of-truth.md
@@ -46,6 +46,7 @@ When adding containers to `deployment.json`:
   "description": "Description of the container",
   "cpu_cores": 2,
   "memory_dedicated": 2048,
+  "vlan": "compute",
   "tags": ["terraform", "container", "some-tag"],
   "pool_id": "infrastructure",
   "root_disk": { "size": 16 }

--- a/agentsmd/rules/infra/deployment-json-source-of-truth.md
+++ b/agentsmd/rules/infra/deployment-json-source-of-truth.md
@@ -8,11 +8,13 @@ type: feedback
 
 `deployment.json` is the **single source of truth** for Terraform resource definitions (containers, VMs, pools, sizing) in this repo.
 
-It is **private and NOT committed**: the live file lives only in the on-prem `s3`
-object store at `s3://iac-inventory/deployment.json` (a versioned bucket), fetched
-by terragrunt at plan/apply via the Doppler `S3_*` creds (`DEPLOYMENT_JSON_PATH`
-overrides with a local file for offline/bootstrap work). The repo keeps only
-`deployment.json.example` as a shape reference.
+It is **private and NOT committed**: the live file is the single versioned object in
+the on-prem `s3` object store, which terragrunt fetches at plan/apply with the Doppler
+`S3_*` creds and FAILS LOUD if it is missing (a blank input can never plan a destroy).
+Its location is parameterized in `terragrunt.hcl` (`S3_INVENTORY_BUCKET` /
+`S3_INVENTORY_KEY`, preferred values as defaults); `DEPLOYMENT_JSON_PATH` overrides with
+a local file for offline/bootstrap work. The repo keeps only `deployment.json.example`
+as a shape reference. Read/edit recipe: `docs/SOPS_SETUP.md` → "Setting Up Layer 1".
 
 **Why:** `terraform.tfvars` was deleted because it silently overrides `deployment.json` via Terraform variable
 precedence (tfvars = level 3, TF_VAR_* env vars from Terragrunt = level 2). It was gitignored, so it didn't
@@ -20,9 +22,9 @@ transfer to new worktrees, causing silent drift where changes appeared to apply 
 
 **How to apply:**
 
-- Make ALL infrastructure changes (containers, VMs, pools, Splunk sizing) in
-  `deployment.json`, then upload it back to `s3://iac-inventory/deployment.json`
-  in the on-prem `s3` store — never `git add deployment.json`
+- Make ALL infrastructure changes (containers, VMs, pools, Splunk sizing) in the live
+  object and upload it back (fetch/validate/upload steps: `docs/SOPS_SETUP.md` Layer 1) —
+  never `git add deployment.json`
 - Never create or commit `terraform.tfvars` — it is gitignored and forbidden
 - If `terraform.tfvars` exists in your worktree, delete it immediately: `rm terraform.tfvars`
 - SOPS (`terraform.sops.json`) holds 5 env-specific values (not necessarily secret, but

--- a/agentsmd/rules/infra/deployment-json-source-of-truth.md
+++ b/agentsmd/rules/infra/deployment-json-source-of-truth.md
@@ -8,13 +8,21 @@ type: feedback
 
 `deployment.json` is the **single source of truth** for Terraform resource definitions (containers, VMs, pools, sizing) in this repo.
 
+It is **private and NOT committed**: the live file lives only in the on-prem `s3`
+object store at `s3://iac-inventory/deployment.json` (a versioned bucket), fetched
+by terragrunt at plan/apply via the Doppler `S3_*` creds (`DEPLOYMENT_JSON_PATH`
+overrides with a local file for offline/bootstrap work). The repo keeps only
+`deployment.json.example` as a shape reference.
+
 **Why:** `terraform.tfvars` was deleted because it silently overrides `deployment.json` via Terraform variable
 precedence (tfvars = level 3, TF_VAR_* env vars from Terragrunt = level 2). It was gitignored, so it didn't
 transfer to new worktrees, causing silent drift where changes appeared to apply but didn't.
 
 **How to apply:**
 
-- Edit `deployment.json` for ALL infrastructure changes: containers, VMs, pools, Splunk sizing
+- Make ALL infrastructure changes (containers, VMs, pools, Splunk sizing) in
+  `deployment.json`, then upload it back to `s3://iac-inventory/deployment.json`
+  in the on-prem `s3` store — never `git add deployment.json`
 - Never create or commit `terraform.tfvars` — it is gitignored and forbidden
 - If `terraform.tfvars` exists in your worktree, delete it immediately: `rm terraform.tfvars`
 - SOPS (`terraform.sops.json`) holds 5 env-specific values (not necessarily secret, but

--- a/deployment.schema.json
+++ b/deployment.schema.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "terraform-proxmox deployment.json (desired-state INPUT)",
+  "description": "Contract for the private desired-state input fetched from the on-prem S3-compatible object store at plan/apply. Its job is to REJECT an empty or structurally-broken input before any plan runs, so a missing/blank file can never produce a destroy-all plan. additionalProperties stays true so per-environment extras and `_*comment` keys never false-fail; only the load-bearing shape is enforced.",
+  "type": "object",
+  "required": [
+    "containers",
+    "nodes",
+    "pools",
+    "proxmox_node"
+  ],
+  "additionalProperties": true,
+  "properties": {
+    "containers": {
+      "type": "object",
+      "description": "LXC desired-state, keyed by name. At least one is required — an empty map is the empty-{} destroy footgun this schema exists to catch. `_`-prefixed keys are inline `_*comment` docs (terragrunt strips them) and are exempt from the entry shape.",
+      "minProperties": 1,
+      "patternProperties": {
+        "^_": {}
+      },
+      "additionalProperties": {
+        "$ref": "#/definitions/container_input"
+      }
+    },
+    "vms": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "pools": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": true
+    },
+    "nodes": {
+      "type": "object",
+      "description": "Cluster node identity, keyed by node name. At least one required.",
+      "minProperties": 1,
+      "additionalProperties": true
+    },
+    "node_storage": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "datastores": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "host_services": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "proxmox_node": {
+      "type": "string",
+      "minLength": 1
+    },
+    "environment": {
+      "type": "string",
+      "minLength": 1
+    }
+  },
+  "definitions": {
+    "container_input": {
+      "type": "object",
+      "description": "A single container's desired-state. Only the fields that break addressing/identity if absent are required; everything else is free.",
+      "required": [
+        "vm_id",
+        "hostname",
+        "vlan"
+      ],
+      "additionalProperties": true,
+      "properties": {
+        "vm_id": {
+          "type": "integer",
+          "minimum": 100
+        },
+        "hostname": {
+          "type": "string",
+          "minLength": 1
+        },
+        "vlan": {
+          "type": "string",
+          "minLength": 1
+        },
+        "pool_id": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    }
+  }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -167,7 +167,11 @@ Cribl Edge and Cribl Stream were previously planned for Docker Swarm on
 
 ### LXC Containers (terraform-proxmox)
 
-Authoritative list lives in `deployment.json` `containers.*`. Summary by pool:
+Authoritative list lives in `deployment.json` `containers.*` — the source of
+truth for infrastructure. That file is **not committed**: its home is the private
+on-prem `s3` object store (`s3://iac-inventory/deployment.json`), fetched by
+terragrunt at plan/apply via the Doppler `S3_*` creds; the repo keeps only
+`deployment.json.example` as a shape reference. Summary by pool:
 
 - **`infrastructure`** — `ansible`, `pve-scripts-local`, `technitium-dns`,
   `pi-hole`, `phpipam`, `apt-cacher-ng`, `minio`, `mailpit`, `ntfy`,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -167,11 +167,10 @@ Cribl Edge and Cribl Stream were previously planned for Docker Swarm on
 
 ### LXC Containers (terraform-proxmox)
 
-Authoritative list lives in `deployment.json` `containers.*` — the source of
-truth for infrastructure. That file is **not committed**: its home is the private
-on-prem `s3` object store (`s3://iac-inventory/deployment.json`), fetched by
-terragrunt at plan/apply via the Doppler `S3_*` creds; the repo keeps only
-`deployment.json.example` as a shape reference. Summary by pool:
+Authoritative list lives in `deployment.json` `containers.*` — the source of truth
+for infrastructure (private, in the on-prem `s3` store; see
+[the source-of-truth rule](../agentsmd/rules/infra/deployment-json-source-of-truth.md)).
+Summary by pool:
 
 - **`infrastructure`** — `ansible`, `pve-scripts-local`, `technitium-dns`,
   `pi-hole`, `phpipam`, `apt-cacher-ng`, `minio`, `mailpit`, `ntfy`,

--- a/docs/INVENTORY_PUBLISHING.md
+++ b/docs/INVENTORY_PUBLISHING.md
@@ -33,10 +33,9 @@ and no terraform toolchain.
 
 ## Freshness contract
 
-The published object reflects the **last apply**. Updating `deployment.json` (the
-private desired-state INPUT, which lives in the on-prem `s3` store at
-`s3://iac-inventory/deployment.json`, not in this repo) without applying changes
-nothing downstream — `apply` is the only publish point. This makes `apply` the
+The published object reflects the **last apply**. Updating the desired-state input
+(`deployment.json`, the private INPUT — see the source-of-truth rule) without applying
+changes nothing downstream — `apply` is the only publish point. This makes `apply` the
 single, auditable way to change what every consumer sees.
 
 ## Relationship to `scripts/sync-inventory.sh`

--- a/docs/INVENTORY_PUBLISHING.md
+++ b/docs/INVENTORY_PUBLISHING.md
@@ -33,9 +33,11 @@ and no terraform toolchain.
 
 ## Freshness contract
 
-The published object reflects the **last apply**. Editing `deployment.json`
-without applying changes nothing downstream — `apply` is the only publish point.
-This makes `apply` the single, auditable way to change what every consumer sees.
+The published object reflects the **last apply**. Updating `deployment.json` (the
+private desired-state INPUT, which lives in the on-prem `s3` store at
+`s3://iac-inventory/deployment.json`, not in this repo) without applying changes
+nothing downstream — `apply` is the only publish point. This makes `apply` the
+single, auditable way to change what every consumer sees.
 
 ## Relationship to `scripts/sync-inventory.sh`
 

--- a/docs/SOPS_SETUP.md
+++ b/docs/SOPS_SETUP.md
@@ -5,7 +5,7 @@ This repository uses a 3-layer architecture for deployment configuration.
 ## The 3 Layers
 
 ```text
-LAYER 1: deployment.json (committed, plaintext, git-diffable)
+LAYER 1: deployment.json (private on-prem `s3` store, NOT committed)
   containers, VMs, pools, template IDs, disk sizes, CPU/memory/tags, proxmox_node
 
 LAYER 2: terraform.sops.json (committed, SOPS-encrypted, 3 values)
@@ -44,23 +44,30 @@ One command — always this, always both:
 aws-vault exec tf-proxmox -- doppler run -- terragrunt plan
 ```
 
-Terragrunt reads `deployment.json` automatically. Terragrunt decrypts `terraform.sops.json`
+Terragrunt fetches `deployment.json` automatically from the on-prem `s3` store
+(via the Doppler `S3_*` creds). Terragrunt decrypts `terraform.sops.json`
 automatically. Doppler injects credentials. No extra flags needed.
 
 ## Setting Up Layer 1: deployment.json
 
-`deployment.json` is committed plaintext. Edit it directly and commit like any other file.
+`deployment.json` is **not committed**. The live file lives only in the private
+on-prem `s3` object store at `s3://iac-inventory/deployment.json`; terragrunt
+fetches it at plan/apply via the Doppler `S3_*` creds. To change it, edit a local
+copy, validate it against `deployment.schema.json`, then upload it back — never
+`git add deployment.json` (it is gitignored).
 
 ```bash
-# Edit directly and commit like any other file
+# Fetch the current copy from the on-prem `s3` store
+aws --endpoint-url "$S3_ENDPOINT" s3 cp s3://iac-inventory/deployment.json deployment.json
+
+# Edit, then validate against the committed schema
 $EDITOR deployment.json
 
-# Commit — no encryption needed
-git add deployment.json
-git commit -m "chore: add deployment config"
+# Upload the new authoritative copy (versioned bucket keeps history)
+aws --endpoint-url "$S3_ENDPOINT" s3 cp deployment.json s3://iac-inventory/deployment.json
 ```
 
-Changes to `deployment.json` produce clean, readable `git diff` output.
+The committed `deployment.json.example` is the shape reference only.
 
 ## Setting Up Layer 2: terraform.sops.json
 
@@ -138,5 +145,6 @@ To re-encrypt the SOPS file with a new age key:
 - The age private key (`keys.txt`) must **never** be committed to git
 - The `.sops.yaml` file contains only the **public** key (safe to commit)
 - `terraform.sops.json` is safe to commit once encrypted (values are ciphertext)
-- `deployment.json` contains no secrets — commit freely, edit directly
+- `deployment.json` is **not committed** — the live file lives in the private
+  on-prem `s3` store (`s3://iac-inventory/deployment.json`), fetched via Doppler `S3_*`
 - `management_network` and `splunk_network` are derived from other values — never set manually

--- a/docs/SOPS_SETUP.md
+++ b/docs/SOPS_SETUP.md
@@ -60,8 +60,12 @@ copy, validate it against `deployment.schema.json`, then upload it back — neve
 # Fetch the current copy from the on-prem `s3` store
 aws --endpoint-url "$S3_ENDPOINT" s3 cp s3://iac-inventory/deployment.json deployment.json
 
-# Edit, then validate against the committed schema
+# Edit it
 $EDITOR deployment.json
+
+# Validate against the committed schema BEFORE uploading — a bad input would
+# otherwise fail loud at the next plan/apply (no devshell change needed)
+nix run nixpkgs#check-jsonschema -- --schemafile deployment.schema.json deployment.json
 
 # Upload the new authoritative copy (versioned bucket keeps history)
 aws --endpoint-url "$S3_ENDPOINT" s3 cp deployment.json s3://iac-inventory/deployment.json

--- a/docs/SOPS_SETUP.md
+++ b/docs/SOPS_SETUP.md
@@ -50,25 +50,18 @@ automatically. Doppler injects credentials. No extra flags needed.
 
 ## Setting Up Layer 1: deployment.json
 
-`deployment.json` is **not committed**. The live file lives only in the private
-on-prem `s3` object store at `s3://iac-inventory/deployment.json`; terragrunt
-fetches it at plan/apply via the Doppler `S3_*` creds. To change it, edit a local
-copy, validate it against `deployment.schema.json`, then upload it back — never
-`git add deployment.json` (it is gitignored).
+Private desired-state input — see
+[the source-of-truth rule](../agentsmd/rules/infra/deployment-json-source-of-truth.md)
+for where it lives and why. Bucket and key default to `S3_INVENTORY_BUCKET` /
+`S3_INVENTORY_KEY` in `terragrunt.hcl`; export those (or substitute the values) to
+read/edit it. Never `git add deployment.json` (it is gitignored).
 
 ```bash
-# Fetch the current copy from the on-prem `s3` store
-aws --endpoint-url "$S3_ENDPOINT" s3 cp s3://iac-inventory/deployment.json deployment.json
-
-# Edit it
+obj="s3://$S3_INVENTORY_BUCKET/$S3_INVENTORY_KEY"
+aws --endpoint-url "$S3_ENDPOINT" s3 cp "$obj" deployment.json   # fetch
 $EDITOR deployment.json
-
-# Validate against the committed schema BEFORE uploading — a bad input would
-# otherwise fail loud at the next plan/apply (no devshell change needed)
-nix run nixpkgs#check-jsonschema -- --schemafile deployment.schema.json deployment.json
-
-# Upload the new authoritative copy (versioned bucket keeps history)
-aws --endpoint-url "$S3_ENDPOINT" s3 cp deployment.json s3://iac-inventory/deployment.json
+nix run nixpkgs#check-jsonschema -- --schemafile deployment.schema.json deployment.json  # validate
+aws --endpoint-url "$S3_ENDPOINT" s3 cp deployment.json "$obj"   # upload (versioned)
 ```
 
 The committed `deployment.json.example` is the shape reference only.
@@ -149,6 +142,6 @@ To re-encrypt the SOPS file with a new age key:
 - The age private key (`keys.txt`) must **never** be committed to git
 - The `.sops.yaml` file contains only the **public** key (safe to commit)
 - `terraform.sops.json` is safe to commit once encrypted (values are ciphertext)
-- `deployment.json` is **not committed** — the live file lives in the private
-  on-prem `s3` store (`s3://iac-inventory/deployment.json`), fetched via Doppler `S3_*`
+- `deployment.json` is **not committed** — it is the private input in the on-prem
+  `s3` store (see "Setting Up Layer 1" above)
 - `management_network` and `splunk_network` are derived from other values — never set manually

--- a/terragrunt.hcl
+++ b/terragrunt.hcl
@@ -1,9 +1,30 @@
 # Terragrunt configuration for Proxmox infrastructure
 
 locals {
-  # Layer 1: Non-secret deployment config (committed plaintext — edit directly, no SOPS).
-  # Contains container/VM definitions, pool names, Splunk VM sizing, template IDs, etc.
-  deployment_config = try(jsondecode(file("${get_terragrunt_dir()}/deployment.json")), {})
+  # Layer 1: private desired-state INPUT, fetched from the on-prem S3-compatible
+  # object store (endpoint + creds come from Doppler S3_*). NOT committed and NOT
+  # git-versioned by design — the single shared home is the versioned object, so
+  # every session/agent reads the same authoritative copy with no local drift.
+  # Bucket / key / region are parameterized: the preferred value is the default
+  # here, overridable per environment via env without editing this file (and the
+  # endpoint/creds never appear in-repo — they live in Doppler S3_*). NOTE: this
+  # store is NOT the AWS S3 tfstate backend (remote_state below); they never share
+  # a credential (AWS_* from aws-vault for state vs S3_* for this fetch).
+  # DEPLOYMENT_JSON_PATH overrides with a local file for offline / bootstrap work.
+  # FAIL-LOUD: a missing object makes the fetch exit non-zero so run_cmd raises — a
+  # blank input can never silently become {} and plan a full destroy (no try()).
+  s3_inventory_bucket = get_env("S3_INVENTORY_BUCKET", "iac-inventory")
+  s3_inventory_key    = get_env("S3_INVENTORY_KEY", "deployment.json")
+  s3_inventory_region = get_env("S3_INVENTORY_REGION", "us-east-1")
+  deployment_json = (
+    get_env("DEPLOYMENT_JSON_PATH", "") != ""
+    ? file(get_env("DEPLOYMENT_JSON_PATH"))
+    : run_cmd(
+      "--terragrunt-quiet", "bash", "-c",
+      "AWS_SESSION_TOKEN= AWS_ACCESS_KEY_ID=\"$S3_ACCESS_KEY\" AWS_SECRET_ACCESS_KEY=\"$S3_SECRET_KEY\" AWS_REGION=${local.s3_inventory_region} aws --endpoint-url \"$S3_ENDPOINT\" s3 cp s3://${local.s3_inventory_bucket}/${local.s3_inventory_key} - --quiet"
+    )
+  )
+  deployment_config = jsondecode(trimspace(local.deployment_json))
 
   # Strip any "_"-prefixed key: deployment.json uses "_comment" / "_*_comment"
   # keys for inline documentation (JSON has no comment syntax). These are not

--- a/terragrunt.hcl
+++ b/terragrunt.hcl
@@ -21,7 +21,7 @@ locals {
     ? file(get_env("DEPLOYMENT_JSON_PATH"))
     : run_cmd(
       "--terragrunt-quiet", "bash", "-c",
-      "AWS_SESSION_TOKEN= AWS_ACCESS_KEY_ID=\"$S3_ACCESS_KEY\" AWS_SECRET_ACCESS_KEY=\"$S3_SECRET_KEY\" AWS_REGION=${local.s3_inventory_region} aws --endpoint-url \"$S3_ENDPOINT\" s3 cp s3://${local.s3_inventory_bucket}/${local.s3_inventory_key} - --quiet"
+      "unset AWS_PROFILE AWS_SESSION_TOKEN; AWS_ACCESS_KEY_ID=\"$S3_ACCESS_KEY\" AWS_SECRET_ACCESS_KEY=\"$S3_SECRET_KEY\" AWS_REGION=${local.s3_inventory_region} aws --endpoint-url \"$S3_ENDPOINT\" s3 cp s3://${local.s3_inventory_bucket}/${local.s3_inventory_key} - --quiet"
     )
   )
   deployment_config = jsondecode(trimspace(local.deployment_json))


### PR DESCRIPTION
## Why

`deployment.json` is the desired-state **INPUT** (containers/VMs/pools/nodes). Since #335 it has been gitignored and **local-only**, so:
- copies drift across worktrees/machines/sessions (this PR's own verification hit it — a stale local copy was missing a container that is live), and
- a missing file made `terragrunt.hcl` `try(jsondecode(file()), {})` silently decode to `{}` and plan a **full DESTROY**.

It is *not* the "inventory" downstream repos read — that OUTPUT (`ansible_inventory`) already has a shared, locked, never-stale home (S3 state + DynamoDB lock + published artifact). This PR gives the INPUT the same treatment.

## What changed

- **`deployment.json` now lives only in the private on-prem `s3` object store** at `s3://iac-inventory/deployment.json` (private bucket, object versioning = history). terragrunt fetches it at plan/apply with the `S3_*` creds Doppler injects. `DEPLOYMENT_JSON_PATH` still overrides with a local file for offline/bootstrap.
- **Fail-loud:** no `try()`. A missing object makes `aws s3 cp` exit non-zero so `run_cmd` aborts terragrunt; `jsondecode` rejects empty/garbage. A blank desired state can no longer masquerade as "destroy everything".
- **`deployment.schema.json`** — input contract that rejects empty/garbage (required top-level keys, ≥1 container; `_*comment` keys exempt; `additionalProperties: true` so per-env extras don't false-fail). Verified against the real input and the example.
- The homelab `s3` store is **not** the AWS S3 state backend — different endpoint + creds; `AWS_SESSION_TOKEN` is cleared so the state-backend token can't clash with `S3_*`. **State + lock stay on AWS S3 + DynamoDB.**
- **Docs:** corrected every stale "committed plaintext / edit-and-commit `deployment.json`" claim to the s3 model (AGENTS.md, .gitignore, README, docs/SOPS_SETUP, docs/ARCHITECTURE, docs/INVENTORY_PUBLISHING, copilot-instructions, the source-of-truth rule). The committed `deployment.json.example` stays the shape reference.

## Verification (live)

CI runs **raw `tofu`** with mock providers and never exercises terragrunt, so this is verified by a real `terragrunt plan`, not CI:
- fetch returns the inventory; **missing object → exit 1** (fail-loud proven);
- plan is clean: `0 add / 1 cosmetic inventory re-publish / 0 destroy`;
- the s3-read **surfaced a pre-existing drift loudly** (a stale local copy missing a live container showed up as a destroy) — exactly the footgun this closes.

## Follow-ups (not in this PR)

- `meta.deployment_sha256` in the published inventory for "input edited in s3 but never applied" drift detection.
- Public docs site (separate repo) — same model update.
- Delete the now-stale local `deployment.json` copies across worktrees (s3 is the single source).

🤖 Generated with [Claude Code](https://claude.com/claude-code)