### PR TITLE
fix(firewall): allow DHCP on the object-storage container

### DIFF
--- a/modules/firewall/object_storage_rules.tf
+++ b/modules/firewall/object_storage_rules.tf
@@ -14,6 +14,12 @@ resource "proxmox_virtual_environment_firewall_options" "object_storage_containe
   log_level_in  = local.firewall_defaults.log_level_in
   log_level_out = local.firewall_defaults.log_level_out
 
+  # This is a DHCP-first guest (deployment.json dhcp=true) behind DROP in/out
+  # policies. Without the firewall's dhcp allow, its own DHCPDISCOVER/OFFER is
+  # dropped and it never leases its reserved siem IP. Static-IP firewalled
+  # guests don't need this, so it's set here rather than in firewall_defaults.
+  dhcp = true
+
   depends_on = [proxmox_virtual_environment_cluster_firewall.main]
 }
 


### PR DESCRIPTION
## Summary

`object-storage` is a DHCP-first guest (`deployment.json` `dhcp: true`) but its
`firewall_options` used the shared DROP in/out policies **without** enabling the
proxmox `dhcp` allow. Its own `DHCPDISCOVER` was dropped outbound (0 packets on
the bridge) so it never leased its reserved siem IP `10.0.20.20` — eth0 up, no
IPv4 for days.

## Change

Set `dhcp = true` on the `object_storage_container` `firewall_options` only
(static-IP firewalled guests don't need it).

## Note

Verified live (set out-of-band on pve1 to confirm: the container leased
`10.0.20.20` immediately). **This PR makes that permanent in IaC — apply pending
a `tf-proxmox` session.** Until applied, the next terraform-proxmox apply would
revert the live `dhcp: 1`.