### PR TITLE
chore(ai): drop n8n from the AI orchestration tier

### DIFF
--- a/constants.tf
+++ b/constants.tf
@@ -59,9 +59,8 @@ locals {
       # Local LLM: Ollama API (CT 167 hermes-infer) + Open WebUI (CT 168 hermes-chat)
       ollama_api     = 11434
       open_webui_web = 8080
-      # AI orchestration stack web UIs (Traefik-fronted) — n8n, Dify, LangFlow,
-      # and Langfuse (LLM trace/cost/eval). ingress.tf references these constants.
-      n8n_web      = 5678
+      # AI orchestration stack web UIs (Traefik-fronted) — Dify, LangFlow, and
+      # Langfuse (LLM trace/cost/eval). ingress.tf references these constants.
       dify_web     = 80
       langflow_web = 7860
       langfuse_web = 3000

--- a/deployment.json.example
+++ b/deployment.json.example
@@ -25,7 +25,7 @@
   "pools": {
     "logging": { "comment": "Logging and observability infrastructure" },
     "infrastructure": { "comment": "Core infrastructure services" },
-    "ai": { "comment": "AI orchestration tier (n8n, Dify, LangFlow, agent-exec)" }
+    "ai": { "comment": "AI orchestration tier (Dify, LangFlow, agent-exec)" }
   },
 
   "datastores": {},
@@ -217,23 +217,7 @@
       "unprivileged": true,
       "features": { "nesting": true }
     },
-    "_ai_orchestration_comment": "AI orchestration tier (AI/ML target tier 5). n8n/Dify/LangFlow are Docker-in-LXC visual builders; agent-exec is a plain Python LXC running CrewAI + LangChain code with OpenLLMetry. VMIDs follow the 6-digit positional convention (docs vmid-network-tiers): 505030 = tier 5 (AI) / sub 0 (user-facing) / crit 5 / instance 0 / OS 3 (Docker) / env 0; agent-exec 505340 has OS digit 4 (LXC); langfuse 405030 is tier 4 (observability). They sit on the CURRENT 'ai'/'siem' VLANs (the 40->50 / 20->40 renumber is deferred), addressed DNS-first (dhcp + reserved_host). Each tool's model provider + vector store is configured per its own install standard; Dify keeps its bundled vector store rather than the shared qdrant. Docker guests carry only nesting (the API token cannot set keyctl/fuse on unprivileged LXC; ansible-proxmox adds those via root@pam, same as the media guests). Firewall: ai-orchestration-svc (UI ports) + native OTLP egress to Cribl Edge; Langfuse adds langfuse-svc (3000). Node placement is set in the live (private) deployment input; the example omits node_name and uses the default.",
-    "n8n": {
-      "vm_id": 505030,
-      "dhcp": true,
-      "reserved_host": 40,
-      "vlan": "ai",
-      "hostname": "n8n",
-      "description": "n8n workflow automation + LLM orchestration glue (Docker-in-LXC)",
-      "cpu_cores": 2,
-      "memory_dedicated": 4096,
-      "tags": ["terraform", "container", "ai", "ai-orchestration", "n8n", "docker"],
-      "pool_id": "ai",
-      "unprivileged": true,
-      "root_disk": { "size": 16 },
-      "mount_points": [{ "volume": "local-zfs", "size": "30G", "path": "/opt/n8n" }],
-      "features": { "nesting": true }
-    },
+    "_ai_orchestration_comment": "AI orchestration tier (AI/ML target tier 5). Dify/LangFlow are Docker-in-LXC visual builders; agent-exec is a plain Python LXC running CrewAI + LangChain code with OpenLLMetry. VMIDs follow the 6-digit positional convention (docs vmid-network-tiers): 505130 = tier 5 (AI) / sub 0 (user-facing) / crit 5 / instance 1 / OS 3 (Docker) / env 0; agent-exec 505340 has OS digit 4 (LXC); langfuse 405030 is tier 4 (observability). They sit on the CURRENT 'ai'/'siem' VLANs (the 40->50 / 20->40 renumber is deferred), addressed DNS-first (dhcp + reserved_host). Each tool's model provider + vector store is configured per its own install standard; Dify keeps its bundled vector store rather than the shared qdrant. Docker guests carry only nesting (the API token cannot set keyctl/fuse on unprivileged LXC; ansible-proxmox adds those via root@pam, same as the media guests). Firewall: ai-orchestration-svc (UI ports) + native OTLP egress to Cribl Edge; Langfuse adds langfuse-svc (3000). Node placement is set in the live (private) deployment input; the example omits node_name and uses the default.",
     "dify": {
       "vm_id": 505130,
       "dhcp": true,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -190,58 +190,45 @@ Summary by pool:
 
 Notable per-container facts:
 
-- `haproxy` LXC fronts syslog on standard ports 514-518 (UDP/TCP, forwarded
-  to Cribl Edge backends 1514-1518) and NetFlow 2055 (UDP) — see
-  [LOGGING_PIPELINE.md](./LOGGING_PIPELINE.md).
-- `cribl-edge-01/02` (port 9420 API) and `cribl-stream-01/02` (port 9000 API)
-  form the two-tier processing pipeline.
-- `splunk-mgmt` is the LXC search head + deployment server + license manager +
-  monitoring console + cluster manager. The `splunk-aio` VM 200 is the
-  dedicated indexing node.
+- `haproxy` LXC fronts syslog 514-518 (UDP/TCP → Cribl Edge backends 1514-1518)
+  and NetFlow 2055 (UDP) — see [LOGGING_PIPELINE.md](./LOGGING_PIPELINE.md).
+- `cribl-edge-01/02` (API 9420) + `cribl-stream-01/02` (API 9000) form the
+  two-tier pipeline.
+- `splunk-mgmt` runs the Splunk management roles (SH/DS/LM/MC/CM); the
+  `splunk-aio` VM 200 is the dedicated indexer.
 - `hermes-infer` is a **privileged** LXC with the AMD RX 6800 passed through
-  (`/dev/kfd` + `/dev/dri`, via the `ansible-proxmox` `lxc_gpu_features` role)
-  running Ollama on ROCm; it serves the `hermes4` model (NousResearch
-  Hermes-4-14B) on port 11434 from a 120 GB volume at `/var/lib/ollama`.
-  `hermes-chat` runs Open WebUI, fronted by Traefik via the `llm` ingress; the
-  `ollama` ingress exposes the raw API. Full write-up:
-  [docs.jacobpevans.com/infrastructure/local-llm](https://docs.jacobpevans.com/infrastructure/local-llm).
-- The **AI orchestration tier** adds `dify` and `langflow` (Docker-in-LXC visual
-  LLM-flow builders, fronted by Traefik at the `dify` / `langflow` ingresses),
-  `agent-exec` (a plain-LXC Python runtime for CrewAI + LangChain code,
-  auto-instrumented with OpenLLMetry → OTLP), and `langfuse` (Langfuse v3 LLM
-  observability on the siem VLAN, `infrastructure` pool, OTLP trace ingest at
-  `:3000/api/public/otel`). Orchestration apps emit OpenTelemetry to Cribl Edge,
-  which forks traces to Langfuse and Splunk. The model endpoint each tool calls
-  resolves by DNS to an OpenAI-compatible runner, so the inference backend is
-  swappable without touching app config. **Tools evaluated:** n8n was
-  investigated and not adopted — its Community Edition gates features required
-  here, and its paid tiers cost more than the self-hosted alternatives even for
-  on-prem use.
+  (`/dev/kfd` + `/dev/dri`, via `ansible-proxmox` `lxc_gpu_features`) running
+  Ollama on ROCm; it serves `hermes4` (NousResearch Hermes-4-14B) on port 11434
+  from a 120 GB `/var/lib/ollama` volume.
+  `hermes-chat` runs Open WebUI (`llm` ingress); `ollama` exposes the raw API.
+  Full write-up: [local-llm](https://docs.jacobpevans.com/infrastructure/local-llm).
+- The **AI orchestration tier** — `dify`/`langflow` (Traefik-fronted) and
+  `agent-exec` on the `ai` VLAN, plus `langfuse` (Langfuse v3 observability on the
+  **siem** VLAN, `infrastructure` pool, OTLP ingest `:3000/api/public/otel`) —
+  emits OpenTelemetry to Cribl Edge, which forks traces to Langfuse + Splunk. Each
+  tool's model endpoint resolves by DNS to an OpenAI-compatible runner, so the
+  backend is swappable. **Tools evaluated:** n8n — not adopted; Community Edition
+  gates needed features and paid tiers cost more than self-hosted even on-prem.
 - `mailpit` and `ntfy` run Docker-in-LXC (`nesting: true`, `keyctl: true`) for
   internal notifications.
 - `download-vpn` is an unprivileged LXC with `/dev/net/tun` passed through
-  (`device_passthrough`) so WireGuard can create `wg0` inside the container.
-  The unified `bulk/data` dataset is bind-mounted from the media-node host as
-  `/data` (size-less `mount_points`) — a single filesystem so torrents and the
-  library hardlink with zero duplication; the `ansible-proxmox` `zfs_pools` role
-  provisions the dataset and `media_lxc_features` applies the mount ahead of use.
-  Egress is locked to the VPN by an in-LXC
-  nftables killswitch (config + continuous validation owned by
-  `ansible-proxmox-apps` `download_vpn` role); Proxmox-level firewall is
-  intentionally not applied to the media pool — the killswitch is the security
-  boundary.
+  (`device_passthrough`) so WireGuard creates `wg0` inside it. The unified
+  `bulk/data` dataset is bind-mounted from the media-node host as `/data`
+  (size-less `mount_points`) so torrents and the library hardlink with zero
+  duplication (`ansible-proxmox` `zfs_pools` provisions it; `media_lxc_features`
+  applies the mount). Egress is VPN-locked by an in-LXC nftables killswitch
+  (`ansible-proxmox-apps` `download_vpn` role); no Proxmox firewall on the media
+  pool — the killswitch is the boundary.
 - `sonarr`, `radarr`, `plex` are LAN-only (no VPN); they reach Prowlarr +
   qBittorrent on `download-vpn` over the LAN and read/write the same unified
   `bulk/data` (`/data`) dataset.
-- `traefik` (VMID 101) is the HTTPS reverse-proxy / TLS ingress on the
-  management VLAN (VLAN 5), co-located with `haproxy`; backends on other VLANs
-  are reached via inter-VLAN routing (UniFi allow rules per UI port). It
-  fronts every service web UI at `https://<name>.<subdomain>` (no ports) and
-  fetches + auto-renews a wildcard `*.<subdomain>` Let's Encrypt certificate
-  itself via the Route53 DNS-01 challenge (lego) — no inbound internet required.
-  Install, dynamic routers (generated from this inventory), and the cert
-  lifecycle are owned by the `ansible-proxmox-apps` `traefik` role; it
-  supersedes the legacy `nginx-proxy-manager` LXC.
+- `traefik` (VMID 101) is the HTTPS reverse-proxy / TLS ingress on the management
+  VLAN (VLAN 5), co-located with `haproxy`; other-VLAN backends are reached via
+  inter-VLAN routing (UniFi allow rules per UI port). It fronts every web UI at
+  `https://<name>.<subdomain>` and auto-renews a wildcard `*.<subdomain>` Let's
+  Encrypt cert via Route53 DNS-01 (lego) — no inbound internet. Install, dynamic
+  routers (from this inventory), and certs are owned by the `ansible-proxmox-apps`
+  `traefik` role; supersedes the legacy `nginx-proxy-manager`.
 
 #### Client reachability of `<name>.<subdomain>`
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -180,7 +180,8 @@ Summary by pool:
   `splunk-mgmt` (SH + DS + LM + MC + CM)
 - **`ai`** — `claude-code-01/02`, `gemini-01/02`, `qdrant`, `llamaindex`,
   `hermes-infer` (Ollama LLM inference on the RX 6800 GPU), `hermes-chat`
-  (Open WebUI chat frontend)
+  (Open WebUI chat frontend), `dify`, `langflow` (LLM orchestration / flow
+  builders), `agent-exec` (CrewAI + LangChain runtime with OpenLLMetry tracing)
 - **`media`** (v1 pinned to the primary media node — `node_name`,
   `node_storage`, and ansible inventory label all aligned on that node;
   v2 lives on the secondary media node) — `download-vpn` (qBittorrent +
@@ -204,6 +205,18 @@ Notable per-container facts:
   `hermes-chat` runs Open WebUI, fronted by Traefik via the `llm` ingress; the
   `ollama` ingress exposes the raw API. Full write-up:
   [docs.jacobpevans.com/infrastructure/local-llm](https://docs.jacobpevans.com/infrastructure/local-llm).
+- The **AI orchestration tier** adds `dify` and `langflow` (Docker-in-LXC visual
+  LLM-flow builders, fronted by Traefik at the `dify` / `langflow` ingresses),
+  `agent-exec` (a plain-LXC Python runtime for CrewAI + LangChain code,
+  auto-instrumented with OpenLLMetry → OTLP), and `langfuse` (Langfuse v3 LLM
+  observability on the siem VLAN, `infrastructure` pool, OTLP trace ingest at
+  `:3000/api/public/otel`). Orchestration apps emit OpenTelemetry to Cribl Edge,
+  which forks traces to Langfuse and Splunk. The model endpoint each tool calls
+  resolves by DNS to an OpenAI-compatible runner, so the inference backend is
+  swappable without touching app config. **Tools evaluated:** n8n was
+  investigated and not adopted — its Community Edition gates features required
+  here, and its paid tiers cost more than the self-hosted alternatives even for
+  on-prem use.
 - `mailpit` and `ntfy` run Docker-in-LXC (`nesting: true`, `keyctl: true`) for
   internal notifications.
 - `download-vpn` is an unprivileged LXC with `/dev/net/tun` passed through

--- a/ingress.tf
+++ b/ingress.tf
@@ -33,7 +33,6 @@ locals {
     ollama        = { backend = "hermes-infer", port = local.pipeline_constants.service_ports.ollama_api }
     qdrant        = { backend = "qdrant", port = local.pipeline_constants.vector_db_ports.qdrant_http }
     # AI orchestration stack UIs (ai VLAN) + Langfuse LLM observability (siem VLAN).
-    n8n             = { backend = "n8n", port = local.pipeline_constants.service_ports.n8n_web }
     dify            = { backend = "dify", port = local.pipeline_constants.service_ports.dify_web }
     langflow        = { backend = "langflow", port = local.pipeline_constants.service_ports.langflow_web }
     langfuse        = { backend = "langfuse", port = local.pipeline_constants.service_ports.langfuse_web }

--- a/locals-ai-orchestration.tf
+++ b/locals-ai-orchestration.tf
@@ -7,7 +7,7 @@ locals {
   # the full network_cidrs map stays sensitive.
   ai_network = nonsensitive(var.network_cidrs["ai"])
 
-  # AI orchestration LXCs (ai-orchestration tag): n8n, Dify, LangFlow, agent-exec.
+  # AI orchestration LXCs (ai-orchestration tag): Dify, LangFlow, agent-exec.
   # Inbound UI ports from internal + outbound internal/HTTPS (model endpoints,
   # external APIs). agent-exec carries the tag too (egress-only; no UI rule fires).
   ai_orchestration_container_ids = {

--- a/main.tf
+++ b/main.tf
@@ -237,7 +237,7 @@ module "firewall" {
   # Hermes Agent LXC: tagged "hermes-agent" (autonomous agent, broad HTTPS egress)
   hermes_agent_container_ids = local.hermes_agent_container_ids
 
-  # AI orchestration LXCs: tagged "ai-orchestration" (n8n, Dify, LangFlow, agent-exec)
+  # AI orchestration LXCs: tagged "ai-orchestration" (Dify, LangFlow, agent-exec)
   ai_orchestration_container_ids = local.ai_orchestration_container_ids
 
   # Langfuse LLM-observability LXC: tagged "langfuse"

--- a/modules/firewall/ai_orchestration_rules.tf
+++ b/modules/firewall/ai_orchestration_rules.tf
@@ -1,4 +1,4 @@
-# AI orchestration tier firewall resources. The orchestration UIs (n8n, Dify,
+# AI orchestration tier firewall resources. The orchestration UIs (Dify,
 # LangFlow) and the agent-exec runtime live on the ai VLAN; Langfuse lives on the
 # siem VLAN. All are DHCP-first guests behind DROP in/out policies, so each gets
 # `dhcp = true` (same reason as object_storage_rules.tf). The Cribl Edge OTLP
@@ -14,11 +14,10 @@ locals {
   # enforced at UniFi; this scopes the Proxmox guest firewall to match.
   ai_src = var.ai_network
 
-  # AI orchestration UIs (n8n, LangFlow, Dify) — inbound from internal so admins
+  # AI orchestration UIs (Dify, LangFlow) — inbound from internal so admins
   # reach the builders; egress (model endpoints, external APIs) via outbound
   # internal/HTTPS groups on the container. Ports DRY from pipeline_constants.
   ai_orchestration_services_rules = [
-    { proto = "tcp", dport = tostring(local.svc_ports.n8n_web), source = local.internal_src, comment = "n8n web UI (TCP ${local.svc_ports.n8n_web}) from internal" },
     { proto = "tcp", dport = tostring(local.svc_ports.langflow_web), source = local.internal_src, comment = "LangFlow web UI (TCP ${local.svc_ports.langflow_web}) from internal" },
     { proto = "tcp", dport = tostring(local.svc_ports.dify_web), source = local.internal_src, comment = "Dify web UI (TCP ${local.svc_ports.dify_web}) from internal" },
   ]
@@ -41,7 +40,7 @@ locals {
   ]
 }
 
-# AI orchestration containers (n8n, Dify, LangFlow, agent-exec)
+# AI orchestration containers (Dify, LangFlow, agent-exec)
 
 resource "proxmox_virtual_environment_firewall_options" "ai_orchestration_container" {
   for_each = var.ai_orchestration_container_ids
@@ -78,7 +77,7 @@ resource "proxmox_virtual_environment_firewall_rules" "ai_orchestration_containe
     for_each = each.key != "agent-exec" ? [1] : []
     content {
       security_group = proxmox_virtual_environment_cluster_firewall_security_group.ai_orchestration_services.name
-      comment        = "AI orchestration UIs (n8n, LangFlow, Dify)"
+      comment        = "AI orchestration UIs (Dify, LangFlow)"
     }
   }
 

--- a/modules/firewall/security_groups.tf
+++ b/modules/firewall/security_groups.tf
@@ -371,7 +371,7 @@ resource "proxmox_virtual_environment_cluster_firewall_security_group" "monitori
 
 resource "proxmox_virtual_environment_cluster_firewall_security_group" "ai_orchestration_services" {
   name    = "ai-orchestration-svc"
-  comment = "AI orchestration UIs (n8n 5678, LangFlow 7860, Dify 80) from internal networks"
+  comment = "AI orchestration UIs (LangFlow 7860, Dify 80) from internal networks"
 
   dynamic "rule" {
     for_each = local.ai_orchestration_services_rules

--- a/modules/firewall/variables.tf
+++ b/modules/firewall/variables.tf
@@ -100,7 +100,7 @@ variable "hermes_agent_container_ids" {
 }
 
 variable "ai_orchestration_container_ids" {
-  description = "Map of AI orchestration LXC names to IDs (tag-driven: n8n, Dify, LangFlow, agent-exec). Inbound UI ports from internal + outbound internal/HTTPS (model endpoints, external APIs)."
+  description = "Map of AI orchestration LXC names to IDs (tag-driven: Dify, LangFlow, agent-exec). Inbound UI ports from internal + outbound internal/HTTPS (model endpoints, external APIs)."
   type        = map(number)
   default     = {}
 }


### PR DESCRIPTION
Removes n8n from the AI orchestration tier. n8n's Community Edition gates
features required here, and its paid tiers cost more than the self-hosted
alternatives even for on-prem use, so it is not adopted.

- Drops the n8n port constant, Traefik ingress route, firewall rule +
  security-group entry, and the example guest.
- Records the evaluation in `docs/ARCHITECTURE.md` (describes what the tier does;
  no internal rationale).

The tier keeps Dify, LangFlow, agent-exec (OpenLLMetry), and Langfuse.

`tofu fmt -check` and `tofu validate` pass; `deployment.json.example` is valid JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VRWSajhQqhCGNUFeGD9PFo
