### PR TITLE
feat(honeypots): network-wide deception fabric with instant phone alerting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,8 +102,8 @@ local gitignored cache. See `docs/INVENTORY_PUBLISHING.md`.
 | Repo | Consumes | Purpose |
 | --- | --- | --- |
 | `ansible-proxmox` | `ansible_inventory` (host_services, node_storage, nodes) | Host config (kernel, ZFS, monitoring, NAS/Samba) |
-| `ansible-proxmox-apps` | `ansible_inventory` (containers, docker_vms, constants, ingress) | Cribl, HAProxy, DNS, etc. |
-| `ansible-splunk` | `ansible_inventory` (splunk_vm) | Splunk Enterprise (Docker) |
+| `ansible-proxmox-apps` | `ansible_inventory` (containers, docker_vms, constants, ingress) | Cribl, HAProxy, DNS, honeypots (`opencanary`, `apprise`, `tpot` roles — see `docs/HONEYPOTS.md`), etc. |
+| `ansible-splunk` | `ansible_inventory` (splunk_vm) | Splunk Enterprise (Docker); incl. the `honeypot` index |
 
 ### Inventory publish + sync (automatic)
 
@@ -162,6 +162,7 @@ For slow operations and "context deadline exceeded" debugging:
 | Secrets roadmap | [`docs/SECRETS_ROADMAP.md`](./docs/SECRETS_ROADMAP.md) |
 | SOPS / age setup | [`docs/SOPS_SETUP.md`](./docs/SOPS_SETUP.md) |
 | Network-quality monitoring (SmokePing) | [`docs/SMOKEPING.md`](./docs/SMOKEPING.md) |
+| Honeypots / deception fabric + phone alerting | [`docs/HONEYPOTS.md`](./docs/HONEYPOTS.md) |
 | Per-WAN network diagnosis (modem/WAN telemetry) | [`docs/NETWORK_DIAGNOSIS.md`](./docs/NETWORK_DIAGNOSIS.md) |
 | Troubleshooting + timeout/debug logging | [`TROUBLESHOOTING.md`](./TROUBLESHOOTING.md) |
 | General docs | [`README.md`](./README.md) |

--- a/constants.tf
+++ b/constants.tf
@@ -15,6 +15,13 @@ locals {
     cisco_asa = { standard = 516, high = 1516, index = "firewall", sourcetype = "cisco:asa" }
     linux     = { standard = 517, high = 1517, index = "os", sourcetype = "syslog" }
     windows   = { standard = 518, high = 1518, index = "os", sourcetype = "syslog" }
+    # Honeypot deception events (OpenCanary tripwires per VLAN + T-Pot deep
+    # sensor). standard 519 = the HAProxy frontend honeypots ship to; high 1519
+    # = the Cribl Edge backend. Lands in the dedicated `honeypot` Splunk index
+    # (Path B — forensics/correlation) in parallel with the real-time apprise
+    # push (Path A). T-Pot reuses the same frontend with its sourcetype set by
+    # the Cribl Edge pipeline. See docs/HONEYPOTS.md + docs/SPLUNK_INDEXES.md.
+    honeypot = { standard = 519, high = 1519, index = "honeypot", sourcetype = "honeypot:opencanary" }
   }
 
   pipeline_constants = {
@@ -112,6 +119,35 @@ locals {
     vector_db_ports = {
       qdrant_http = 6333
       qdrant_grpc = 6334
+    }
+    # Honeypot / deception sensors. apprise_api = the honeypot-notify gateway's
+    # REST port (caronc/apprise-api): honeypots POST one webhook and Apprise fans
+    # it out to Slack + phone push (Path A). The remaining entries are the
+    # low-interaction decoy services the per-VLAN OpenCanary tripwires emulate —
+    # the firewall honeypot_services group ACCEPTs+logs these from internal so an
+    # intruder touching ANY of them trips an alert. SSH (22) is already covered by
+    # internal_access. The honeypot syslog frontend (519) lives in syslog_port_map
+    # above. Consumed by modules/firewall and the opencanary/apprise/tpot roles in
+    # ansible-proxmox-apps. See docs/HONEYPOTS.md.
+    honeypot_ports = {
+      apprise_api = 8000
+      ftp         = 21
+      telnet      = 23
+      http        = 80
+      https       = 443
+      smb         = 445
+      tftp        = 69   # udp
+      snmp        = 161  # udp
+      ntp         = 123  # udp — OpenCanary NTP module (honeypot CTs only; no host chrony clash)
+      sip         = 5060 # udp
+      mssql       = 1433
+      mysql       = 3306
+      postgres    = 5432
+      rdp         = 3389
+      vnc         = 5900
+      redis       = 6379
+      git         = 9418
+      http_proxy  = 8080
     }
     # Media stack web UIs. qBittorrent + Prowlarr run inside the download-vpn
     # LXC bound to wg0; their UIs are reachable on the LAN. Sonarr/Radarr/Plex

--- a/deployment.json.example
+++ b/deployment.json.example
@@ -25,7 +25,8 @@
   "pools": {
     "logging": { "comment": "Logging and observability infrastructure" },
     "infrastructure": { "comment": "Core infrastructure services" },
-    "ai": { "comment": "AI orchestration tier (Dify, LangFlow, agent-exec)" }
+    "ai": { "comment": "AI orchestration tier (Dify, LangFlow, agent-exec)" },
+    "security": { "comment": "Honeypots and deception sensors (OpenCanary tripwires, T-Pot, apprise notify gateway)" }
   },
 
   "datastores": {},
@@ -112,6 +113,38 @@
       ],
       "cdrom_file_id": "local:iso/proxmox-backup-server.iso",
       "protection": true
+    },
+    "_tpot_comment": "T-Pot deep-sensor (telekom-security/tpotce) — the all-in-one platform bundling 20+ honeypots (Cowrie SSH/Telnet, Dionaea SMB/malware, Conpot ICS/SCADA, Heralding, Log4pot, the Beelzebub+Galah LLM pots, medical/printer pots, tarpits, ...) plus an Elastic attack-map dashboard. Runs Docker-on-VM (like the Splunk VM), placed on the high-CPU/fast node (proxmox-1) because the Elastic stack + many containers are resource-hungry. DNS-first (dhcp:true): VMs now carry positional VMIDs too (locals.tf vm_ipv4 short-circuits cidrhost when dhcp/static). VMID 495100 = tier 4 (observability/security) · sub 9 (deception) · crit 5 · OS 1 (VM/qemu) · instance 0 · env 0. The `tpot` tag drives the firewall (wide-net input, restricted egress); `docker` puts it in docker_vms for the ansible-proxmox-apps `tpot` role, which runs the installer + wires ElastAlert -> the apprise gateway. Reachable at https://tpot.{domain} (T-Pot serves its own dashboard). Sits on the nonprod/untrusted decoy segment.",
+    "tpot": {
+      "vm_id": 495100,
+      "dhcp": true,
+      "reserved_host": 38,
+      "vlan": "nonprod",
+      "name": "tpot",
+      "description": "T-Pot all-in-one multi-honeypot platform (Cowrie, Dionaea, Conpot, Galah/Beelzebub LLM, Log4pot, ...) + attack-map dashboard",
+      "node_name": "proxmox-1",
+      "cpu_cores": 8,
+      "memory_dedicated": 16384,
+      "tags": ["terraform", "docker", "honeypot", "tpot"],
+      "boot_disk": { "datastore_id": "local-zfs", "size": 256 },
+      "clone_template": { "template_id": 9000 },
+      "user_account": { "username": "debian", "password": "", "keys": [] }
+    },
+    "_tpot_warm_comment": "Warm standby of the deep sensor on the normally-shut-down backup node (proxmox-3). DR copy only — spun up when proxmox-3 is powered for backups or during failover (the VM schema has no on_boot field; proxmox-3 is commissioned:false so nothing is applied there until you commission it). instance 1 -> VMID 495110.",
+    "tpot-warm": {
+      "vm_id": 495110,
+      "dhcp": true,
+      "reserved_host": 39,
+      "vlan": "nonprod",
+      "name": "tpot-warm",
+      "description": "Warm-standby T-Pot (DR copy) on the backup node proxmox-3",
+      "node_name": "proxmox-3",
+      "cpu_cores": 8,
+      "memory_dedicated": 16384,
+      "tags": ["terraform", "docker", "honeypot", "tpot"],
+      "boot_disk": { "datastore_id": "local-zfs", "size": 256 },
+      "clone_template": { "template_id": 9000 },
+      "user_account": { "username": "debian", "password": "", "keys": [] }
     }
   },
 
@@ -279,6 +312,59 @@
       "root_disk": { "size": 24 },
       "mount_points": [{ "volume": "local-zfs", "size": "80G", "path": "/opt/langfuse" }],
       "features": { "nesting": true }
+    },
+
+    "_honeypot_comment": "DECEPTION FABRIC (see docs/HONEYPOTS.md). Three pieces: (1) honeypot-notify — the dedicated alert gateway (caronc/apprise-api). Honeypots POST one webhook; Apprise fans it to Slack + phone push (ntfy/Pushover). The `honeypot`+`notify` tags give it the apprise port inbound + OPEN egress (to reach external notifiers); Slack webhook/phone tokens come from Doppler at runtime, never committed. (2) honeypot-tw-* — one lightweight OpenCanary tripwire PER VLAN (clone the example below for every entry in your network_cidrs map: lan_main, dns, mgmt, bmc, compute, siem, pipeline, data, ai, apps, media_svc, homeauto, nonprod). Each fakes SSH/HTTP/SMB/DB/RDP/SNMP/... and alerts instantly on any touch; the `honeypot` tag opens the decoy ports + internal-only egress (a poked sensor can reach the gateway + syslog 519 but never the internet). (3) the T-Pot VM above. VMID convention (positional, DNS-first): a tripwire adopts the TIER of the VLAN it defends (tier = VLAN/10; specials 1/5/53 use the 7-digit prefix form) · sub 9 (deception) · crit 5 · OS 0 (LXC) · instance 0 · env 0 — e.g. nonprod(90)=995000, apps(60)=695000, compute(10)=195000, mgmt(5)=0595000. Placement honors the node roles: gateway + most tripwires on proxmox-2; put 1-2 tripwires (highest-value VLANs) + the T-Pot VM on the fast node proxmox-1; warm/backup copies on the normally-off proxmox-3. reserved_host octets (.36-.39 + per-tripwire) are illustrative — reconcile every VMID + octet against your live deployment.json before applying.",
+    "honeypot-notify": {
+      "vm_id": 492000,
+      "dhcp": true,
+      "reserved_host": 36,
+      "vlan": "mgmt",
+      "hostname": "honeypot-notify",
+      "description": "Honeypot alert gateway (caronc/apprise-api): fans honeypot hits out to Slack + phone push. Open egress for external notifiers.",
+      "node_name": "proxmox-2",
+      "cpu_cores": 1,
+      "memory_dedicated": 512,
+      "tags": ["terraform", "container", "honeypot", "notify", "docker"],
+      "pool_id": "security",
+      "root_disk": { "size": 8 },
+      "unprivileged": true,
+      "features": { "nesting": true, "keyctl": true }
+    },
+    "_honeypot_notify_warm_comment": "Cold spare of the alert path on the backup node (proxmox-3, normally off). start_on_boot:false so it stays dormant until DR; instance 1 -> VMID 492010.",
+    "honeypot-notify-warm": {
+      "vm_id": 492010,
+      "dhcp": true,
+      "reserved_host": 37,
+      "vlan": "mgmt",
+      "hostname": "honeypot-notify-warm",
+      "description": "Warm-standby apprise gateway (cold spare of the alert path) on proxmox-3",
+      "node_name": "proxmox-3",
+      "cpu_cores": 1,
+      "memory_dedicated": 512,
+      "tags": ["terraform", "container", "honeypot", "notify", "docker"],
+      "pool_id": "security",
+      "root_disk": { "size": 8 },
+      "unprivileged": true,
+      "start_on_boot": false,
+      "features": { "nesting": true, "keyctl": true }
+    },
+    "_honeypot_tripwire_comment": "Representative per-VLAN OpenCanary tripwire. CLONE ONE PER VLAN, swapping the leading tier digit to that VLAN's tier and the `vlan` field to its name. This example defends the nonprod/untrusted segment (tier 9). Place 1-2 of your highest-value tripwires (e.g. compute, siem) on proxmox-1; the rest on proxmox-2.",
+    "honeypot-tw-nonprod": {
+      "vm_id": 995000,
+      "dhcp": true,
+      "reserved_host": 66,
+      "vlan": "nonprod",
+      "hostname": "honeypot-tw-nonprod",
+      "description": "OpenCanary tripwire on the nonprod VLAN — fakes SSH/HTTP/SMB/DB/RDP/SNMP/... and alerts instantly via the apprise gateway + Splunk honeypot index",
+      "node_name": "proxmox-2",
+      "cpu_cores": 1,
+      "memory_dedicated": 256,
+      "tags": ["terraform", "container", "honeypot", "docker"],
+      "pool_id": "security",
+      "root_disk": { "size": 8 },
+      "unprivileged": true,
+      "features": { "nesting": true, "keyctl": true }
     }
   }
 }

--- a/docs/HONEYPOTS.md
+++ b/docs/HONEYPOTS.md
@@ -15,7 +15,7 @@ notification gateway** that pages you on Slack and your phone in seconds.
 
 ## Architecture
 
-```
+```text
             EVERY live VLAN gets its own OpenCanary tripwire (DHCP/DNS-first LXC)
   Default Mgmt DNS  Core Storage Data Obs/Sec AI Apps Media Home Untrusted
     │      │    │    │     │      │     │     │   │     │     │       │
@@ -180,4 +180,8 @@ untrusted segment and never holds anything real.
 - [INFRASTRUCTURE_NUMBERING.md](./INFRASTRUCTURE_NUMBERING.md) — VMID scheme
 - [SPLUNK_INDEXES.md](./SPLUNK_INDEXES.md) — the `honeypot` index
 - [LOGGING_PIPELINE.md](./LOGGING_PIPELINE.md) — syslog → Cribl → Splunk
-- Upstream: [T-Pot](https://github.com/telekom-security/tpotce) · [OpenCanary](https://github.com/thinkst/opencanary) · [Apprise](https://github.com/caronc/apprise) · [awesome-honeypots](https://github.com/paralax/awesome-honeypots)
+- Upstream:
+  [T-Pot](https://github.com/telekom-security/tpotce) ·
+  [OpenCanary](https://github.com/thinkst/opencanary) ·
+  [Apprise](https://github.com/caronc/apprise) ·
+  [awesome-honeypots](https://github.com/paralax/awesome-honeypots)

--- a/docs/HONEYPOTS.md
+++ b/docs/HONEYPOTS.md
@@ -1,0 +1,183 @@
+# Honeypots & Deception Fabric
+
+Network-wide deception sensors that fire an **immediate phone alert** the moment
+anything touches a fake service, plus a forensic copy into Splunk. This repo
+(the **infrastructure layer**) provisions the guests, firewall, and inventory;
+the honeypot software itself is deployed by the downstream **ansible-proxmox-apps**
+roles (`opencanary`, `apprise`, `tpot`).
+
+## Why
+
+An attacker who lands inside any VLAN should trip something loud. Before this,
+nothing in the lab watched lateral movement. The design gives **every VLAN a
+tripwire**, a **deep sensor** for breadth + threat-intel, and a **dedicated
+notification gateway** that pages you on Slack and your phone in seconds.
+
+## Architecture
+
+```
+            EVERY live VLAN gets its own OpenCanary tripwire (DHCP/DNS-first LXC)
+  Default Mgmt DNS  Core Storage Data Obs/Sec AI Apps Media Home Untrusted
+    │      │    │    │     │      │     │     │   │     │     │       │
+    └──────┴────┴────┴─────┴──────┴─────┴─────┴───┴─────┴─────┴───┐   │  T-Pot deep-sensor VM
+                                                                  │   │  (nonprod/untrusted)
+  On every honeypot HIT, two parallel paths fire:                 │   │
+                                                                  ▼   ▼
+  (A) INSTANT   ── HTTP POST ─► honeypot-notify (apprise-api) ─► Slack + phone push
+  (B) FORENSIC  ── syslog 519 ─► HAProxy ─► Cribl Edge ─► Cribl Stream ─► Splunk `honeypot` index
+```
+
+- **Path A (instant):** OpenCanary's webhook handler and a T-Pot
+  ElastAlert/Logstash output POST one JSON to the apprise-api gateway, which
+  fans it to Slack **and** a phone-push service (ntfy/Pushover). Sub-second,
+  independent of Splunk.
+- **Path B (forensic):** the same events ride the existing syslog pipeline
+  (frontend **519** → backend **1519**, added to `syslog_port_map` in
+  `constants.tf`) into the dedicated `honeypot` Splunk index for history,
+  dashboards, and correlation. See [SPLUNK_INDEXES.md](./SPLUNK_INDEXES.md).
+
+## Sensors (popular + maintained, June 2026)
+
+| Sensor | Role | Where |
+| --- | --- | --- |
+| **OpenCanary** (thinkst) | Low-interaction multi-service tripwire: SSH, Telnet, FTP, HTTP(S), SMB, RDP, MSSQL, MySQL, Postgres, Redis, VNC, SNMP, SIP, TFTP, NTP, git, TCP-banner | **Every VLAN** (one LXC each) |
+| **T-Pot** (telekom-security) — bundles **Cowrie** (SSH/Telnet), **Dionaea** (SMB/malware), **Conpot** (ICS/SCADA), **Heralding**, **Honeytrap**, **Mailoney**, **Adbhoney**, **CiscoASA**, **CitrixHoneypot**, **ElasticPot**, **RedisHoneypot**, **Dicompot/Medpot**, **IPPHoney/Miniprint**, **Log4pot**, **ddospot**, **Endlessh/Go-pot/Hellpot/Glutton** tarpits, **H0neytr4p**, **Honeyaml**, and the **Beelzebub** + **Galah** LLM pots | Deep, medium/high-interaction breadth + Elastic attack-map dashboard | **nonprod** decoy VM |
+| **Apprise API** (caronc) | Notification gateway (Path A) — *not* a honeypot | `honeypot-notify` LXC |
+
+Adding a standalone pot later (e.g. a dedicated Cowrie/Dionaea LXC on one VLAN)
+uses the exact same Docker-in-LXC pattern as a tripwire — tag it `honeypot`.
+
+## VMID & addressing convention
+
+Honeypots follow the current 6-7-digit positional scheme
+(`[Tier][Sub-tier][Crit][OS][Instance][Env]`, see
+[INFRASTRUCTURE_NUMBERING.md](./INFRASTRUCTURE_NUMBERING.md)) and are
+**DHCP/DNS-first** (`dhcp: true` + a `reserved_host` octet; reached by
+`{hostname}.{subdomain}`). VMs now support this too — `locals.tf` short-circuits
+`cidrhost()` for any guest with `dhcp = true` or a static `ip_config`, so a VM
+can carry a 7-digit positional VMID (the T-Pot VM does).
+
+Honeypot digit choices: **sub-tier `9`** (deception), **crit `5`** for tripwires
+(`2` for the alert-critical notify gateway), **OS `0`** (LXC; the T-Pot VM uses
+the VM OS-digit `1`), **instance/env `0`**. A tripwire adopts the **tier of the
+VLAN it defends** (tier = VLAN ÷ 10; special VLANs 1/5/53 use the 7-digit prefix
+form), so the number tells you which segment it watches.
+
+> The VMIDs and `reserved_host` octets in `deployment.json.example` are
+> **illustrative** — reconcile every value against the live (gitignored)
+> `deployment.json` for collisions before applying.
+
+## Per-VLAN tripwire map
+
+Rule: **one OpenCanary LXC per entry in the live `network_cidrs` / `vlan_ids`
+map**, so coverage tracks the real topology regardless of doc/code drift.
+
+| Tier / VLAN | Proposed VMID | Emphasis (OpenCanary modules) |
+| --- | --- | --- |
+| Default (1) | 0195000 | SSH, HTTP, FTP, Telnet, SMB |
+| Management (5) | 0595000 | SSH, HTTPS, SNMP, RDP, VNC |
+| DNS (53) | 5395000 | NTP, SNMP, SSH, HTTP |
+| 1 Core (10) | 195000 | SSH, HTTP, MySQL, Redis, SMB |
+| 2 Storage (20) | 295000 | SSH, SMB, FTP, MSSQL |
+| 3 Data/pipeline (30) | 395000 | MySQL, MSSQL, Redis, SSH, TCP-banner (fake syslog/HEC) |
+| 4 Observability/Security (40) | 495000 | SSH, HTTP, MSSQL, Redis |
+| 5 AI/ML (50) | 595000 | HTTP, SSH, Redis, TCP-banner (fake model API) |
+| 6 Apps (60) | 695000 | HTTP, HTTPS, SSH, FTP, MySQL |
+| 7 Media (70) | 795000 | HTTP, SMB, FTP, SSH |
+| 8 Home/IoT (80) | 895000 | HTTP, SSH, Telnet, SIP |
+| 9 Untrusted (90) | 995000 | SSH, HTTP, SMB, Telnet |
+
+If the live topology still carries the extra `variables-network.tf` keys
+(`bmc`, `pipeline`, `media_svc`, `homeauto`, `nonprod`), add a tripwire for each
+of those too — one per live VLAN.
+
+## Node placement
+
+Node roles (`deployment.json` → `nodes`): **proxmox-1** = fast/CPU
+(amd-desktop), **proxmox-2** = default workhorse (R410), **proxmox-3** =
+normally shut down (R710, `commissioned: false`) for backups/warm.
+
+- **proxmox-1 (CPU/high-speed):** primary **T-Pot VM** (Elastic + many
+  containers) **plus 2 tripwires** (highest-value VLANs, e.g. Core + Obs/Sec).
+- **proxmox-2:** the `honeypot-notify` gateway + all remaining tripwires
+  (lightweight, always-on, live sensors).
+- **proxmox-3 (normally off → backups/warm):** **warm-standby T-Pot** and
+  **warm-standby notify** (`start_on_boot: false`). No primary live sensors — a
+  powered-off node can't alert; these are DR copies brought up during failover
+  or backup windows.
+
+## Firewall posture
+
+Tag-driven, wired through `modules/firewall` (see `honeypot_rules.tf`,
+`vm_rules.tf`, `security_groups.tf`):
+
+- **Tripwires** (`honeypot` tag): input DROP + the `honeypot-svc` group
+  (ACCEPT+log the decoy ports, logged at `info`). Egress restricted to internal
+  only (`outbound-internal`) — a poked sensor reaches the notify gateway + syslog
+  519 but **never the internet**.
+- **Notify gateway** (`honeypot` + `notify` tags): input DROP + `honeypot-notify-svc`
+  (apprise port 8000); **open egress** so it can reach Slack/Pushover/ntfy.sh.
+  Kept out of `notification_container_ids` (Mailpit/ntfy) so it is never
+  double-claimed by two `firewall_options` resources.
+- **T-Pot VM** (`tpot` tag): input **ACCEPT** (a deliberate wide-net sensor that
+  manages its own dockerized firewall; logged), egress DROP + internal + HTTPS
+  (image/update + threat-intel pulls) so captured malware can't beacon out.
+
+## Alerting setup (secrets)
+
+The apprise gateway loads its targets from Doppler at runtime — **never
+committed**:
+
+- `SLACK_WEBHOOK_URL` (or `APPRISE_SLACK_*`) — Slack incoming webhook.
+- `NTFY_*` / `PUSHOVER_*` — phone-push token.
+
+Honeypots POST to `http://honeypot-notify.<domain>:8000/notify/<config>` (or the
+Traefik route `https://honeypot-notify.<domain>`). The apprise UI is in the
+ingress table (`ingress.tf`).
+
+## Adding / removing a sensor
+
+1. **Tripwire:** add a `honeypot-tw-<vlan>` container in `deployment.json`
+   (clone the `honeypot-tw-nonprod` example) with `dhcp: true`, a free
+   `reserved_host`, the VLAN's positional VMID, tags
+   `["terraform","container","docker","honeypot"]`, `pool_id: "security"`. The
+   firewall + inventory + DNS reservation follow automatically from the tags.
+2. **Notify gateway / T-Pot:** already in the example — adjust `node_name` and
+   resources to taste.
+3. Remove by deleting the entry; the tag-driven maps shrink automatically.
+
+The `opencanary` Ansible role renders each tripwire's `opencanary.conf` from the
+inventory (modules per the map above) and wires the webhook handler (Path A) +
+syslog handler to 519 (Path B).
+
+## T-Pot dashboard
+
+T-Pot serves its own authenticated HTTPS dashboard (attack map, Kibana). Reach
+it directly at `https://tpot.<domain>` (DNS-first FQDN). The `tpot` Ansible role
+runs the installer, selects the edition compose, and adds the ElastAlert →
+apprise rule so new attacks also page you instantly.
+
+## Operational note
+
+This is a **deception system**: inbound connections on the decoy ports are
+expected and are the signal. Tripwire egress is internal-only and T-Pot egress
+is restricted, but treat the T-Pot VM as hostile-by-design — it lives on the
+untrusted segment and never holds anything real.
+
+## Verification
+
+1. `tofu fmt -check`, `tofu validate`, `tofu test` (root + `modules/firewall`).
+2. `terragrunt plan` — expect the tripwire LXCs + notify CTs + T-Pot VMs + the
+   `honeypot-svc`/`honeypot-notify-svc` groups + `security` pool, with
+   `node_name` per the placement table and no changes to existing resources.
+3. **End-to-end:** from a host on any VLAN, `nmap -sT <tripwire-fqdn>` or
+   `ssh fakeuser@<tripwire-fqdn>`. Within seconds expect (a) a Slack message +
+   phone push, and (b) the event in Splunk's `honeypot` index. Repeat against the
+   T-Pot VM (e.g. Cowrie SSH) for the deep-sensor path.
+
+## Related
+
+- [INFRASTRUCTURE_NUMBERING.md](./INFRASTRUCTURE_NUMBERING.md) — VMID scheme
+- [SPLUNK_INDEXES.md](./SPLUNK_INDEXES.md) — the `honeypot` index
+- [LOGGING_PIPELINE.md](./LOGGING_PIPELINE.md) — syslog → Cribl → Splunk
+- Upstream: [T-Pot](https://github.com/telekom-security/tpotce) · [OpenCanary](https://github.com/thinkst/opencanary) · [Apprise](https://github.com/caronc/apprise) · [awesome-honeypots](https://github.com/paralax/awesome-honeypots)

--- a/docs/SPLUNK_INDEXES.md
+++ b/docs/SPLUNK_INDEXES.md
@@ -14,7 +14,7 @@ This document defines the Splunk indexes used in the logging pipeline, their pur
 | network        | General network logs      | Switches, routers, other       | 365 days  |
 | netmon_metrics | Per-WAN network diagnosis | Probes, DOCSIS SNMP, satellite | 90 days   |
 | netflow        | UniFi NetFlow/IPFIX flows | UniFi gateway (IPFIX 2055)     | 90 days   |
-| honeypot       | Honeypot deception events | OpenCanary tripwires, T-Pot (syslog 519) | 365 days  |
+| honeypot       | Honeypot deception events | OpenCanary tripwires, T-Pot    | 365 days  |
 
 ## Index Configuration
 
@@ -170,24 +170,24 @@ diagnostics and `netflow` flow indexes are each capped at **50GB** (`51200`).
 
 ## Source Type Mapping
 
-| Source Type    | Index          | Description            |
-| -------------- | -------------- | ---------------------- |
-| unifi:usg      | unifi          | UniFi Security Gateway |
-| unifi:switch   | unifi          | UniFi switches         |
-| unifi:ap       | unifi          | UniFi access points    |
-| syslog:linux   | os             | Linux syslog           |
-| syslog:macos   | os             | macOS syslog           |
-| syslog:windows | os             | Windows Event Log      |
-| pan:traffic    | firewall       | Palo Alto traffic      |
-| pan:threat     | firewall       | Palo Alto threats      |
-| cisco:asa      | firewall       | Cisco ASA              |
-| syslog:network | network        | Generic network        |
-| netmon:probe   | netmon_metrics | Telegraf active probes |
-| netmon:docsis  | netmon_metrics | Cable modem SNMP       |
-| netmon:sat     | netmon_metrics | satellite uplink probe |
-| ipfix          | netflow        | UniFi NetFlow/IPFIX    |
-| honeypot:opencanary | honeypot  | OpenCanary tripwires   |
-| honeypot:tpot  | honeypot       | T-Pot deep sensor      |
+| Source Type         | Index          | Description            |
+| ------------------- | -------------- | ---------------------- |
+| unifi:usg           | unifi          | UniFi Security Gateway |
+| unifi:switch        | unifi          | UniFi switches         |
+| unifi:ap            | unifi          | UniFi access points    |
+| syslog:linux        | os             | Linux syslog           |
+| syslog:macos        | os             | macOS syslog           |
+| syslog:windows      | os             | Windows Event Log      |
+| pan:traffic         | firewall       | Palo Alto traffic      |
+| pan:threat          | firewall       | Palo Alto threats      |
+| cisco:asa           | firewall       | Cisco ASA              |
+| syslog:network      | network        | Generic network        |
+| netmon:probe        | netmon_metrics | Telegraf active probes |
+| netmon:docsis       | netmon_metrics | Cable modem SNMP       |
+| netmon:sat          | netmon_metrics | satellite uplink probe |
+| ipfix               | netflow        | UniFi NetFlow/IPFIX    |
+| honeypot:opencanary | honeypot       | OpenCanary tripwires   |
+| honeypot:tpot       | honeypot       | T-Pot deep sensor      |
 
 ## HEC Token Configuration
 

--- a/docs/SPLUNK_INDEXES.md
+++ b/docs/SPLUNK_INDEXES.md
@@ -14,6 +14,7 @@ This document defines the Splunk indexes used in the logging pipeline, their pur
 | network        | General network logs      | Switches, routers, other       | 365 days  |
 | netmon_metrics | Per-WAN network diagnosis | Probes, DOCSIS SNMP, satellite | 90 days   |
 | netflow        | UniFi NetFlow/IPFIX flows | UniFi gateway (IPFIX 2055)     | 90 days   |
+| honeypot       | Honeypot deception events | OpenCanary tripwires, T-Pot (syslog 519) | 365 days  |
 
 ## Index Configuration
 
@@ -124,6 +125,24 @@ frozenTimePeriodInSecs = 7776000
 - High-volume traffic-flow telemetry, split from `network` so its volume has its own
   size and retention envelope
 
+### honeypot
+
+```ini
+[honeypot]
+homePath = $SPLUNK_DB/honeypot/db
+coldPath = $SPLUNK_DB/honeypot/colddb
+thawedPath = $SPLUNK_DB/honeypot/thaweddb
+maxTotalDataSizeMB = 51200
+frozenTimePeriodInSecs = 31536000
+```
+
+**Data types**:
+
+- OpenCanary tripwire interactions (per-VLAN decoy SSH/HTTP/SMB/DB/RDP/SNMP/... touches)
+- T-Pot honeypot events (Cowrie sessions, Dionaea captures, etc.)
+- Forensic/correlation copy (Path B) of the same events that fire the real-time
+  apprise phone/Slack alert (Path A). See [HONEYPOTS.md](./HONEYPOTS.md).
+
 ## Retention Policy
 
 Security-log indexes use a **365-day retention** period (`frozenTimePeriodInSecs = 31536000`).
@@ -143,10 +162,11 @@ diagnostics and `netflow` flow indexes are each capped at **50GB** (`51200`).
 
 **Capacity planning**:
 
-- Total: 500GB across 6 indexes (4 × 100GB security + netmon_metrics 50GB + netflow 50GB)
+- Total: 550GB across 7 indexes (4 × 100GB security + netmon_metrics 50GB + netflow 50GB + honeypot 50GB)
 - Splunk VM disk: 500GB allocated
-- Caps now equal the 500GB VM disk — grow the VM disk (leaving ~50GB for Splunk internal
-  indexes) before onboarding the broader host/container/firewall log sources
+- Caps now exceed the 500GB VM disk — grow the VM disk (leaving ~50GB for Splunk internal
+  indexes) before onboarding the broader host/container/firewall log sources. Honeypot
+  volume is low in practice (alert-grade events), but the cap bounds a decoy flood.
 
 ## Source Type Mapping
 
@@ -166,6 +186,8 @@ diagnostics and `netflow` flow indexes are each capped at **50GB** (`51200`).
 | netmon:docsis  | netmon_metrics | Cable modem SNMP       |
 | netmon:sat     | netmon_metrics | satellite uplink probe |
 | ipfix          | netflow        | UniFi NetFlow/IPFIX    |
+| honeypot:opencanary | honeypot  | OpenCanary tripwires   |
+| honeypot:tpot  | honeypot       | T-Pot deep sensor      |
 
 ## HEC Token Configuration
 
@@ -202,6 +224,9 @@ splunk_indexes:
   - name: netflow
     maxTotalDataSizeMB: 51200
     frozenTimePeriodInSecs: 7776000
+  - name: honeypot
+    maxTotalDataSizeMB: 51200
+    frozenTimePeriodInSecs: 31536000
 ```
 
 ## Related Documentation

--- a/ingress.tf
+++ b/ingress.tf
@@ -24,14 +24,15 @@ locals {
     # openbao is intentionally NOT here: it is a 3-node Raft HA cluster, fronted
     # as a load-balanced multi-backend pool (openbao_backends below) so the
     # ingress survives a single node loss — not a single-backend route.
-    mailpit       = { backend = "mailpit", port = local.pipeline_constants.notification_ports.mailpit_web }
-    ntfy          = { backend = "ntfy", port = local.pipeline_constants.notification_ports.ntfy_http }
-    homeassistant = { backend = "homeassistant", port = local.pipeline_constants.service_ports.homeassistant_web }
-    openproject   = { backend = "openproject", port = local.pipeline_constants.service_ports.openproject_web }
-    prometheus    = { backend = "prometheus", port = local.pipeline_constants.service_ports.prometheus_web }
-    llm           = { backend = "hermes-chat", port = local.pipeline_constants.service_ports.open_webui_web }
-    ollama        = { backend = "hermes-infer", port = local.pipeline_constants.service_ports.ollama_api }
-    qdrant        = { backend = "qdrant", port = local.pipeline_constants.vector_db_ports.qdrant_http }
+    mailpit           = { backend = "mailpit", port = local.pipeline_constants.notification_ports.mailpit_web }
+    ntfy              = { backend = "ntfy", port = local.pipeline_constants.notification_ports.ntfy_http }
+    "honeypot-notify" = { backend = "honeypot-notify", port = local.pipeline_constants.honeypot_ports.apprise_api }
+    homeassistant     = { backend = "homeassistant", port = local.pipeline_constants.service_ports.homeassistant_web }
+    openproject       = { backend = "openproject", port = local.pipeline_constants.service_ports.openproject_web }
+    prometheus        = { backend = "prometheus", port = local.pipeline_constants.service_ports.prometheus_web }
+    llm               = { backend = "hermes-chat", port = local.pipeline_constants.service_ports.open_webui_web }
+    ollama            = { backend = "hermes-infer", port = local.pipeline_constants.service_ports.ollama_api }
+    qdrant            = { backend = "qdrant", port = local.pipeline_constants.vector_db_ports.qdrant_http }
     # AI orchestration stack UIs (ai VLAN) + Langfuse LLM observability (siem VLAN).
     dify            = { backend = "dify", port = local.pipeline_constants.service_ports.dify_web }
     langflow        = { backend = "langflow", port = local.pipeline_constants.service_ports.langflow_web }

--- a/inventory_publish.tf
+++ b/inventory_publish.tf
@@ -32,12 +32,16 @@ locals {
       }
     }
     # Regular VMs - using SSH connection
-    # DRY: IP derived from vm_id (consistent with containers and cloud-init config)
+    # DRY: static VMs advertise their vm_id-derived IP; DHCP-first VMs advertise
+    # their FQDN (local.vm_address) with a deterministic MAC + reserved IP, exactly
+    # like the containers block above.
     vms = {
       for k, v in module.vms.vm_details : k => {
         vmid               = v.id
         hostname           = v.name
-        ip                 = split("/", local.vm_ipv4[k])[0]
+        ip                 = local.vm_address[k]
+        mac                = try(var.vms[k].dhcp, false) ? local.vm_mac[k] : null
+        reserved_ip        = local.vm_reserved_ip[k]
         node               = v.node_name
         ansible_connection = "ssh"
         tags               = v.tags
@@ -49,7 +53,9 @@ locals {
       for k, v in module.vms.vm_details : k => {
         vmid               = v.id
         hostname           = v.name
-        ip                 = split("/", local.vm_ipv4[k])[0]
+        ip                 = local.vm_address[k]
+        mac                = try(var.vms[k].dhcp, false) ? local.vm_mac[k] : null
+        reserved_ip        = local.vm_reserved_ip[k]
         node               = v.node_name
         ansible_connection = "ssh"
         tags               = v.tags

--- a/locals-honeypot.tf
+++ b/locals-honeypot.tf
@@ -1,0 +1,27 @@
+# Honeypot tag-filter locals — extracted from locals.tf so that file stays under
+# the shared _file-size workflow's 12 KB limit (locals merge across files in a
+# module, so this is a pure relocation with no behavior change). Consumed by the
+# firewall module call in main.tf.
+
+locals {
+  # Honeypot LXCs (honeypot tag): per-VLAN OpenCanary tripwires + the apprise-api
+  # alert gateway. The notify gateway additionally carries the "notify" tag so the
+  # firewall module can split it out (open egress + apprise port) from the
+  # tripwires (decoy ports + internal-only egress). Kept distinct from
+  # notification_container_ids (Mailpit/ntfy) so a guest is never double-claimed
+  # by two firewall_options resources.
+  honeypot_container_ids = {
+    for k, v in var.containers : k => v.vm_id
+    if contains(coalesce(try(v.tags, null), []), "honeypot")
+  }
+  honeypot_notify_container_ids = {
+    for k, v in var.containers : k => v.vm_id
+    if contains(coalesce(try(v.tags, null), []), "honeypot") && contains(coalesce(try(v.tags, null), []), "notify")
+  }
+
+  # T-Pot deep-sensor VM(s): tagged "tpot" (wide-net input, restricted egress).
+  tpot_vm_ids = {
+    for k, v in var.vms : k => v.vm_id
+    if contains(try(v.tags, []), "tpot")
+  }
+}

--- a/locals-vm-network.tf
+++ b/locals-vm-network.tf
@@ -1,0 +1,49 @@
+# Per-VM addressing locals — extracted from locals.tf so that file stays under
+# the shared _file-size workflow's 12 KB limit (locals merge across files in a
+# module, so this is a pure relocation with no behavior change). Mirrors the
+# container_* addressing locals in locals.tf.
+
+locals {
+  # Per-VM IPv4/gateway, same DRY + short-circuit rules as containers, so a VM
+  # can carry a 6-7-digit positional VMID (which overflows the /24 host space)
+  # by going DHCP-first (dhcp = true) or pinning a static ipv4_address. The
+  # cidrhost derive branch is reached ONLY when neither is set (legacy ≤254 ids),
+  # exactly mirroring container_ipv4 — see the extended note in that block.
+  vm_ipv4 = {
+    for k, v in var.vms : k => (
+      try(v.dhcp, false) ? "dhcp" : (
+        try(v.ip_config.ipv4_address, null) != null
+        ? nonsensitive(v.ip_config.ipv4_address)
+        : nonsensitive("${cidrhost(var.network_cidrs[v.vlan], v.vm_id)}/${split("/", var.network_cidrs[v.vlan])[1]}")
+      )
+    )
+  }
+  vm_gateway = {
+    for k, v in var.vms : k => (
+      try(v.dhcp, false) ? null : nonsensitive(cidrhost(var.network_cidrs[v.vlan], 1))
+    )
+  }
+
+  # Deterministic MAC + reserved IP + advertised address for DHCP-first VMs —
+  # identical join-key shape to the container_* locals so tofu-unifi pins the
+  # reservation and technitium_dns points the A record at the same address.
+  vm_mac = {
+    for k, v in var.vms : k => format("02:%s:%s:%s:%s:%s",
+      substr(md5(v.name), 0, 2), substr(md5(v.name), 2, 2),
+      substr(md5(v.name), 4, 2), substr(md5(v.name), 6, 2),
+    substr(md5(v.name), 8, 2))
+  }
+  vm_reserved_ip = {
+    for k, v in var.vms : k => (
+      try(v.dhcp, false) && try(v.reserved_host, null) != null
+      ? nonsensitive(cidrhost(var.network_cidrs[v.vlan], v.reserved_host)) : null
+    )
+  }
+  vm_address = {
+    for k, v in var.vms : k => (
+      try(v.dhcp, false)
+      ? (var.domain != "" ? "${v.name}.${var.domain}" : v.name)
+      : split("/", local.vm_ipv4[k])[0]
+    )
+  }
+}

--- a/locals.tf
+++ b/locals.tf
@@ -88,48 +88,9 @@ locals {
       : split("/", local.container_ipv4[k])[0]
     )
   }
-  # Per-VM IPv4/gateway, same DRY + short-circuit rules as containers above, so a
-  # VM can carry a 6-7-digit positional VMID (which overflows the /24 host space)
-  # by going DHCP-first (dhcp = true) or pinning a static ipv4_address. The
-  # cidrhost derive branch is reached ONLY when neither is set (legacy ≤254 ids),
-  # exactly mirroring container_ipv4 — see the extended note in that block.
-  vm_ipv4 = {
-    for k, v in var.vms : k => (
-      try(v.dhcp, false) ? "dhcp" : (
-        try(v.ip_config.ipv4_address, null) != null
-        ? nonsensitive(v.ip_config.ipv4_address)
-        : nonsensitive("${cidrhost(var.network_cidrs[v.vlan], v.vm_id)}/${split("/", var.network_cidrs[v.vlan])[1]}")
-      )
-    )
-  }
-  vm_gateway = {
-    for k, v in var.vms : k => (
-      try(v.dhcp, false) ? null : nonsensitive(cidrhost(var.network_cidrs[v.vlan], 1))
-    )
-  }
-
-  # Deterministic MAC + reserved IP + advertised address for DHCP-first VMs —
-  # identical join-key shape to the container_* locals so tofu-unifi pins the
-  # reservation and technitium_dns points the A record at the same address.
-  vm_mac = {
-    for k, v in var.vms : k => format("02:%s:%s:%s:%s:%s",
-      substr(md5(v.name), 0, 2), substr(md5(v.name), 2, 2),
-      substr(md5(v.name), 4, 2), substr(md5(v.name), 6, 2),
-    substr(md5(v.name), 8, 2))
-  }
-  vm_reserved_ip = {
-    for k, v in var.vms : k => (
-      try(v.dhcp, false) && try(v.reserved_host, null) != null
-      ? nonsensitive(cidrhost(var.network_cidrs[v.vlan], v.reserved_host)) : null
-    )
-  }
-  vm_address = {
-    for k, v in var.vms : k => (
-      try(v.dhcp, false)
-      ? (var.domain != "" ? "${v.name}.${var.domain}" : v.name)
-      : split("/", local.vm_ipv4[k])[0]
-    )
-  }
+  # VM IPv4/gateway + DHCP-first MAC/reserved-IP/advertised-address locals are
+  # extracted into locals-vm-network.tf (locals merge across files in a module)
+  # to keep this file under the shared _file-size workflow's 12 KB limit.
 
   # VGA type validation helper
   valid_vga_types = ["std", "cirrus", "vmware", "qxl"]
@@ -178,20 +139,9 @@ locals {
     if contains(coalesce(try(v.tags, null), []), "notifications")
   }
 
-  # Honeypot LXCs (honeypot tag): per-VLAN OpenCanary tripwires + the apprise-api
-  # alert gateway. The notify gateway additionally carries the "notify" tag so the
-  # firewall module can split it out (open egress + apprise port) from the
-  # tripwires (decoy ports + internal-only egress). Kept distinct from
-  # notification_container_ids (Mailpit/ntfy) so a guest is never double-claimed
-  # by two firewall_options resources.
-  honeypot_container_ids = {
-    for k, v in var.containers : k => v.vm_id
-    if contains(coalesce(try(v.tags, null), []), "honeypot")
-  }
-  honeypot_notify_container_ids = {
-    for k, v in var.containers : k => v.vm_id
-    if contains(coalesce(try(v.tags, null), []), "honeypot") && contains(coalesce(try(v.tags, null), []), "notify")
-  }
+  # Honeypot tag-filter locals (honeypot_container_ids,
+  # honeypot_notify_container_ids) live in locals-honeypot.tf to keep this file
+  # under the 12 KB size gate; locals merge across files in the module.
 
   # Vector database containers: Qdrant (vectordb tag)
   vectordb_container_ids = {

--- a/locals.tf
+++ b/locals.tf
@@ -88,12 +88,47 @@ locals {
       : split("/", local.container_ipv4[k])[0]
     )
   }
+  # Per-VM IPv4/gateway, same DRY + short-circuit rules as containers above, so a
+  # VM can carry a 6-7-digit positional VMID (which overflows the /24 host space)
+  # by going DHCP-first (dhcp = true) or pinning a static ipv4_address. The
+  # cidrhost derive branch is reached ONLY when neither is set (legacy ≤254 ids),
+  # exactly mirroring container_ipv4 — see the extended note in that block.
   vm_ipv4 = {
-    for k, v in var.vms : k =>
-    nonsensitive("${cidrhost(var.network_cidrs[v.vlan], v.vm_id)}/${split("/", var.network_cidrs[v.vlan])[1]}")
+    for k, v in var.vms : k => (
+      try(v.dhcp, false) ? "dhcp" : (
+        try(v.ip_config.ipv4_address, null) != null
+        ? nonsensitive(v.ip_config.ipv4_address)
+        : nonsensitive("${cidrhost(var.network_cidrs[v.vlan], v.vm_id)}/${split("/", var.network_cidrs[v.vlan])[1]}")
+      )
+    )
   }
   vm_gateway = {
-    for k, v in var.vms : k => nonsensitive(cidrhost(var.network_cidrs[v.vlan], 1))
+    for k, v in var.vms : k => (
+      try(v.dhcp, false) ? null : nonsensitive(cidrhost(var.network_cidrs[v.vlan], 1))
+    )
+  }
+
+  # Deterministic MAC + reserved IP + advertised address for DHCP-first VMs —
+  # identical join-key shape to the container_* locals so tofu-unifi pins the
+  # reservation and technitium_dns points the A record at the same address.
+  vm_mac = {
+    for k, v in var.vms : k => format("02:%s:%s:%s:%s:%s",
+      substr(md5(v.name), 0, 2), substr(md5(v.name), 2, 2),
+      substr(md5(v.name), 4, 2), substr(md5(v.name), 6, 2),
+    substr(md5(v.name), 8, 2))
+  }
+  vm_reserved_ip = {
+    for k, v in var.vms : k => (
+      try(v.dhcp, false) && try(v.reserved_host, null) != null
+      ? nonsensitive(cidrhost(var.network_cidrs[v.vlan], v.reserved_host)) : null
+    )
+  }
+  vm_address = {
+    for k, v in var.vms : k => (
+      try(v.dhcp, false)
+      ? (var.domain != "" ? "${v.name}.${var.domain}" : v.name)
+      : split("/", local.vm_ipv4[k])[0]
+    )
   }
 
   # VGA type validation helper
@@ -141,6 +176,21 @@ locals {
   notification_container_ids = {
     for k, v in var.containers : k => v.vm_id
     if contains(coalesce(try(v.tags, null), []), "notifications")
+  }
+
+  # Honeypot LXCs (honeypot tag): per-VLAN OpenCanary tripwires + the apprise-api
+  # alert gateway. The notify gateway additionally carries the "notify" tag so the
+  # firewall module can split it out (open egress + apprise port) from the
+  # tripwires (decoy ports + internal-only egress). Kept distinct from
+  # notification_container_ids (Mailpit/ntfy) so a guest is never double-claimed
+  # by two firewall_options resources.
+  honeypot_container_ids = {
+    for k, v in var.containers : k => v.vm_id
+    if contains(coalesce(try(v.tags, null), []), "honeypot")
+  }
+  honeypot_notify_container_ids = {
+    for k, v in var.containers : k => v.vm_id
+    if contains(coalesce(try(v.tags, null), []), "honeypot") && contains(coalesce(try(v.tags, null), []), "notify")
   }
 
   # Vector database containers: Qdrant (vectordb tag)

--- a/main.tf
+++ b/main.tf
@@ -73,8 +73,14 @@ module "vms" {
         ipv4_gateway = local.vm_gateway[k]
       }
       # Tag every NIC onto the VM's service VLAN (802.1Q id from var.vlan_ids).
+      # DHCP-first VMs also get a deterministic MAC (local.vm_mac) so tofu-unifi
+      # can pin a stable reservation; static VMs keep a null MAC (provider
+      # auto-generates) so they are not replaced — same pattern as containers.
       network_interfaces = [
-        for ni in v.network_interfaces : merge(ni, { vlan_id = lookup(var.vlan_ids, v.vlan, null) })
+        for ni in v.network_interfaces : merge(ni, {
+          vlan_id     = lookup(var.vlan_ids, v.vlan, null)
+          mac_address = try(v.dhcp, false) ? local.vm_mac[k] : null
+        })
       ]
       user_account = {
         username = v.user_account.username
@@ -242,6 +248,17 @@ module "firewall" {
 
   # Langfuse LLM-observability LXC: tagged "langfuse"
   langfuse_container_ids = local.langfuse_container_ids
+
+  # Honeypot LXCs: per-VLAN OpenCanary tripwires + apprise notify gateway (honeypot tag)
+  honeypot_container_ids        = local.honeypot_container_ids
+  honeypot_notify_container_ids = local.honeypot_notify_container_ids
+
+  # T-Pot deep-sensor VM(s): tagged "tpot"
+  tpot_vm_ids = {
+    for k, v in var.vms : k => v.vm_id
+    if contains(try(v.tags, []), "tpot")
+  }
+
 
   # Pipeline constants: single source of truth for service ports (DRY)
   pipeline_constants = local.pipeline_constants

--- a/main.tf
+++ b/main.tf
@@ -72,10 +72,8 @@ module "vms" {
         ipv4_address = local.vm_ipv4[k]
         ipv4_gateway = local.vm_gateway[k]
       }
-      # Tag every NIC onto the VM's service VLAN (802.1Q id from var.vlan_ids).
-      # DHCP-first VMs also get a deterministic MAC (local.vm_mac) so tofu-unifi
-      # can pin a stable reservation; static VMs keep a null MAC (provider
-      # auto-generates) so they are not replaced — same pattern as containers.
+      # NIC onto the VM's service VLAN; DHCP-first VMs get a deterministic MAC
+      # (local.vm_mac) for a stable reservation, same pattern as containers.
       network_interfaces = [
         for ni in v.network_interfaces : merge(ni, {
           vlan_id     = lookup(var.vlan_ids, v.vlan, null)
@@ -249,15 +247,10 @@ module "firewall" {
   # Langfuse LLM-observability LXC: tagged "langfuse"
   langfuse_container_ids = local.langfuse_container_ids
 
-  # Honeypot LXCs: per-VLAN OpenCanary tripwires + apprise notify gateway (honeypot tag)
+  # Honeypots (honeypot/notify/tpot tags); filters in locals-honeypot.tf.
   honeypot_container_ids        = local.honeypot_container_ids
   honeypot_notify_container_ids = local.honeypot_notify_container_ids
-
-  # T-Pot deep-sensor VM(s): tagged "tpot"
-  tpot_vm_ids = {
-    for k, v in var.vms : k => v.vm_id
-    if contains(try(v.tags, []), "tpot")
-  }
+  tpot_vm_ids                   = local.tpot_vm_ids
 
 
   # Pipeline constants: single source of truth for service ports (DRY)

--- a/modules/firewall/honeypot_rules.tf
+++ b/modules/firewall/honeypot_rules.tf
@@ -1,0 +1,79 @@
+# =============================================================================
+# Honeypot container firewall (per-VLAN OpenCanary tripwires + apprise gateway)
+# =============================================================================
+#
+# Two roles share the `honeypot` tag and this resource set:
+#
+#   * tripwires (honeypot, NOT notify) — emulate decoy services on every VLAN.
+#     input DROP + honeypot_services (ACCEPT+log the decoy ports) so any touch
+#     alerts; egress restricted to internal (outbound_internal) so a poked
+#     sensor can reach the notify gateway (Path A) and HAProxy syslog 519
+#     (Path B) but can NEVER beacon to the internet.
+#
+#   * notify gateway (honeypot + notify) — the apprise-api alert sink. input
+#     DROP + honeypot_notify_services (just :8000); output ACCEPT so it can
+#     fan out to Slack / Pushover / ntfy.sh (same open-egress posture as the
+#     Mailpit/ntfy notification containers).
+#
+# A guest is the notify gateway iff its key is in honeypot_notify_container_ids
+# (a subset of honeypot_container_ids). Membership drives both the per-guest
+# output_policy and which rule set applies — mirroring how pipeline_container
+# grants Cribl-Edge-only HTTPS egress within one shared resource.
+
+resource "proxmox_virtual_environment_firewall_options" "honeypot_container" {
+  for_each = var.honeypot_container_ids
+
+  node_name    = var.node_name
+  container_id = each.value
+  enabled      = local.firewall_defaults.enabled
+  input_policy = local.firewall_defaults.input_policy
+  # Notify gateway needs the internet (external notifiers); tripwires must not
+  # have it (a compromised decoy must not exfiltrate).
+  output_policy = contains(keys(var.honeypot_notify_container_ids), each.key) ? "ACCEPT" : local.firewall_defaults.output_policy
+  # Decoy interactions are the signal — log inbound at info, not warning.
+  log_level_in  = "info"
+  log_level_out = local.firewall_defaults.log_level_out
+
+  depends_on = [proxmox_virtual_environment_cluster_firewall.main]
+}
+
+resource "proxmox_virtual_environment_firewall_rules" "honeypot_container" {
+  for_each = var.honeypot_container_ids
+
+  node_name    = var.node_name
+  container_id = each.value
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.internal_access.name
+    comment        = "Internal access (SSH, ICMP)"
+  }
+
+  # Notify gateway: apprise-api inbound only.
+  dynamic "rule" {
+    for_each = contains(keys(var.honeypot_notify_container_ids), each.key) ? [1] : []
+    content {
+      security_group = proxmox_virtual_environment_cluster_firewall_security_group.honeypot_notify_services.name
+      comment        = "Honeypot alert gateway (apprise-api)"
+    }
+  }
+
+  # Tripwires: decoy service surface + internal-only egress (reach notify
+  # gateway + HAProxy syslog 519; no internet).
+  dynamic "rule" {
+    for_each = contains(keys(var.honeypot_notify_container_ids), each.key) ? [] : [1]
+    content {
+      security_group = proxmox_virtual_environment_cluster_firewall_security_group.honeypot_services.name
+      comment        = "Honeypot decoy services (FTP/HTTP/SMB/DB/RDP/SNMP/...)"
+    }
+  }
+
+  dynamic "rule" {
+    for_each = contains(keys(var.honeypot_notify_container_ids), each.key) ? [] : [1]
+    content {
+      security_group = proxmox_virtual_environment_cluster_firewall_security_group.outbound_internal.name
+      comment        = "Outbound to internal only (notify gateway + syslog 519)"
+    }
+  }
+
+  depends_on = [proxmox_virtual_environment_firewall_options.honeypot_container]
+}

--- a/modules/firewall/honeypot_rules.tf
+++ b/modules/firewall/honeypot_rules.tf
@@ -20,6 +20,77 @@
 # output_policy and which rule set applies — mirroring how pipeline_container
 # grants Cribl-Edge-only HTTPS egress within one shared resource.
 
+locals {
+  # Honeypot decoy surface: the low-interaction services each per-VLAN OpenCanary
+  # tripwire emulates. ACCEPT+log from internal so any touch on a fake service
+  # trips an alert (the whole point — these are NOT real services). SSH (22) is
+  # already opened by internal_access. Ports are DRY from honeypot_ports. (Defined
+  # here rather than locals.tf to keep that file under the 12 KB size gate.)
+  honeypot_services_rules = [
+    { proto = "tcp", dport = tostring(local.honeypot_ports.ftp), source = local.internal_src, comment = "Honeypot FTP decoy from internal" },
+    { proto = "tcp", dport = tostring(local.honeypot_ports.telnet), source = local.internal_src, comment = "Honeypot Telnet decoy from internal" },
+    { proto = "tcp", dport = tostring(local.honeypot_ports.http), source = local.internal_src, comment = "Honeypot HTTP decoy from internal" },
+    { proto = "tcp", dport = tostring(local.honeypot_ports.https), source = local.internal_src, comment = "Honeypot HTTPS decoy from internal" },
+    { proto = "tcp", dport = tostring(local.honeypot_ports.smb), source = local.internal_src, comment = "Honeypot SMB decoy from internal" },
+    { proto = "tcp", dport = tostring(local.honeypot_ports.mssql), source = local.internal_src, comment = "Honeypot MSSQL decoy from internal" },
+    { proto = "tcp", dport = tostring(local.honeypot_ports.mysql), source = local.internal_src, comment = "Honeypot MySQL decoy from internal" },
+    { proto = "tcp", dport = tostring(local.honeypot_ports.postgres), source = local.internal_src, comment = "Honeypot PostgreSQL decoy from internal" },
+    { proto = "tcp", dport = tostring(local.honeypot_ports.rdp), source = local.internal_src, comment = "Honeypot RDP decoy from internal" },
+    { proto = "tcp", dport = tostring(local.honeypot_ports.vnc), source = local.internal_src, comment = "Honeypot VNC decoy from internal" },
+    { proto = "tcp", dport = tostring(local.honeypot_ports.redis), source = local.internal_src, comment = "Honeypot Redis decoy from internal" },
+    { proto = "tcp", dport = tostring(local.honeypot_ports.git), source = local.internal_src, comment = "Honeypot git decoy from internal" },
+    { proto = "tcp", dport = tostring(local.honeypot_ports.http_proxy), source = local.internal_src, comment = "Honeypot HTTP-proxy decoy from internal" },
+    { proto = "udp", dport = tostring(local.honeypot_ports.snmp), source = local.internal_src, comment = "Honeypot SNMP decoy from internal" },
+    { proto = "udp", dport = tostring(local.honeypot_ports.sip), source = local.internal_src, comment = "Honeypot SIP decoy from internal" },
+    { proto = "udp", dport = tostring(local.honeypot_ports.tftp), source = local.internal_src, comment = "Honeypot TFTP decoy from internal" },
+    { proto = "udp", dport = tostring(local.honeypot_ports.ntp), source = local.internal_src, comment = "Honeypot NTP decoy from internal" },
+  ]
+
+  # The honeypot-notify gateway (apprise-api) inbound surface: just its REST port.
+  # Open egress is set on its firewall_options (output_policy ACCEPT) so it can
+  # reach external notifiers (Slack/Pushover/ntfy.sh) — same posture as the
+  # Mailpit/ntfy notification containers.
+  honeypot_notify_services_rules = [
+    { proto = "tcp", dport = tostring(local.honeypot_ports.apprise_api), source = local.internal_src, comment = "apprise-api alert gateway from internal" },
+  ]
+}
+
+# Cluster security groups (defined here rather than security_groups.tf to keep
+# that file under the 12 KB size gate).
+resource "proxmox_virtual_environment_cluster_firewall_security_group" "honeypot_services" {
+  name    = "honeypot-svc"
+  comment = "Honeypot decoy services (FTP/Telnet/HTTP/SMB/DB/RDP/VNC/SNMP/SIP/TFTP/NTP/...) — ACCEPT+log from internal so any interaction with a per-VLAN OpenCanary tripwire fires an alert"
+
+  dynamic "rule" {
+    for_each = local.honeypot_services_rules
+    content {
+      type    = "in"
+      action  = "ACCEPT"
+      proto   = rule.value.proto
+      dport   = rule.value.dport
+      source  = rule.value.source
+      comment = rule.value.comment
+    }
+  }
+}
+
+resource "proxmox_virtual_environment_cluster_firewall_security_group" "honeypot_notify_services" {
+  name    = "honeypot-notify-svc"
+  comment = "Honeypot alert gateway: apprise-api REST port (${local.honeypot_ports.apprise_api}) from internal networks"
+
+  dynamic "rule" {
+    for_each = local.honeypot_notify_services_rules
+    content {
+      type    = "in"
+      action  = "ACCEPT"
+      proto   = rule.value.proto
+      dport   = rule.value.dport
+      source  = rule.value.source
+      comment = rule.value.comment
+    }
+  }
+}
+
 resource "proxmox_virtual_environment_firewall_options" "honeypot_container" {
   for_each = var.honeypot_container_ids
 

--- a/modules/firewall/locals.tf
+++ b/modules/firewall/locals.tf
@@ -31,6 +31,7 @@ locals {
   notification_ports = var.pipeline_constants.notification_ports
   vector_db_ports    = var.pipeline_constants.vector_db_ports
   netflow_ports      = var.pipeline_constants.netflow_ports
+  honeypot_ports     = var.pipeline_constants.honeypot_ports
 
   # Syslog ports — derived from syslog_port_map so that adding a new source
   # family auto-expands the firewall surface. standard = app-facing HAProxy
@@ -88,6 +89,38 @@ locals {
   vectordb_services_rules = [
     { proto = "tcp", dport = tostring(local.vector_db_ports.qdrant_http), source = local.internal_src, comment = "Qdrant HTTP API from internal" },
     { proto = "tcp", dport = tostring(local.vector_db_ports.qdrant_grpc), source = local.internal_src, comment = "Qdrant gRPC from internal" },
+  ]
+
+  # Honeypot decoy surface: the low-interaction services each per-VLAN OpenCanary
+  # tripwire emulates. ACCEPT+log from internal so any touch on a fake service
+  # trips an alert (the whole point — these are NOT real services). SSH (22) is
+  # already opened by internal_access. Ports are DRY from honeypot_ports.
+  honeypot_services_rules = [
+    { proto = "tcp", dport = tostring(local.honeypot_ports.ftp), source = local.internal_src, comment = "Honeypot FTP decoy from internal" },
+    { proto = "tcp", dport = tostring(local.honeypot_ports.telnet), source = local.internal_src, comment = "Honeypot Telnet decoy from internal" },
+    { proto = "tcp", dport = tostring(local.honeypot_ports.http), source = local.internal_src, comment = "Honeypot HTTP decoy from internal" },
+    { proto = "tcp", dport = tostring(local.honeypot_ports.https), source = local.internal_src, comment = "Honeypot HTTPS decoy from internal" },
+    { proto = "tcp", dport = tostring(local.honeypot_ports.smb), source = local.internal_src, comment = "Honeypot SMB decoy from internal" },
+    { proto = "tcp", dport = tostring(local.honeypot_ports.mssql), source = local.internal_src, comment = "Honeypot MSSQL decoy from internal" },
+    { proto = "tcp", dport = tostring(local.honeypot_ports.mysql), source = local.internal_src, comment = "Honeypot MySQL decoy from internal" },
+    { proto = "tcp", dport = tostring(local.honeypot_ports.postgres), source = local.internal_src, comment = "Honeypot PostgreSQL decoy from internal" },
+    { proto = "tcp", dport = tostring(local.honeypot_ports.rdp), source = local.internal_src, comment = "Honeypot RDP decoy from internal" },
+    { proto = "tcp", dport = tostring(local.honeypot_ports.vnc), source = local.internal_src, comment = "Honeypot VNC decoy from internal" },
+    { proto = "tcp", dport = tostring(local.honeypot_ports.redis), source = local.internal_src, comment = "Honeypot Redis decoy from internal" },
+    { proto = "tcp", dport = tostring(local.honeypot_ports.git), source = local.internal_src, comment = "Honeypot git decoy from internal" },
+    { proto = "tcp", dport = tostring(local.honeypot_ports.http_proxy), source = local.internal_src, comment = "Honeypot HTTP-proxy decoy from internal" },
+    { proto = "udp", dport = tostring(local.honeypot_ports.snmp), source = local.internal_src, comment = "Honeypot SNMP decoy from internal" },
+    { proto = "udp", dport = tostring(local.honeypot_ports.sip), source = local.internal_src, comment = "Honeypot SIP decoy from internal" },
+    { proto = "udp", dport = tostring(local.honeypot_ports.tftp), source = local.internal_src, comment = "Honeypot TFTP decoy from internal" },
+    { proto = "udp", dport = tostring(local.honeypot_ports.ntp), source = local.internal_src, comment = "Honeypot NTP decoy from internal" },
+  ]
+
+  # The honeypot-notify gateway (apprise-api) inbound surface: just its REST port.
+  # Open egress is set on its firewall_options (output_policy ACCEPT) so it can
+  # reach external notifiers (Slack/Pushover/ntfy.sh) — same posture as the
+  # Mailpit/ntfy notification containers.
+  honeypot_notify_services_rules = [
+    { proto = "tcp", dport = tostring(local.honeypot_ports.apprise_api), source = local.internal_src, comment = "apprise-api alert gateway from internal" },
   ]
 
   apt_cacher_ng_services_rules = [

--- a/modules/firewall/locals.tf
+++ b/modules/firewall/locals.tf
@@ -91,37 +91,10 @@ locals {
     { proto = "tcp", dport = tostring(local.vector_db_ports.qdrant_grpc), source = local.internal_src, comment = "Qdrant gRPC from internal" },
   ]
 
-  # Honeypot decoy surface: the low-interaction services each per-VLAN OpenCanary
-  # tripwire emulates. ACCEPT+log from internal so any touch on a fake service
-  # trips an alert (the whole point — these are NOT real services). SSH (22) is
-  # already opened by internal_access. Ports are DRY from honeypot_ports.
-  honeypot_services_rules = [
-    { proto = "tcp", dport = tostring(local.honeypot_ports.ftp), source = local.internal_src, comment = "Honeypot FTP decoy from internal" },
-    { proto = "tcp", dport = tostring(local.honeypot_ports.telnet), source = local.internal_src, comment = "Honeypot Telnet decoy from internal" },
-    { proto = "tcp", dport = tostring(local.honeypot_ports.http), source = local.internal_src, comment = "Honeypot HTTP decoy from internal" },
-    { proto = "tcp", dport = tostring(local.honeypot_ports.https), source = local.internal_src, comment = "Honeypot HTTPS decoy from internal" },
-    { proto = "tcp", dport = tostring(local.honeypot_ports.smb), source = local.internal_src, comment = "Honeypot SMB decoy from internal" },
-    { proto = "tcp", dport = tostring(local.honeypot_ports.mssql), source = local.internal_src, comment = "Honeypot MSSQL decoy from internal" },
-    { proto = "tcp", dport = tostring(local.honeypot_ports.mysql), source = local.internal_src, comment = "Honeypot MySQL decoy from internal" },
-    { proto = "tcp", dport = tostring(local.honeypot_ports.postgres), source = local.internal_src, comment = "Honeypot PostgreSQL decoy from internal" },
-    { proto = "tcp", dport = tostring(local.honeypot_ports.rdp), source = local.internal_src, comment = "Honeypot RDP decoy from internal" },
-    { proto = "tcp", dport = tostring(local.honeypot_ports.vnc), source = local.internal_src, comment = "Honeypot VNC decoy from internal" },
-    { proto = "tcp", dport = tostring(local.honeypot_ports.redis), source = local.internal_src, comment = "Honeypot Redis decoy from internal" },
-    { proto = "tcp", dport = tostring(local.honeypot_ports.git), source = local.internal_src, comment = "Honeypot git decoy from internal" },
-    { proto = "tcp", dport = tostring(local.honeypot_ports.http_proxy), source = local.internal_src, comment = "Honeypot HTTP-proxy decoy from internal" },
-    { proto = "udp", dport = tostring(local.honeypot_ports.snmp), source = local.internal_src, comment = "Honeypot SNMP decoy from internal" },
-    { proto = "udp", dport = tostring(local.honeypot_ports.sip), source = local.internal_src, comment = "Honeypot SIP decoy from internal" },
-    { proto = "udp", dport = tostring(local.honeypot_ports.tftp), source = local.internal_src, comment = "Honeypot TFTP decoy from internal" },
-    { proto = "udp", dport = tostring(local.honeypot_ports.ntp), source = local.internal_src, comment = "Honeypot NTP decoy from internal" },
-  ]
-
-  # The honeypot-notify gateway (apprise-api) inbound surface: just its REST port.
-  # Open egress is set on its firewall_options (output_policy ACCEPT) so it can
-  # reach external notifiers (Slack/Pushover/ntfy.sh) — same posture as the
-  # Mailpit/ntfy notification containers.
-  honeypot_notify_services_rules = [
-    { proto = "tcp", dport = tostring(local.honeypot_ports.apprise_api), source = local.internal_src, comment = "apprise-api alert gateway from internal" },
-  ]
+  # honeypot_services_rules + honeypot_notify_services_rules are defined in
+  # honeypot_rules.tf (alongside the honeypot resources) to keep this file under
+  # the shared _file-size workflow's 12 KB limit. locals merge across files in a
+  # module, so the rule lists referenced by the security groups resolve the same.
 
   apt_cacher_ng_services_rules = [
     { proto = "tcp", dport = tostring(local.svc_ports.apt_cacher_ng), source = local.internal_src, comment = "apt-cacher-ng from internal" },

--- a/modules/firewall/security_groups.tf
+++ b/modules/firewall/security_groups.tf
@@ -352,6 +352,40 @@ resource "proxmox_virtual_environment_cluster_firewall_security_group" "idrac_kv
   }
 }
 
+resource "proxmox_virtual_environment_cluster_firewall_security_group" "honeypot_services" {
+  name    = "honeypot-svc"
+  comment = "Honeypot decoy services (FTP/Telnet/HTTP/SMB/DB/RDP/VNC/SNMP/SIP/TFTP/NTP/...) — ACCEPT+log from internal so any interaction with a per-VLAN OpenCanary tripwire fires an alert"
+
+  dynamic "rule" {
+    for_each = local.honeypot_services_rules
+    content {
+      type    = "in"
+      action  = "ACCEPT"
+      proto   = rule.value.proto
+      dport   = rule.value.dport
+      source  = rule.value.source
+      comment = rule.value.comment
+    }
+  }
+}
+
+resource "proxmox_virtual_environment_cluster_firewall_security_group" "honeypot_notify_services" {
+  name    = "honeypot-notify-svc"
+  comment = "Honeypot alert gateway: apprise-api REST port (${local.honeypot_ports.apprise_api}) from internal networks"
+
+  dynamic "rule" {
+    for_each = local.honeypot_notify_services_rules
+    content {
+      type    = "in"
+      action  = "ACCEPT"
+      proto   = rule.value.proto
+      dport   = rule.value.dport
+      source  = rule.value.source
+      comment = rule.value.comment
+    }
+  }
+}
+
 resource "proxmox_virtual_environment_cluster_firewall_security_group" "monitoring_services" {
   name    = "monitoring-svc"
   comment = "Network-quality monitoring: SmokePing UI + Prometheus exporters (speedtest, smokeping_prober, blackbox, atlas) + irtt UDP, from internal networks"

--- a/modules/firewall/security_groups.tf
+++ b/modules/firewall/security_groups.tf
@@ -352,39 +352,7 @@ resource "proxmox_virtual_environment_cluster_firewall_security_group" "idrac_kv
   }
 }
 
-resource "proxmox_virtual_environment_cluster_firewall_security_group" "honeypot_services" {
-  name    = "honeypot-svc"
-  comment = "Honeypot decoy services (FTP/Telnet/HTTP/SMB/DB/RDP/VNC/SNMP/SIP/TFTP/NTP/...) — ACCEPT+log from internal so any interaction with a per-VLAN OpenCanary tripwire fires an alert"
-
-  dynamic "rule" {
-    for_each = local.honeypot_services_rules
-    content {
-      type    = "in"
-      action  = "ACCEPT"
-      proto   = rule.value.proto
-      dport   = rule.value.dport
-      source  = rule.value.source
-      comment = rule.value.comment
-    }
-  }
-}
-
-resource "proxmox_virtual_environment_cluster_firewall_security_group" "honeypot_notify_services" {
-  name    = "honeypot-notify-svc"
-  comment = "Honeypot alert gateway: apprise-api REST port (${local.honeypot_ports.apprise_api}) from internal networks"
-
-  dynamic "rule" {
-    for_each = local.honeypot_notify_services_rules
-    content {
-      type    = "in"
-      action  = "ACCEPT"
-      proto   = rule.value.proto
-      dport   = rule.value.dport
-      source  = rule.value.source
-      comment = rule.value.comment
-    }
-  }
-}
+# honeypot_services + honeypot_notify_services groups are in honeypot_rules.tf (size gate).
 
 resource "proxmox_virtual_environment_cluster_firewall_security_group" "monitoring_services" {
   name    = "monitoring-svc"

--- a/modules/firewall/tests/rule_generation.tftest.hcl
+++ b/modules/firewall/tests/rule_generation.tftest.hcl
@@ -20,17 +20,23 @@ variables {
       splunk_forwarding = 9997
       cribl_edge_api    = 9420
       cribl_stream_api  = 9000
-      apt_cacher_ng     = 3142
-      minio_api         = 9000
-      minio_console     = 9001
-      infisical_api     = 8080
-      openbao_api       = 8200
-      openbao_cluster   = 8201
-      postgres_default  = 5432
-      redis_default     = 6379
-      ntp               = 123
-      idrac_kvm_r410    = 5800
-      idrac_kvm_r710    = 5801
+      # Cribl S2S + Prometheus remote_write (referenced by pipeline/cribl_stream rules)
+      cribl_s2s           = 10300
+      cribl_prometheus_rw = 9201
+      apt_cacher_ng       = 3142
+      minio_api           = 9000
+      minio_console       = 9001
+      # Object storage (RustFS) — referenced by object_storage_services_rules
+      object_storage_s3      = 9000
+      object_storage_console = 9001
+      infisical_api          = 8080
+      openbao_api            = 8200
+      openbao_cluster        = 8201
+      postgres_default       = 5432
+      redis_default          = 6379
+      ntp                    = 123
+      idrac_kvm_r410         = 5800
+      idrac_kvm_r710         = 5801
       # monitoring ports (own alignment group — longest key in the map)
       smokeping_web      = 80
       speedtest_exporter = 9798
@@ -65,6 +71,26 @@ variables {
     vector_db_ports = {
       qdrant_http = 6333
       qdrant_grpc = 6334
+    }
+    honeypot_ports = {
+      apprise_api = 8000
+      ftp         = 21
+      telnet      = 23
+      http        = 80
+      https       = 443
+      smb         = 445
+      tftp        = 69
+      snmp        = 161
+      ntp         = 123
+      sip         = 5060
+      mssql       = 1433
+      mysql       = 3306
+      postgres    = 5432
+      rdp         = 3389
+      vnc         = 5900
+      redis       = 6379
+      git         = 9418
+      http_proxy  = 8080
     }
   }
 }
@@ -120,10 +146,10 @@ run "pipeline_services_rules_always_three" {
     internal_networks = ["192.168.10.0/24", "192.168.20.0/24", "192.168.30.0/24"]
   }
 
-  # HAProxy stats (8404) + Cribl Edge API (9420) + Cribl Edge HEC input (8088)
+  # HAProxy stats (8404) + Cribl Edge API (9420) + Cribl Edge HEC input (8088) + Cribl S2S frontend (10300)
   assert {
-    condition     = length(local.pipeline_services_rules) == 3
-    error_message = "pipeline_services_rules must be exactly 3, got ${length(local.pipeline_services_rules)}"
+    condition     = length(local.pipeline_services_rules) == 4
+    error_message = "pipeline_services_rules must be exactly 4, got ${length(local.pipeline_services_rules)}"
   }
 }
 
@@ -161,9 +187,10 @@ run "cribl_stream_rules_always_one" {
     internal_networks = ["192.168.10.0/24", "192.168.20.0/24", "192.168.30.0/24"]
   }
 
+  # Cribl Stream API (9000) + Cribl S2S input (10300) + Prometheus remote_write (9201)
   assert {
-    condition     = length(local.cribl_stream_services_rules) == 1
-    error_message = "cribl_stream_services_rules must be exactly 1 (TCP 9000), got ${length(local.cribl_stream_services_rules)}"
+    condition     = length(local.cribl_stream_services_rules) == 3
+    error_message = "cribl_stream_services_rules must be exactly 3, got ${length(local.cribl_stream_services_rules)}"
   }
 }
 
@@ -424,6 +451,51 @@ run "syslog_standard_range_tracks_port_map" {
   assert {
     condition     = !contains(local.syslog_standard_ports, 1514)
     error_message = "syslog_standard_ports must not contain backend ports, got '${jsonencode(local.syslog_standard_ports)}'"
+  }
+}
+
+run "honeypot_notify_rule_tracks_constant" {
+  command = plan
+
+  variables {
+    internal_networks = ["192.168.0.0/16"]
+  }
+
+  # The alert gateway exposes exactly its apprise-api REST port.
+  assert {
+    condition     = length(local.honeypot_notify_services_rules) == 1
+    error_message = "honeypot_notify_services_rules must be exactly 1 (apprise_api), got ${length(local.honeypot_notify_services_rules)}"
+  }
+
+  assert {
+    condition     = local.honeypot_notify_services_rules[0].dport == tostring(var.pipeline_constants.honeypot_ports.apprise_api)
+    error_message = "honeypot_notify rule must track honeypot_ports.apprise_api, got '${local.honeypot_notify_services_rules[0].dport}'"
+  }
+}
+
+run "honeypot_decoy_rules_track_constants_and_split_proto" {
+  command = plan
+
+  variables {
+    internal_networks = ["192.168.10.0/24", "192.168.20.0/24"]
+  }
+
+  # First decoy rule is FTP (TCP), sourced from the comma-joined internal nets.
+  assert {
+    condition     = local.honeypot_services_rules[0].dport == tostring(var.pipeline_constants.honeypot_ports.ftp) && local.honeypot_services_rules[0].proto == "tcp"
+    error_message = "honeypot decoy rule 0 must be TCP ftp, got proto='${local.honeypot_services_rules[0].proto}' dport='${local.honeypot_services_rules[0].dport}'"
+  }
+
+  assert {
+    condition     = local.honeypot_services_rules[0].source == "192.168.10.0/24,192.168.20.0/24"
+    error_message = "honeypot decoy rule source must be comma-joined networks, got '${local.honeypot_services_rules[0].source}'"
+  }
+
+  # The UDP decoys (SNMP/SIP/TFTP/NTP) must be present so OpenCanary's UDP
+  # modules are reachable — assert at least one udp rule exists.
+  assert {
+    condition     = length([for r in local.honeypot_services_rules : r if r.proto == "udp"]) == 4
+    error_message = "honeypot_services_rules must include exactly 4 UDP decoys (snmp/sip/tftp/ntp), got ${length([for r in local.honeypot_services_rules : r if r.proto == "udp"])}"
   }
 }
 

--- a/modules/firewall/variables.tf
+++ b/modules/firewall/variables.tf
@@ -111,6 +111,23 @@ variable "langfuse_container_ids" {
   default     = {}
 }
 
+variable "honeypot_container_ids" {
+  description = "Map of honeypot LXC names to IDs (honeypot tag): per-VLAN OpenCanary tripwires + the apprise-api notify gateway. Tag-driven, set by root locals."
+  type        = map(number)
+  default     = {}
+}
+
+variable "honeypot_notify_container_ids" {
+  description = "Subset of honeypot_container_ids that is the alert gateway (honeypot + notify tags). These get the apprise-api inbound port and open egress (to reach Slack/Pushover/ntfy.sh) instead of the decoy service ports."
+  type        = map(number)
+  default     = {}
+}
+
+variable "tpot_vm_ids" {
+  description = "Map of T-Pot deep-sensor VM names to IDs (tpot tag). T-Pot is a deliberate wide-net sensor that manages its own container firewall, so its Proxmox input policy is permissive-but-logged; egress is restricted."
+  type        = map(number)
+  default     = {}
+}
 variable "management_network" {
   description = "CIDR of management network for SSH/Web access. Configure in terraform.tfvars for your environment."
   type        = string
@@ -142,6 +159,7 @@ variable "pipeline_constants" {
     netflow_ports      = map(number)
     notification_ports = map(number)
     vector_db_ports    = map(number)
+    honeypot_ports     = map(number)
   })
 }
 

--- a/modules/firewall/vm_rules.tf
+++ b/modules/firewall/vm_rules.tf
@@ -49,3 +49,43 @@ resource "proxmox_virtual_environment_firewall_rules" "splunk_vm" {
 
   depends_on = [proxmox_virtual_environment_firewall_options.splunk_vm]
 }
+
+# T-Pot deep-sensor VM. T-Pot deliberately exposes 20+ honeypot ports and runs
+# its own dockerized firewall; enumerating that surface in Proxmox would be
+# brittle and self-defeating, so input is permissive-but-logged. Egress is the
+# real control: DROP by default with outbound limited to internal (reach the
+# apprise gateway + HAProxy syslog 519) plus HTTPS (image/update + threat-intel
+# pulls) — captured malware cannot beacon to arbitrary destinations.
+
+resource "proxmox_virtual_environment_firewall_options" "tpot_vm" {
+  for_each = var.tpot_vm_ids
+
+  node_name     = var.node_name
+  vm_id         = each.value
+  enabled       = local.firewall_defaults.enabled
+  input_policy  = "ACCEPT" # wide-net sensor; T-Pot manages its own per-service firewall
+  output_policy = local.firewall_defaults.output_policy
+  log_level_in  = "info"
+  log_level_out = local.firewall_defaults.log_level_out
+
+  depends_on = [proxmox_virtual_environment_cluster_firewall.main]
+}
+
+resource "proxmox_virtual_environment_firewall_rules" "tpot_vm" {
+  for_each = var.tpot_vm_ids
+
+  node_name = var.node_name
+  vm_id     = each.value
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.outbound_internal.name
+    comment        = "Outbound to internal only (apprise gateway + syslog 519)"
+  }
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.outbound_https.name
+    comment        = "Outbound HTTPS (T-Pot image/update + threat-intel pulls)"
+  }
+
+  depends_on = [proxmox_virtual_environment_firewall_options.tpot_vm]
+}

--- a/tests/firewall_filtering.tftest.hcl
+++ b/tests/firewall_filtering.tftest.hcl
@@ -494,3 +494,68 @@ run "non_idrac_container_not_in_idrac_kvm_container_ids" {
     error_message = "idrac_kvm_container_ids should be empty when no containers have the 'idrac' tag"
   }
 }
+
+# --- honeypot_container_ids / honeypot_notify_container_ids tests ---
+
+run "honeypot_tagged_containers_split_tripwire_vs_notify" {
+  command = plan
+
+  variables {
+    containers = {
+      "honeypot-tw-apps" = {
+        vm_id         = 695000
+        hostname      = "honeypot-tw-apps"
+        vlan          = "apps"
+        dhcp          = true
+        reserved_host = 66
+        tags          = ["terraform", "container", "honeypot", "docker"]
+      }
+      "honeypot-notify" = {
+        vm_id         = 492000
+        hostname      = "honeypot-notify"
+        vlan          = "mgmt"
+        dhcp          = true
+        reserved_host = 36
+        tags          = ["terraform", "container", "honeypot", "notify", "docker"]
+      }
+    }
+  }
+
+  # Both honeypot guests are in the base map.
+  assert {
+    condition     = contains(keys(local.honeypot_container_ids), "honeypot-tw-apps") && contains(keys(local.honeypot_container_ids), "honeypot-notify")
+    error_message = "both honeypot-tagged guests must be in honeypot_container_ids"
+  }
+
+  # Only the notify gateway is in the notify subset.
+  assert {
+    condition     = contains(keys(local.honeypot_notify_container_ids), "honeypot-notify") && !contains(keys(local.honeypot_notify_container_ids), "honeypot-tw-apps")
+    error_message = "only the honeypot+notify guest belongs to honeypot_notify_container_ids"
+  }
+
+  # A honeypot guest must never be double-claimed by the Mailpit/ntfy notification map.
+  assert {
+    condition     = !contains(keys(local.notification_container_ids), "honeypot-notify")
+    error_message = "honeypot notify gateway must not also land in notification_container_ids (would create duplicate firewall_options)"
+  }
+}
+
+run "non_honeypot_container_not_in_honeypot_ids" {
+  command = plan
+
+  variables {
+    containers = {
+      "mailpit" = {
+        vm_id    = 110
+        hostname = "mailpit"
+        vlan     = "apps"
+        tags     = ["terraform", "container", "notifications", "docker"]
+      }
+    }
+  }
+
+  assert {
+    condition     = length(local.honeypot_container_ids) == 0 && length(local.honeypot_notify_container_ids) == 0
+    error_message = "honeypot maps must be empty when no containers carry the 'honeypot' tag"
+  }
+}

--- a/variables-vms.tf
+++ b/variables-vms.tf
@@ -18,6 +18,15 @@ variable "vms" {
     # (the primary node). Set to "proxmox-2"/"proxmox-3" to place a VM on another cluster node.
     node_name = optional(string)
 
+    # DHCP/DNS-first addressing (optional), mirroring containers. dhcp = true
+    # means no vm_id-derived IP — the lease provides the address and the guest is
+    # reached by {name}.{domain}; this is what lets a VM carry a 6-7-digit
+    # positional VMID (which would overflow the /24 host space). reserved_host is
+    # the host octet tofu-unifi pins the deterministic MAC to (and the DNS A
+    # record resolves to). Omit both for legacy ≤254 static-derived VMs.
+    dhcp          = optional(bool, false)
+    reserved_host = optional(number)
+
     # Resource configuration
     cpu_cores        = optional(number, 4)
     cpu_type         = optional(string, "x86-64-v2-AES")


### PR DESCRIPTION
## Why

An attacker who lands inside any VLAN should trip something loud. Today nothing watches lateral movement, Slack isn't wired anywhere, and there's no real-time external alerting. This adds a **three-tier honeypot fabric covering every VLAN** plus a **dedicated notification gateway** that pages you on Slack + your phone in seconds — reusing the existing DRY model (`deployment.json` → firewall module → `ansible_inventory` → downstream Ansible).

## What

**Sensors (popular + still-maintained, June 2026):**
- **OpenCanary tripwires** (`honeypot` tag) — one lightweight Docker-in-LXC **per live VLAN**; fakes SSH/HTTP/SMB/DB/RDP/SNMP/… and alerts on any touch.
- **T-Pot deep-sensor VM** (`tpot` tag) — bundles 20+ honeypots (Cowrie, Dionaea, Conpot, Log4pot, the Beelzebub/Galah LLM pots, medical/printer/ICS pots, tarpits, …) + the Elastic attack-map dashboard, on the untrusted segment.
- **honeypot-notify gateway** (`honeypot` + `notify` tags) — `caronc/apprise-api` fans one webhook out to **Slack + phone push** (ntfy/Pushover).

**Two parallel paths on every hit:** (A) instant apprise push to Slack/phone; (B) forensic copy into a new Splunk **`honeypot`** index via syslog **519** (added to `syslog_port_map`).

**Firewall posture** (tag-driven, `modules/firewall`):
- Tripwires: new `honeypot-svc` group ACCEPTs+logs the decoy ports; egress internal-only (a poked sensor can't reach the internet).
- Notify gateway: `honeypot-notify-svc` (apprise :8000) + open egress; kept out of the Mailpit/ntfy map so it's never double-claimed.
- T-Pot VM: permissive-but-logged input (it manages its own dockerized firewall), restricted egress so captured malware can't beacon out.

**Infra enabler:** VMs gain DHCP/DNS-first support (`locals.tf` short-circuits `cidrhost`, + `vm_mac`/`vm_reserved_ip`/`vm_address`) so a VM can carry a **7-digit positional VMID** like the containers already do; inventory publishes VM `mac`/`reserved_ip` to match.

**Node placement** honors the roles: T-Pot + 2 tripwires on the fast node (proxmox-1), gateway + remaining tripwires on the workhorse (proxmox-2), warm standbys on the normally-off backup node (proxmox-3).

**Docs:** new `docs/HONEYPOTS.md` (architecture, per-VLAN map, VMID/addressing convention, alert flow, secrets, add/remove a sensor); `honeypot` index in `SPLUNK_INDEXES.md`; `AGENTS.md` references.

## Follow-up (separate repos)
Honeypot software lands via three new `ansible-proxmox-apps` roles (`opencanary`, `apprise`, `tpot`) + the HAProxy/Cribl 519 route, and the `honeypot` index in `ansible-splunk`. Slack webhook + phone token come from Doppler at runtime — never committed.

## Notes for the reviewer
- `deployment.json` is gitignored — example entries (VMIDs, `reserved_host` octets) are **illustrative**; reconcile against the live file for collisions before applying. The rollout rule is **one tripwire per live VLAN**.
- Also refreshed a stale firewall-module test fixture (it lacked `cribl_s2s`/`cribl_prometheus_rw`, so `pipeline_services_rules`/`cribl_stream_services_rules` count asserts never actually ran) — now `24 passed`.

## Verification
- `tofu fmt -check -recursive` ✅ · `tofu validate` ✅
- `tofu test` (root) ✅ **105 passed, 0 failed** · `modules/firewall` ✅ **24 passed, 0 failed**
- End-to-end (post-apply): `nmap`/`ssh` a tripwire → Slack + phone push within seconds, and the event in Splunk's `honeypot` index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018jFfAQcChjDjdPXCmSUxuV

---
_Generated by [Claude Code](https://claude.ai/code/session_018jFfAQcChjDjdPXCmSUxuV)_