### PR TITLE
fix(containers): ignore out-of-band idmap drift to protect media

### DIFF
--- a/modules/proxmox-container/main.tf
+++ b/modules/proxmox-container/main.tf
@@ -186,6 +186,14 @@ resource "proxmox_virtual_environment_container" "containers" {
       # are still created at provision time; only post-creation reconciliation is
       # ignored (mounts are effectively set-once here).
       mount_point,
+      # Ignore idmap drift, same rationale as mount_point. The media containers'
+      # uid/gid passthrough (e.g. gid 13000 ↔ 13000 for the /data mount) is applied
+      # post-creation by the ansible-proxmox `media_lxc_features` role — it is
+      # root@pam-only, so the BPG API token cannot set it. Without this, every
+      # refresh reads the live idmap back into state and tries to strip it, which
+      # would revert the media stack's write access. idmap is not declared in
+      # deployment.json, so this only suppresses out-of-band reconciliation.
+      idmap,
     ]
   }
 }


### PR DESCRIPTION
## What

Add `idmap` to the `proxmox-container` module's lifecycle `ignore_changes`,
mirroring the existing `mount_point` ignore.

## Why it matters

The media containers' uid/gid passthrough (e.g. `gid 13000 ↔ 13000` for the
`/data` mount) is applied post-creation by the downstream `media_lxc_features`
role. That reconciliation is `root@pam`-only, so the provider's API token cannot
manage it. On every refresh the provider read the live idmap back into state and
planned to strip it (config declares none), which would revert the media stack's
write access — the documented "never apply media post-Ansible" trap.

This is the same class of out-of-band, `root@pam`-only drift already handled for
`mount_point`. `idmap` is not declared in `deployment.json`, so the ignore only
suppresses post-creation reconciliation; provisioning is unaffected.

## Verification

A full-repo plan that previously showed 4 media containers losing their idmap
blocks now shows them dropping out of the diff entirely (0 changes to existing
containers from this cause).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VRWSajhQqhCGNUFeGD9PFo