### PR TITLE
docs(rules): point deployment.json rule at the canonical ACID contract

### DIFF
--- a/agentsmd/rules/infra/deployment-json-source-of-truth.md
+++ b/agentsmd/rules/infra/deployment-json-source-of-truth.md
@@ -1,68 +1,48 @@
 ---
 name: deployment-json-source-of-truth
-description: deployment.json is the single source of truth for all Terraform infrastructure config; terraform.tfvars must never exist
+description: deployment.json is the single source of truth for all Terraform infrastructure config; it is a single-writer S3 object and terraform.tfvars must never exist
 type: feedback
 ---
 
 # deployment.json is the Single Source of Truth
 
-`deployment.json` is the **single source of truth** for Terraform resource definitions (containers, VMs, pools, sizing) in this repo.
+`deployment.json` is the **single source of truth** for Terraform resource
+definitions (containers, VMs, pools, sizing) in this repo. The full ACID
+contract — fetch, schema validation, single-writer locking, and container
+authoring rules — is documented once at
+[docs.jacobpevans.com → Deployment state contract](https://docs.jacobpevans.com/infrastructure/deployment-state-contract).
+**Read it before changing any infrastructure config.** This rule keeps only the
+hard prohibitions and the repo-specific layer split that the public page leaves out.
 
-It is **private and NOT committed**: the live file is the single versioned object in
-the on-prem `s3` object store, which terragrunt fetches at plan/apply with the Doppler
-`S3_*` creds and FAILS LOUD if it is missing (a blank input can never plan a destroy).
-Its location is parameterized in `terragrunt.hcl` (`S3_INVENTORY_BUCKET` /
-`S3_INVENTORY_KEY`, preferred values as defaults); `DEPLOYMENT_JSON_PATH` overrides with
-a local file for offline/bootstrap work. The repo keeps only `deployment.json.example`
-as a shape reference. Read/edit recipe: `docs/SOPS_SETUP.md` → "Setting Up Layer 1".
+**Where it lives:** the live file is **NOT committed** — it is the single
+versioned object in the on-prem `s3` object store, fetched by terragrunt at
+plan/apply with the Doppler `S3_*` creds, and it **FAILS LOUD** if missing (a
+blank input can never plan a destroy). Location is parameterized in
+`terragrunt.hcl` (`S3_INVENTORY_BUCKET` / `S3_INVENTORY_KEY`);
+`DEPLOYMENT_JSON_PATH` overrides with a local file for offline/bootstrap work
+only. The repo keeps only `deployment.json.example`. Read/edit recipe:
+`docs/SOPS_SETUP.md` → "Setting Up Layer 1".
 
-**Why:** `terraform.tfvars` was deleted because it silently overrides `deployment.json` via Terraform variable
-precedence (tfvars = level 3, TF_VAR_* env vars from Terragrunt = level 2). It was gitignored, so it didn't
-transfer to new worktrees, causing silent drift where changes appeared to apply but didn't.
+**Hard prohibitions (the tripwires):**
 
-**How to apply:**
+- Make ALL infrastructure changes in the live S3 object (fetch → edit → validate
+  → upload, per `docs/SOPS_SETUP.md` Layer 1) — never `git add deployment.json`.
+- Never create or commit `terraform.tfvars`. It silently overrides
+  `deployment.json` via variable precedence (tfvars = level 3, `TF_VAR_*` from
+  Terragrunt = level 2) and is gitignored, so it drifts between worktrees —
+  changes appear to apply but don't. If one exists in your worktree, delete it
+  immediately: `rm terraform.tfvars`.
+- One writer at a time: the OpenTofu state lock serializes applies and
+  `-lock-timeout` makes concurrent runs wait. Don't bypass it.
+- Container keys MUST match the Terraform state keys exactly — a mismatch
+  triggers destroy + recreate. Verify against `terragrunt state list` first.
+  (Authoring details: see the contract page above.)
 
-- Make ALL infrastructure changes (containers, VMs, pools, Splunk sizing) in the live
-  object and upload it back (fetch/validate/upload steps: `docs/SOPS_SETUP.md` Layer 1) —
-  never `git add deployment.json`
-- Never create or commit `terraform.tfvars` — it is gitignored and forbidden
-- If `terraform.tfvars` exists in your worktree, delete it immediately: `rm terraform.tfvars`
-- SOPS (`terraform.sops.json`) holds 5 env-specific values (not necessarily secret, but
-  installation-specific — they'd reveal private infra details if committed plaintext):
-  `network_prefix`, `domain`, `vm_ssh_public_key_path`, `vm_ssh_private_key_path`,
-  `proxmox_ssh_username`
-- Doppler holds only runtime credentials: `PROXMOX_VE_*`, `SPLUNK_*`, `PROXMOX_SSH_PRIVATE_KEY`
+**Repo-specific layer split (not on the public page — installation-specific):**
 
-## Compact DRY Format for Containers
-
-When adding containers to `deployment.json`:
-
-- **Omit** `root_disk.datastore_id` — defaults to `local-zfs` via module
-- **Omit** `network_interfaces` when you want `firewall: true` (the default)
-- **Include** `network_interfaces` only when `firewall: false` is needed
-
-```json
-"my-container": {
-  "vm_id": 123,
-  "hostname": "my-container",
-  "description": "Description of the container",
-  "cpu_cores": 2,
-  "memory_dedicated": 2048,
-  "vlan": "compute",
-  "tags": ["terraform", "container", "some-tag"],
-  "pool_id": "infrastructure",
-  "root_disk": { "size": 16 }
-}
-```
-
-For containers that must bypass the Proxmox firewall (e.g., DNS servers, management tools):
-
-```json
-"network_interfaces": [{ "name": "eth0", "bridge": "vmbr0", "firewall": false }]
-```
-
-## Key Name Alignment
-
-Container key names in `deployment.json` MUST match the Terraform state keys exactly. A key mismatch
-triggers destroy + recreate. Always verify against `terragrunt state list` before adding entries for
-containers that already exist in state.
+- SOPS (`terraform.sops.json`) holds 5 env-specific values (not necessarily
+  secret, but installation-specific — they'd reveal private infra details if
+  committed plaintext): `network_prefix`, `domain`, `vm_ssh_public_key_path`,
+  `vm_ssh_private_key_path`, `proxmox_ssh_username`.
+- Doppler holds only runtime credentials: `PROXMOX_VE_*`, `SPLUNK_*`,
+  `PROXMOX_SSH_PRIVATE_KEY`.

--- a/agentsmd/rules/infra/deployment-json-source-of-truth.md
+++ b/agentsmd/rules/infra/deployment-json-source-of-truth.md
@@ -1,6 +1,6 @@
 ---
 name: deployment-json-source-of-truth
-description: deployment.json is the single source of truth for all Terraform infrastructure config; it is a single-writer S3 object and terraform.tfvars must never exist
+description: deployment.json is the single source of truth for Terraform config; it is a single-writer S3 object and terraform.tfvars must never exist
 type: feedback
 ---
 
@@ -34,15 +34,15 @@ only. The repo keeps only `deployment.json.example`. Read/edit recipe:
   immediately: `rm terraform.tfvars`.
 - One writer at a time: the OpenTofu state lock serializes applies and
   `-lock-timeout` makes concurrent runs wait. Don't bypass it.
-- Container keys MUST match the Terraform state keys exactly — a mismatch
+- Container and VM keys MUST match the Terraform state keys exactly — a mismatch
   triggers destroy + recreate. Verify against `terragrunt state list` first.
   (Authoring details: see the contract page above.)
 
 **Repo-specific layer split (not on the public page — installation-specific):**
 
-- SOPS (`terraform.sops.json`) holds 5 env-specific values (not necessarily
-  secret, but installation-specific — they'd reveal private infra details if
-  committed plaintext): `network_prefix`, `domain`, `vm_ssh_public_key_path`,
-  `vm_ssh_private_key_path`, `proxmox_ssh_username`.
+- SOPS (`terraform.sops.json`) holds installation-specific values (not
+  necessarily secret, but they'd reveal private infra details if committed
+  plaintext): `network_prefix`, `domain`, the `vm_ssh_*` key paths,
+  `proxmox_ssh_username`, and `rack_servers` (BMC IPs/MACs, chassis, service tags).
 - Doppler holds only runtime credentials: `PROXMOX_VE_*`, `SPLUNK_*`,
   `PROXMOX_SSH_PRIVATE_KEY`.


### PR DESCRIPTION
## What

Slims the `deployment-json-source-of-truth` agent rule to a **pointer** at the single canonical contract, instead of restating the mechanics here.

The container-format and key-name-alignment details now live once on the public canonical page (`docs.jacobpevans.com/infrastructure/deployment-state-contract`, dryvist/docs#88). This rule keeps only what an in-repo agent needs inline:

- the source-of-truth statement + a link to the full ACID contract,
- the hard tripwires (never `git add deployment.json`, never `terraform.tfvars`, single-writer via the state lock, key-name alignment),
- the repo-specific SOPS/Doppler layer split (installation-specific values the public page deliberately omits).

## Why

Part of aligning every tofu/ansible repo to one definition of how `deployment.json` is read and written. Companion PRs: dryvist/docs#88 (public canonical), dryvist/docs-starlight#55 (private companion).

## Verification

- `markdownlint-cli2` clean on the changed file (repo config, MD013=160).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D8De2aQvYqr5cFZ7Tz2ntG