### PR TITLE
fix(firewall): shorten honeypot notify security-group name to Proxmox's 18-char cap

### DIFF
--- a/modules/firewall/honeypot_rules.tf
+++ b/modules/firewall/honeypot_rules.tf
@@ -75,7 +75,8 @@ resource "proxmox_virtual_environment_cluster_firewall_security_group" "honeypot
 }
 
 resource "proxmox_virtual_environment_cluster_firewall_security_group" "honeypot_notify_services" {
-  name    = "honeypot-notify-svc"
+  # Proxmox caps cluster security-group names at 18 chars; keep this <= that.
+  name    = "honeypot-ntfy-svc"
   comment = "Honeypot alert gateway: apprise-api REST port (${local.honeypot_ports.apprise_api}) from internal networks"
 
   dynamic "rule" {


### PR DESCRIPTION
## What

Rename the honeypot notify-gateway cluster security group `honeypot-notify-svc` (19 chars) → `honeypot-ntfy-svc` (17 chars).

## Why

The deception fabric (#491) was merged with CI (validate + `tofu test`) green, but CI never runs a **live** Proxmox `create`. On the first real apply the notify group failed:

```
Error: error creating security group: received an HTTP 400 response -
Reason: Bad Request (group: value may only be 18 characters long)
```

Proxmox caps cluster firewall security-group names at 18 chars. The sibling `honeypot-svc` (12) applied fine; only the notify group tripped the limit.

## Safety

- The name is consumed via the `.name` **attribute** (`honeypot_rules.tf` refs + rules), never a string literal, so no other references change.
- No test asserts the literal name (tests key on the `honeypot-notify` *container* id, unrelated).
- **Live state already carries `honeypot-ntfy-svc`** (applied during the AI-orchestration/rebuild go-live); this PR aligns `main` with live and unblocks any future apply from `main`.

## Follow-up (not in this PR)

Consider a module-level guard asserting all cluster security-group names ≤ 18 chars, so this class of error fails at `validate`/`test` time instead of live apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DzUXQk78Vou8n1o7itS3Md