### PR TITLE
fix: keep production VMIDs solely in deployment.json

### DIFF
--- a/docs/INFRASTRUCTURE_NUMBERING.md
+++ b/docs/INFRASTRUCTURE_NUMBERING.md
@@ -70,16 +70,16 @@ How `locals.tf` resolves a guest's address (`container_ipv4`):
 
 `cidrhost` is evaluated **only** on the derive branch (an if/else, not `coalesce`, so it
 short-circuits — see PR #444). That is what lets a static-IP exception host carry a 6-7-digit
-positional VMID: a `cidrhost(cidr, 5310010)` would overflow the /24, but it is never
+positional VMID: a `cidrhost(cidr, 5310090)` would overflow the /24, but it is never
 evaluated when a static `ip_config` is present.
 
 ### DNS servers (special VLAN 53, static exception) — worked example
 
 DNS = VLAN 53, outside the tier÷10 rule, so DNS guests use a **7-digit `53`-prefixed** ID and
-a **static** IP. The pve2 DNS secondary `technitium-dns-2`:
+a **static** IP. An illustrative DNS secondary (the real IDs live only in `deployment.json`):
 
-- VMID **5310010** = `53` (DNS VLAN) · sub 1 (mgmt) · crit 0 (most critical) · OS 0 (LXC) ·
-  instance 1 · env 0 (prod).
+- VMID **5310090** = `53` (DNS VLAN) · sub 1 (mgmt) · crit 0 (most critical) · OS 0 (LXC) ·
+  instance 9 · env 0 (prod).
 - static `ip_config` `<dns-subnet>.3` (gateway `.1`, primary `.2`, secondary `.3`).
 
 > IP examples on this page use the `192.168.<vlan>.x` placeholder shape (committed-file rule);

--- a/tests/ansible_inventory_contract.tftest.hcl
+++ b/tests/ansible_inventory_contract.tftest.hcl
@@ -303,7 +303,7 @@ run "ansible_inventory_ingress_route_table" {
       # Network-quality monitoring LXC — DNS-first (dhcp) with a 6-digit positional
       # VMID (observability tier 4). No vm_id-derived IP; fronted by FQDN.
       "smokeping" = {
-        vm_id         = 412000
+        vm_id         = 990001
         dhcp          = true
         reserved_host = 30
         hostname      = "smokeping"

--- a/tests/firewall_filtering.tftest.hcl
+++ b/tests/firewall_filtering.tftest.hcl
@@ -323,7 +323,7 @@ run "object_storage_tagged_container_in_object_storage_ids" {
   variables {
     containers = {
       "object-storage" = {
-        vm_id         = 202000
+        vm_id         = 990004
         hostname      = "object-storage"
         vlan          = "siem"
         dhcp          = true
@@ -339,8 +339,8 @@ run "object_storage_tagged_container_in_object_storage_ids" {
   }
 
   assert {
-    condition     = local.object_storage_container_ids["object-storage"] == 202000
-    error_message = "object_storage_container_ids['object-storage'] should be vm_id 202000"
+    condition     = local.object_storage_container_ids["object-storage"] == 990004
+    error_message = "object_storage_container_ids['object-storage'] should be vm_id 990004"
   }
 
   assert {

--- a/tests/locals.tftest.hcl
+++ b/tests/locals.tftest.hcl
@@ -139,8 +139,8 @@ run "splunk_derived_ip_uses_siem_vlan" {
   command = plan
 
   assert {
-    condition     = local.splunk_derived_ip == "192.168.20.200/24"
-    error_message = "splunk_derived_ip should be siem-VLAN 192.168.20.200/24, got ${local.splunk_derived_ip}"
+    condition     = local.splunk_derived_ip == "192.168.20.99/24"
+    error_message = "splunk_derived_ip should be siem-VLAN 192.168.20.99/24 (placeholder default splunk_vm_id), got ${local.splunk_derived_ip}"
   }
 
   assert {
@@ -188,8 +188,8 @@ run "splunk_network_ips_default_no_containers" {
   }
 
   assert {
-    condition     = contains(local.splunk_network_ips, "192.168.20.200")
-    error_message = "splunk_network_ips should contain splunk VM IP 192.168.20.200"
+    condition     = contains(local.splunk_network_ips, "192.168.20.99")
+    error_message = "splunk_network_ips should contain splunk VM IP 192.168.20.99 (placeholder default)"
   }
 }
 
@@ -208,7 +208,7 @@ run "splunk_network_ips_includes_splunk_tagged_container" {
   }
 
   assert {
-    condition     = contains(local.splunk_network_ips, "192.168.20.200")
+    condition     = contains(local.splunk_network_ips, "192.168.20.99")
     error_message = "splunk_network_ips must include splunk VM IP"
   }
 
@@ -453,7 +453,7 @@ run "monitoring_ids_picks_up_monitoring_tagged" {
   variables {
     containers = {
       "smokeping" = {
-        vm_id         = 412000
+        vm_id         = 990001
         dhcp          = true
         reserved_host = 30
         hostname      = "smokeping"
@@ -464,8 +464,8 @@ run "monitoring_ids_picks_up_monitoring_tagged" {
   }
 
   assert {
-    condition     = local.monitoring_container_ids["smokeping"] == 412000
-    error_message = "monitoring_container_ids should map 'smokeping' to its 6-digit VMID 412000"
+    condition     = local.monitoring_container_ids["smokeping"] == 990001
+    error_message = "monitoring_container_ids should map 'smokeping' to its 6-digit VMID 990001"
   }
 
   # DNS-first guest: no vm_id-derived IP. cidrhost is skipped (a 6-digit id would
@@ -486,7 +486,7 @@ run "container_dhcp_resolves_fqdn_and_null_gateway" {
     domain = "example.com"
     containers = {
       "speedtest" = {
-        vm_id         = 416000
+        vm_id         = 990002
         dhcp          = true
         reserved_host = 31
         hostname      = "speedtest"
@@ -508,7 +508,7 @@ run "container_dhcp_resolves_fqdn_and_null_gateway" {
 }
 
 # Static-IP exception host (a DNS server, reachable before DNS is up) carrying a
-# 7-digit positional VMID. cidrhost(<dns cidr>, 5310010) would overflow the /24,
+# 7-digit positional VMID. cidrhost(<dns cidr>, 9900001) would overflow the /24,
 # so this run only passes because the static ip_config short-circuits the derive
 # branch — the regression guard for the coalesce -> if/else change in locals.tf.
 run "container_static_ip_with_positional_vmid_skips_cidrhost" {
@@ -517,7 +517,7 @@ run "container_static_ip_with_positional_vmid_skips_cidrhost" {
   variables {
     containers = {
       "technitium-dns-2" = {
-        vm_id     = 5310010
+        vm_id     = 9900001
         hostname  = "technitium-dns-2"
         vlan      = "dns"
         ip_config = { ipv4_address = "192.168.2.3/24" }
@@ -605,7 +605,7 @@ run "container_mac_is_deterministic_locally_administered" {
   variables {
     containers = {
       "smokeping" = {
-        vm_id         = 412000
+        vm_id         = 990001
         dhcp          = true
         reserved_host = 30
         hostname      = "smokeping"
@@ -644,7 +644,7 @@ run "container_reserved_ip_from_reserved_host" {
       # DHCP-first media-VLAN guest: reserved_host 210 -> 192.168.55.210, decoupled
       # from the 6-digit positional vm_id (which the /24 cidrhost math can't express).
       "netq-probe-media" = {
-        vm_id         = 415000
+        vm_id         = 990003
         dhcp          = true
         reserved_host = 210
         hostname      = "netq-probe-media"

--- a/variables-splunk.tf
+++ b/variables-splunk.tf
@@ -1,9 +1,9 @@
 # Splunk variables: VM sizing, identity, and SSH access for the Splunk deployment
 
 variable "splunk_vm_id" {
-  description = "VM ID for the Splunk VM. Default matches the canonical homelab deployment so tests and consumers do not need to redeclare it."
+  description = "VM ID for the Splunk VM. The real VM ID is the single source of truth in deployment.json (injected by terragrunt); this default is a non-production placeholder (kept a valid /24 host octet so the derived siem IP resolves) so tests and standalone plans resolve without redeclaring it."
   type        = number
-  default     = 200
+  default     = 99
   validation {
     condition     = var.splunk_vm_id > 0 && var.splunk_vm_id < 10000
     error_message = "Splunk VM ID must be between 1 and 9999."


### PR DESCRIPTION
## What

Enforces the single-source-of-truth rule for VM IDs: `deployment.json` (the private S3 input)
holds the real VM IDs; terraform reads it via terragrunt, downstream resolves the published
inventory. A sweep found three committed copies of real production VMIDs duplicating it.

| Place | Before | After |
| --- | --- | --- |
| `variables-splunk.tf` | `default = 200` (the live Splunk VM ID — the description even said it "matches the canonical homelab deployment") | non-production placeholder `99` (a valid /24 host octet so the derived siem IP still resolves); real value lives only in `deployment.json` |
| `tests/*.tftest.hcl` | fixtures hardcoded 412000 / 416000 / 415000 / 202000 / 5310010 and asserted on them | synthetic fixtures (990001–990004, 9900001) — value-agnostic logic tests, same approach as the molecule scenario fix in ansible-proxmox#307 |
| `docs/INFRASTRUCTURE_NUMBERING.md` | DNS worked example cited the real `technitium-dns-2` VMID | genericized to an illustrative value |

The three Splunk tests that pinned the default-derived `.200` now assert the placeholder `.99`
(they exercise the default path). The 3-digit legacy/illustrative IDs in the IP-derivation tests
(governed by the `192.168.*` committed-IP convention) are left as-is.

## Verification

- `tofu test` — **103 passed / 0 failed** (matches the pre-change baseline).
- `tofu fmt` — clean.

## Context

Found while sweeping all infra repos for hardcoded production VMIDs. ansible-proxmox,
ansible-proxmox-apps, ansible-splunk, tofu-unifi, and int_homelab are all clean (they resolve
every VMID from the inventory at runtime). `deployment.json.example` still mirrors a few real
VMIDs — handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0128QwhN5mvem4ARsS55HqKH