### PR TITLE
fix(ci): repair and enable the ci-fix wrapper

### DIFF
--- a/.github/workflows/ci-fix.yml
+++ b/.github/workflows/ci-fix.yml
@@ -1,12 +1,14 @@
 name: CI Fix (Claude)
 
+# Thin caller for dryvist/ai-workflows cc-ci-fix. When CI Gate fails on a PR
+# branch, Claude analyzes the failure and pushes a verified fix commit to that
+# branch (max 2 attempts/PR). The reusable handles gating, attempt-capping,
+# daily limits, and concurrency — so this wrapper stays minimal.
 on:
-  workflow_dispatch:
-  # --- DISABLED AUTOMATIC TRIGGERS (restore by uncommenting) ---
-  # workflow_run:
-  #   workflows: ["Terraform CI", "Markdown Lint"]
-  #   types: [completed]
-  # --- END DISABLED ---
+  workflow_run:
+    workflows: ["CI Gate"] # the required merge gate (File Size, Markdown, Secret Scan, Terraform)
+    types: [completed]
+  workflow_dispatch: # manual trigger for testing / re-runs
 
 permissions:
   actions: read
@@ -15,22 +17,11 @@ permissions:
   issues: write
   pull-requests: write
 
-# --- DISABLED AUTOMATIC TRIGGERS (restore by uncommenting) ---
-# concurrency:
-#   group: ci-fix-${{ github.event.workflow_run.head_branch }}
-#   cancel-in-progress: true
-# --- END DISABLED ---
-
 jobs:
-  fix:
-    # --- DISABLED AUTOMATIC TRIGGERS (restore by uncommenting) ---
-    # if: >-
-    #   github.event.workflow_run.conclusion == 'failure' &&
-    #   github.event.workflow_run.head_branch != 'main'
-    # --- END DISABLED ---
-    uses: dryvist/ai-workflows/.github/workflows/ci-fix.yml@main
-    with:
-      repo_context: "Terraform/OpenTofu project managing Proxmox VE infrastructure"
-      ci_structure: "terraform.yml (tofu fmt/init/validate/test), markdown-lint.yml (markdownlint)"
-      extra_tools: "Bash(tofu:*)"
+  ci-fix:
+    uses: dryvist/ai-workflows/.github/workflows/cc-ci-fix.yml@main
     secrets: inherit
+    with:
+      repo_context: "Terraform/OpenTofu project managing Proxmox VE infrastructure."
+      ci_structure: "CI Gate aggregates required checks: File Size (HARD 12KB per-file limit, docs especially), Markdown Lint, Secret Scan, and Terraform (tofu fmt/init/validate/test)."
+      extra_tools: "Bash(tofu:*)"


### PR DESCRIPTION
## What

Repairs and enables the dormant **CI Fix (Claude)** wrapper so CI failures on PR
branches get auto-fixed by `dryvist/ai-workflows`' `cc-ci-fix` reusable workflow.

## Why it was broken

- It called `…/ci-fix.yml@main`, but the reusable was renamed to
  **`cc-ci-fix.yml`** — the old path no longer resolves, so the wrapper could
  never run.
- Its auto-triggers were commented out and watched `["Terraform CI",
  "Markdown Lint"]`. Neither emits the **File Size** failure that blocks merges —
  that check lives in the **`CI Gate`** workflow.

## Change

Replaced with the canonical thin form (mirrors
`ai-workflows/examples/ci-fix-caller.yml`):

- `uses: …/cc-ci-fix.yml@main` (correct path; `@main` per the dryvist
  self-reference convention).
- Auto-triggers on `workflow_run` of **`CI Gate`** — the required merge gate
  aggregating File Size, Markdown Lint, Secret Scan, and Terraform.
- Dropped the stale `concurrency`/`if` guard; the reusable gates on failure,
  caps attempts (2/PR), enforces the daily limit, and serializes runs itself.
- Kept `workflow_dispatch` for manual testing.

## Note on the original target (PR #501)

This was prompted by #501 (File Size failure on `docs/ARCHITECTURE.md`), but
**#501 has since merged**, so this wrapper now serves future PRs. `workflow_run`
runs from the default branch, so it takes effect once this lands on `main`. A
fresh throwaway PR that trips File Size can validate it end-to-end on demand.

## Verification

- `python3 -c yaml.safe_load` → valid YAML. No untrusted input reaches any
  `run:` (only static strings passed to the reusable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
