### PR TITLE
docs(deployment): add appdata/<app> datasets to the example

### DIFF
--- a/deployment.json.example
+++ b/deployment.json.example
@@ -45,7 +45,12 @@
             "media/tv": { "quota": "2T", "properties": { "recordsize": "1M", "compression": "zstd" } },
             "media/movies": { "quota": "2T", "properties": { "recordsize": "1M", "compression": "zstd" } },
             "appdata": { "quota": "100G", "properties": { "recordsize": "16K", "atime": "off", "compression": "zstd" } },
-            "appdata/plex": {}
+            "appdata/plex": {},
+            "appdata/sonarr": {},
+            "appdata/radarr": {},
+            "appdata/qbittorrent": {},
+            "appdata/prowlarr": {},
+            "appdata/seerr": {}
           }
         },
         "example-nvme": {


### PR DESCRIPTION
## What

Add the five per-app config-persistence datasets to `deployment.json.example`, keeping the
committed template in lockstep with the live `node_storage` contract.

Each media app now bind-mounts a snapshotted `bulk/appdata/<app>` dataset over its config dir
(realized by ansible-proxmox `zfs_pools`), so its database survives a container
destroy/recreate — extending the existing `appdata/plex` pattern to sonarr, radarr,
qbittorrent, prowlarr, and seerr. Children inherit the `appdata` parent's
recordsize/atime/compression and the recursive sanoid + syncoid coverage.

## Notes

- The live `deployment.json` is the private S3 input (gitignored); this example is the public
  template only. The live dataset additions are published to the S3 input separately.
- Pairs with dryvist/ansible-proxmox#307 (the `media_lxc_features` mounts that consume these
  datasets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0128QwhN5mvem4ARsS55HqKH