### PR TITLE
fix(proxmox): unblock the AI-orchestration tier apply (docker features + firewall group name)

### DIFF
--- a/modules/firewall/security_groups.tf
+++ b/modules/firewall/security_groups.tf
@@ -370,7 +370,7 @@ resource "proxmox_virtual_environment_cluster_firewall_security_group" "monitori
 }
 
 resource "proxmox_virtual_environment_cluster_firewall_security_group" "ai_orchestration_services" {
-  name    = "ai-orchestration-svc"
+  name    = "ai-orch-svc" # Proxmox security-group names max 18 chars
   comment = "AI orchestration UIs (LangFlow 7860, Dify 80) from internal networks"
 
   dynamic "rule" {

--- a/modules/proxmox-container/locals.tf
+++ b/modules/proxmox-container/locals.tf
@@ -1,22 +1,28 @@
 # Docker-in-LXC feature derivation.
 #
-# A container tagged `docker` runs Docker inside the LXC, which requires the
-# `nesting` + `keyctl` features, plus `fuse` for the fuse-overlayfs storage driver
-# this homelab uses on ZFS-backed LXCs (the ansible-proxmox-apps registry-mirror
-# play sets storage-driver=fuse-overlayfs). Derive all three from the tag so every
-# docker guest gets the full set automatically instead of hand-declaring them per
-# container — they had drifted (some nesting+keyctl+fuse, some only nesting, some
-# none, while live containers carried features applied out-of-band by pct/Ansible).
+# A container tagged `docker` runs Docker inside the LXC, which needs `nesting`
+# plus `keyctl` + `fuse` for the fuse-overlayfs storage driver this homelab uses
+# on ZFS-backed LXCs (the ansible-proxmox-apps registry-mirror play sets
+# storage-driver=fuse-overlayfs).
 #
-# The tag only ever ADDS: any explicitly-declared feature still applies (logical OR),
-# so a non-docker container is unaffected and a docker container that already
-# declared the full set sees no change.
+# Only `nesting` is derived from the tag, because it is the one container feature
+# an API token may set at create time. `keyctl` and `fuse` are root@pam-only: a
+# token gets HTTP 403 ("changing feature flags (except nesting) is only allowed
+# for root@pam"), and BPG does not set them over its SSH connection either. They
+# are applied out-of-band, post-create, by the ansible-proxmox `lxc_features` role
+# (`pct set --features` over root SSH), and the container's
+# `lifecycle ignore_changes = [features]` keeps Terraform from reverting them.
+# Deriving keyctl/fuse from the tag (PR #457) made the create call send them and
+# 403 every *new* docker guest — so they are nesting-only here.
+#
+# The tag only ever ADDS `nesting`: any explicitly-declared feature still applies
+# (logical OR), so a non-docker container is unaffected.
 locals {
   effective_features = {
     for k, c in var.containers : k => {
       nesting = c.features.nesting || contains(c.tags, "docker")
-      keyctl  = c.features.keyctl || contains(c.tags, "docker")
-      fuse    = c.features.fuse || contains(c.tags, "docker")
+      keyctl  = c.features.keyctl
+      fuse    = c.features.fuse
       mount   = c.features.mount
     }
   }


### PR DESCRIPTION
## Problem

PR #457 made the `docker` tag derive `keyctl` + `fuse` + `nesting` in `effective_features`, so the container resource now sends all three in its create call. `keyctl` and `fuse` are root@pam-only in Proxmox: an API token gets `HTTP 403 — Permission check failed (changing feature flags (except nesting) is only allowed for root@pam)` at create, and the BPG provider does not set them over its SSH connection either. Every *new* docker-tagged LXC therefore fails to apply.

## Fix

Derive only `nesting` from the tag — the one container feature an API token may set at create. `keyctl`/`fuse` stay explicit. They are applied out-of-band, post-create, by the `ansible-proxmox` `lxc_features` role (`pct set --features` over root SSH) — which #457's own comment already describes — and the container's `lifecycle ignore_changes = [features]` keeps Terraform from reverting them.

## Impact

No existing guest is affected: only not-yet-created guests carry the `docker` tag, and `features` is in `ignore_changes` for everything already in state. Verified live: with this change the create proceeds past the 403 (a token sets `nesting`); the remaining create-time dependency is the LXC template being present on the target node, staged by the `ct_templates` role.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VRWSajhQqhCGNUFeGD9PFo