### PR TITLE
feat(ingress): front IaC automation platform (Terrakube + Semaphore) + RustFS S3 API by FQDN

### DIFF
--- a/constants.tf
+++ b/constants.tf
@@ -116,6 +116,18 @@ locals {
       qdrant_http = 6333
       qdrant_grpc = 6334
     }
+    # IaC automation platform (Terrakube + Semaphore UI) on the iac-platform VM
+    # (docker compose, mgmt VLAN, pve3). Host ports published by the compose
+    # stack; ingress.tf fronts each behind its own <name>.<domain> route. The
+    # Terrakube executor is deliberately NOT listed: it must never be fronted —
+    # only the API reaches it, on the compose-internal network.
+    iac_platform_ports = {
+      terrakube_ui       = 28080
+      terrakube_api      = 28081
+      terrakube_registry = 28082
+      terrakube_dex      = 28083
+      semaphore_web      = 28084
+    }
     # Honeypot / deception sensors. apprise_api = the honeypot-notify gateway's
     # REST port (caronc/apprise-api): honeypots POST one webhook and Apprise fans
     # it out to Slack + phone push (Path A). The remaining entries are the

--- a/ingress.tf
+++ b/ingress.tf
@@ -19,7 +19,12 @@ locals {
     technitium       = { backend = "technitium-dns", port = local.pipeline_constants.service_ports.technitium_web }
     phpipam          = { backend = "phpipam", port = local.pipeline_constants.service_ports.phpipam_web }
     "object-storage" = { backend = "object-storage", port = local.pipeline_constants.service_ports.object_storage_console }
-    infisical        = { backend = "infisical", port = local.pipeline_constants.service_ports.infisical_api }
+    # RustFS S3 API behind its own FQDN so consumers (Terrakube state storage,
+    # anything S3) never dial an IP:port — per the no-IP-references rule every
+    # system is reached via a valid-TLS hostname. Path-style S3 required by
+    # clients (one hostname, no per-bucket vhosts under the wildcard cert).
+    s3        = { backend = "object-storage", port = local.pipeline_constants.service_ports.object_storage_s3 }
+    infisical = { backend = "infisical", port = local.pipeline_constants.service_ports.infisical_api }
     # openbao is intentionally NOT here: it is a 3-node Raft HA cluster, fronted
     # as a load-balanced multi-backend pool (openbao_backends below) so the
     # ingress survives a single node loss — not a single-backend route.
@@ -138,6 +143,27 @@ locals {
         sticky            = true
         health_check      = true
         health_check_path = "/v1/sys/health?standbyok=true"
+      }
+    ] : [],
+    # IaC automation platform (Terrakube + Semaphore UI) on the iac-platform VM
+    # (DHCP/DNS-first, mgmt VLAN, pve3). Appended like the Splunk VM (VMs are not
+    # in var.containers, so no ingress_services row), but conditionally — a
+    # deployment.json without the VM never emits dangling routes. The backend is
+    # local.vm_address: the VM's FQDN, never an IP (DNS-first doctrine). Four
+    # Terrakube hostnames are required upstream (UI/API/registry/dex each get
+    # their own vhost); the executor is deliberately not fronted. pve3 powers
+    # off nightly — consumers must treat these routes as daytime-available.
+    contains(keys(var.vms), "iac-platform") ? [
+      for svc in [
+        { name = "terrakube", port = local.pipeline_constants.iac_platform_ports.terrakube_ui },
+        { name = "terrakube-api", port = local.pipeline_constants.iac_platform_ports.terrakube_api },
+        { name = "terrakube-registry", port = local.pipeline_constants.iac_platform_ports.terrakube_registry },
+        { name = "terrakube-dex", port = local.pipeline_constants.iac_platform_ports.terrakube_dex },
+        { name = "semaphore", port = local.pipeline_constants.iac_platform_ports.semaphore_web },
+        ] : {
+        name = svc.name
+        ip   = local.vm_address["iac-platform"]
+        port = svc.port
       }
     ] : []
   )


### PR DESCRIPTION
## Summary

Companion change for the new central IaC management tier ([dryvist/iac-platform](https://github.com/dryvist/iac-platform), Terrakube + Semaphore UI on the new `iac-platform` VM — VMID 110030, mgmt VLAN, pve3):

- **5 platform routes** (`terrakube`, `terrakube-api`, `terrakube-registry`, `terrakube-dex`, `semaphore`) appended to the ingress table, conditional on the VM existing in `deployment.json` (splunk-VM precedent, but guarded). Backends advertise the VM's **FQDN** via `vm_address` (DNS-first), never an IP. The Terrakube executor is deliberately not fronted.
- **`s3` route**: RustFS S3 API behind its own FQDN (`s3.<domain>`) so S3 consumers — first: Terrakube state storage — never dial an IP:port. The existing `object-storage` route only fronts the console (9001).
- **`iac_platform_ports` constants map** (28080-28084): ports stay references, never literals.

The VM entry itself lives in the gitignored `deployment.json` (added locally; validates against `deployment.schema.json`). pve3 placement is deliberate: the IaC control plane is a not-24/7 workload per node doctrine.

## Cost impact

Free — homelab-only routing/config; no cloud resources, no GHAS/Actions surface.

## Test plan

- `tofu fmt` / `tofu validate` clean
- `tofu test`: 93 passed; the 1 failure (`ansible_inventory_untagged_native_and_static_ip`) is pre-existing on clean `origin/main` with local OpenTofu 1.10.9 (function-calls-in-test-variables), unrelated to this diff
- `check-jsonschema` on the updated `deployment.json`: ok
- After merge + apply: `terrakube-*.pve`/`semaphore.pve`/`s3.pve` resolve via Technitium and route via Traefik with the wildcard cert (platform routes stay 502 until the compose stack deploys — expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qna3JuDp5y7MB2it6RqUKn