### PR TITLE
feat: add LLM fabric foundation (VLAN end-state, llm-fast/router ports, firewall)

### DIFF
--- a/constants.tf
+++ b/constants.tf
@@ -59,7 +59,13 @@ locals {
       # Proxmox cluster web UI (:8006) — fronted by Traefik at the ingress
       # subdomain apex, load-balanced across every commissioned node's UI.
       proxmox_web = 8006
-      # Local LLM: Ollama API (CT 167 hermes-infer) + Open WebUI (CT 168 hermes-chat)
+      # Local LLM fabric. llm_fast_api = llama-swap OpenAI-compatible endpoint on
+      # the GPU llm-fast guest; llm_router_api = LiteLLM proxy that routes across
+      # llm-fast + the larger off-box model endpoints; open_webui_web = the chat
+      # UI. ollama_api is retained through the retirement phase (superseded by
+      # llama-swap on llm_fast_api).
+      llm_fast_api   = 10434
+      llm_router_api = 4000
       ollama_api     = 11434
       open_webui_web = 8080
       # AI orchestration stack web UIs (Traefik-fronted) — Dify, LangFlow, and

--- a/deployment.json.example
+++ b/deployment.json.example
@@ -250,9 +250,59 @@
       "unprivileged": true,
       "features": { "nesting": true }
     },
-    "_ai_orchestration_comment": "AI orchestration tier (AI/ML target tier 5). Dify/LangFlow are Docker-in-LXC visual builders; agent-exec is a plain Python LXC running CrewAI + LangChain code with OpenLLMetry. VMIDs follow the 6-digit positional convention (docs vmid-network-tiers); the values here are illustrative. They sit on the CURRENT 'ai'/'siem' VLANs (the 40->50 / 20->40 renumber is deferred), addressed DNS-first (dhcp + reserved_host). Each tool's model provider + vector store is configured per its own install standard; Dify keeps its bundled vector store rather than the shared qdrant. Docker guests carry only nesting (the API token cannot set keyctl/fuse on unprivileged LXC; ansible-proxmox adds those via root@pam, same as the media guests). Firewall: ai-orchestration-svc (UI ports) + native OTLP egress to Cribl Edge; Langfuse adds langfuse-svc (3000). Node placement is set in the live (private) deployment input; the example omits node_name and uses the default.",
+    "_llm_fabric_comment": "Local LLM fabric (AI tier 5, ai VLAN). llm-fast is a PRIVILEGED LXC with GPU passthrough (/dev/kfd + a /dev/dri render node) running the fast/small-model server (llama-swap, OpenAI-compatible on llm_fast_api). llm-router-* front the fabric with a LiteLLM proxy (llm_router_api) that routes to llm-fast plus the larger off-box model endpoints. open-webui is the chat UI (open_webui_web). VMIDs follow the 6-digit positional convention (docs vmid-network-tiers); values here are illustrative. GPU passthrough requires a privileged container (unprivileged:false), so the API token cannot create it — root@pam does (ansible-proxmox / hands-on), the same constraint as the media guests' keyctl/fuse. Tag llm-fast opens llm_fast_api from internal; tag llm-router opens llm_router_api. Node placement is set in the live (private) deployment input; the example omits node_name and uses the default.",
+    "llm-fast": {
+      "vm_id": 503000,
+      "dhcp": true,
+      "reserved_host": 44,
+      "vlan": "ai",
+      "hostname": "llm-fast",
+      "description": "GPU fast/small-model server (llama-swap, OpenAI-compatible on llm_fast_api). Privileged LXC with AMD ROCm passthrough.",
+      "cpu_cores": 4,
+      "memory_dedicated": 16384,
+      "tags": ["terraform", "container", "ai", "llm-fast"],
+      "pool_id": "ai",
+      "unprivileged": false,
+      "root_disk": { "size": 24 },
+      "mount_points": [{ "volume": "local-zfs", "size": "120G", "path": "/var/lib/llm" }],
+      "device_passthrough": [
+        { "path": "/dev/kfd" },
+        { "path": "/dev/dri/renderD128" }
+      ]
+    },
+    "open-webui": {
+      "vm_id": 505000,
+      "dhcp": true,
+      "reserved_host": 45,
+      "vlan": "ai",
+      "hostname": "open-webui",
+      "description": "Open WebUI chat frontend for the LLM fabric (open_webui_web; Docker-in-LXC)",
+      "cpu_cores": 2,
+      "memory_dedicated": 4096,
+      "tags": ["terraform", "container", "ai", "open-webui", "docker"],
+      "pool_id": "ai",
+      "unprivileged": true,
+      "root_disk": { "size": 16 },
+      "features": { "nesting": true }
+    },
+    "llm-router-1": {
+      "vm_id": 512000,
+      "dhcp": true,
+      "reserved_host": 46,
+      "vlan": "ai",
+      "hostname": "llm-router-1",
+      "description": "LiteLLM proxy fronting the fabric (llm_router_api) — routes to llm-fast + off-box model endpoints (Docker-in-LXC)",
+      "cpu_cores": 2,
+      "memory_dedicated": 4096,
+      "tags": ["terraform", "container", "ai", "llm-router", "docker"],
+      "pool_id": "ai",
+      "unprivileged": true,
+      "root_disk": { "size": 16 },
+      "features": { "nesting": true }
+    },
+    "_ai_orchestration_comment": "AI orchestration tier (AI/ML tier 5). Dify/LangFlow are Docker-in-LXC visual builders; agent-exec is a plain Python LXC running CrewAI + LangChain code with OpenLLMetry. VMIDs follow the 6-digit positional convention (docs vmid-network-tiers); the values here are illustrative. They sit on the 'ai' VLAN (tier 5) and 'siem' VLAN (tier 4) — the committed end-state of the vlan_ids map — addressed DNS-first (dhcp + reserved_host). Each tool's model provider + vector store is configured per its own install standard; Dify keeps its bundled vector store rather than the shared qdrant. Docker guests carry only nesting (the API token cannot set keyctl/fuse on unprivileged LXC; ansible-proxmox adds those via root@pam, same as the media guests). Firewall: ai-orch-svc (UI ports) + native OTLP egress to Cribl Edge; Langfuse adds langfuse-svc (3000). Node placement is set in the live (private) deployment input; the example omits node_name and uses the default.",
     "dify": {
-      "vm_id": 510000,
+      "vm_id": 505010,
       "dhcp": true,
       "reserved_host": 41,
       "vlan": "ai",
@@ -268,7 +318,7 @@
       "features": { "nesting": true }
     },
     "langflow": {
-      "vm_id": 510010,
+      "vm_id": 505020,
       "dhcp": true,
       "reserved_host": 42,
       "vlan": "ai",
@@ -284,7 +334,7 @@
       "features": { "nesting": true }
     },
     "agent-exec": {
-      "vm_id": 510020,
+      "vm_id": 515000,
       "dhcp": true,
       "reserved_host": 43,
       "vlan": "ai",
@@ -298,7 +348,7 @@
       "root_disk": { "size": 24 }
     },
     "langfuse": {
-      "vm_id": 410040,
+      "vm_id": 405000,
       "dhcp": true,
       "reserved_host": 40,
       "vlan": "siem",

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -178,7 +178,7 @@ Summary by pool:
   `prometheus`, `traefik` (HTTPS/TLS ingress)
 - **`logging`** — `haproxy`, `cribl-edge-01/02`, `cribl-stream-01/02`,
   `splunk-mgmt` (SH + DS + LM + MC + CM)
-- **`ai`** — `claude-code-01/02`, `gemini-01/02`, `qdrant`, `llamaindex`,
+- **`ai`** — `qdrant`, `llamaindex`,
   `hermes-infer` (Ollama LLM inference on the RX 6800 GPU), `hermes-chat`
   (Open WebUI chat frontend), `dify`, `langflow` (LLM orchestration / flow
   builders), `agent-exec` (CrewAI + LangChain runtime with OpenLLMetry tracing)

--- a/locals-llm-fabric.tf
+++ b/locals-llm-fabric.tf
@@ -6,13 +6,13 @@ locals {
   # OpenAI-compatible on llm_fast_api). Inbound llm_fast_api from internal.
   llm_fast_container_ids = {
     for k, v in var.containers : k => v.vm_id
-    if contains(coalesce(try(v.tags, null), []), "llm-fast")
+    if contains(try(v.tags, []), "llm-fast")
   }
 
   # llm-router LXCs (llm-router tag): the LiteLLM proxy fronting the fabric
   # (llm_router_api). Inbound llm_router_api from internal.
   llm_router_container_ids = {
     for k, v in var.containers : k => v.vm_id
-    if contains(coalesce(try(v.tags, null), []), "llm-router")
+    if contains(try(v.tags, []), "llm-router")
   }
 }

--- a/locals-llm-fabric.tf
+++ b/locals-llm-fabric.tf
@@ -1,0 +1,18 @@
+# Local LLM fabric root locals — tag-driven container-id maps fed to
+# modules/firewall. Sibling of locals-ai-orchestration.tf; kept out of locals.tf
+# so that file stays under the shared _file-size 12 KB error threshold.
+locals {
+  # llm-fast LXCs (llm-fast tag): the GPU fast/small-model server (llama-swap,
+  # OpenAI-compatible on llm_fast_api). Inbound llm_fast_api from internal.
+  llm_fast_container_ids = {
+    for k, v in var.containers : k => v.vm_id
+    if contains(coalesce(try(v.tags, null), []), "llm-fast")
+  }
+
+  # llm-router LXCs (llm-router tag): the LiteLLM proxy fronting the fabric
+  # (llm_router_api). Inbound llm_router_api from internal.
+  llm_router_container_ids = {
+    for k, v in var.containers : k => v.vm_id
+    if contains(coalesce(try(v.tags, null), []), "llm-router")
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -244,6 +244,10 @@ module "firewall" {
   # Langfuse LLM-observability LXC: tagged "langfuse"
   langfuse_container_ids = local.langfuse_container_ids
 
+  # LLM fabric LXCs: llm-router (LiteLLM proxy) + llm-fast (GPU llama-swap server)
+  llm_router_container_ids = local.llm_router_container_ids
+  llm_fast_container_ids   = local.llm_fast_container_ids
+
   # Honeypots (honeypot/notify/tpot tags); filters in locals-honeypot.tf.
   honeypot_container_ids        = local.honeypot_container_ids
   honeypot_notify_container_ids = local.honeypot_notify_container_ids

--- a/modules/firewall/llm_fabric_rules.tf
+++ b/modules/firewall/llm_fabric_rules.tf
@@ -19,6 +19,42 @@ locals {
   ]
 }
 
+# Security groups (kept here, not security_groups.tf, to stay under its size gate)
+
+resource "proxmox_virtual_environment_cluster_firewall_security_group" "llm_router_services" {
+  name    = "llm-router-svc"
+  comment = "LLM router / LiteLLM proxy API (${local.svc_ports.llm_router_api}) from internal networks"
+
+  dynamic "rule" {
+    for_each = local.llm_router_services_rules
+    content {
+      type    = "in"
+      action  = "ACCEPT"
+      proto   = rule.value.proto
+      dport   = rule.value.dport
+      source  = rule.value.source
+      comment = rule.value.comment
+    }
+  }
+}
+
+resource "proxmox_virtual_environment_cluster_firewall_security_group" "llm_fast_services" {
+  name    = "llm-fast-svc"
+  comment = "LLM fast / llama-swap server API (${local.svc_ports.llm_fast_api}) from internal networks"
+
+  dynamic "rule" {
+    for_each = local.llm_fast_services_rules
+    content {
+      type    = "in"
+      action  = "ACCEPT"
+      proto   = rule.value.proto
+      dport   = rule.value.dport
+      source  = rule.value.source
+      comment = rule.value.comment
+    }
+  }
+}
+
 # llm-router containers (LiteLLM proxy)
 
 resource "proxmox_virtual_environment_firewall_options" "llm_router_container" {

--- a/modules/firewall/llm_fabric_rules.tf
+++ b/modules/firewall/llm_fabric_rules.tf
@@ -1,0 +1,116 @@
+# Local LLM fabric firewall resources. The GPU fast/small-model server (llm-fast)
+# and the LiteLLM router (llm-router) live on the ai VLAN behind DROP in/out
+# policies, so each gets `dhcp = true` (same reason as ai_orchestration_rules.tf).
+#
+# Rule data lives here (not in locals.tf) so that file stays under the shared
+# _file-size 12 KB error threshold. local.svc_ports / local.internal_src are
+# defined in locals.tf — cross-file local refs resolve within the module.
+locals {
+  # llm-router — the LiteLLM proxy fronting the fabric. Inbound llm_router_api
+  # from internal so callers reach the OpenAI-compatible router endpoint.
+  llm_router_services_rules = [
+    { proto = "tcp", dport = tostring(local.svc_ports.llm_router_api), source = local.internal_src, comment = "LLM router / LiteLLM proxy (TCP ${local.svc_ports.llm_router_api}) from internal" },
+  ]
+
+  # llm-fast — the llama-swap GPU server. Inbound llm_fast_api from internal
+  # (the router and direct callers reach the OpenAI-compatible fast endpoint).
+  llm_fast_services_rules = [
+    { proto = "tcp", dport = tostring(local.svc_ports.llm_fast_api), source = local.internal_src, comment = "LLM fast / llama-swap server (TCP ${local.svc_ports.llm_fast_api}) from internal" },
+  ]
+}
+
+# llm-router containers (LiteLLM proxy)
+
+resource "proxmox_virtual_environment_firewall_options" "llm_router_container" {
+  for_each = var.llm_router_container_ids
+
+  node_name     = var.node_name
+  container_id  = each.value
+  enabled       = local.firewall_defaults.enabled
+  input_policy  = local.firewall_defaults.input_policy
+  output_policy = local.firewall_defaults.output_policy
+  log_level_in  = local.firewall_defaults.log_level_in
+  log_level_out = local.firewall_defaults.log_level_out
+
+  # DHCP-first guests behind DROP policies need their own DHCPDISCOVER/OFFER
+  # allowed or they never lease their reserved ai-VLAN address.
+  dhcp = true
+
+  depends_on = [proxmox_virtual_environment_cluster_firewall.main]
+}
+
+resource "proxmox_virtual_environment_firewall_rules" "llm_router_container" {
+  for_each = var.llm_router_container_ids
+
+  node_name    = var.node_name
+  container_id = each.value
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.internal_access.name
+    comment        = "Internal access (SSH, ICMP)"
+  }
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.llm_router_services.name
+    comment        = "LLM router / LiteLLM proxy API from internal"
+  }
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.outbound_internal.name
+    comment        = "Outbound to internal (llm-fast + off-box model endpoints, DNS)"
+  }
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.outbound_https.name
+    comment        = "Outbound HTTPS (external model APIs, package installs)"
+  }
+
+  depends_on = [proxmox_virtual_environment_firewall_options.llm_router_container]
+}
+
+# llm-fast containers (GPU llama-swap server)
+
+resource "proxmox_virtual_environment_firewall_options" "llm_fast_container" {
+  for_each = var.llm_fast_container_ids
+
+  node_name     = var.node_name
+  container_id  = each.value
+  enabled       = local.firewall_defaults.enabled
+  input_policy  = local.firewall_defaults.input_policy
+  output_policy = local.firewall_defaults.output_policy
+  log_level_in  = local.firewall_defaults.log_level_in
+  log_level_out = local.firewall_defaults.log_level_out
+
+  dhcp = true
+
+  depends_on = [proxmox_virtual_environment_cluster_firewall.main]
+}
+
+resource "proxmox_virtual_environment_firewall_rules" "llm_fast_container" {
+  for_each = var.llm_fast_container_ids
+
+  node_name    = var.node_name
+  container_id = each.value
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.internal_access.name
+    comment        = "Internal access (SSH, ICMP)"
+  }
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.llm_fast_services.name
+    comment        = "LLM fast / llama-swap server API from internal"
+  }
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.outbound_internal.name
+    comment        = "Outbound to internal (DNS, model/weight fetch via internal mirror)"
+  }
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.outbound_https.name
+    comment        = "Outbound HTTPS (model/weight downloads, package installs)"
+  }
+
+  depends_on = [proxmox_virtual_environment_firewall_options.llm_fast_container]
+}

--- a/modules/firewall/security_groups.tf
+++ b/modules/firewall/security_groups.tf
@@ -388,6 +388,40 @@ resource "proxmox_virtual_environment_cluster_firewall_security_group" "langfuse
   }
 }
 
+resource "proxmox_virtual_environment_cluster_firewall_security_group" "llm_router_services" {
+  name    = "llm-router-svc"
+  comment = "LLM router / LiteLLM proxy API (${local.svc_ports.llm_router_api}) from internal networks"
+
+  dynamic "rule" {
+    for_each = local.llm_router_services_rules
+    content {
+      type    = "in"
+      action  = "ACCEPT"
+      proto   = rule.value.proto
+      dport   = rule.value.dport
+      source  = rule.value.source
+      comment = rule.value.comment
+    }
+  }
+}
+
+resource "proxmox_virtual_environment_cluster_firewall_security_group" "llm_fast_services" {
+  name    = "llm-fast-svc"
+  comment = "LLM fast / llama-swap server API (${local.svc_ports.llm_fast_api}) from internal networks"
+
+  dynamic "rule" {
+    for_each = local.llm_fast_services_rules
+    content {
+      type    = "in"
+      action  = "ACCEPT"
+      proto   = rule.value.proto
+      dport   = rule.value.dport
+      source  = rule.value.source
+      comment = rule.value.comment
+    }
+  }
+}
+
 resource "proxmox_virtual_environment_cluster_firewall_security_group" "otel_ingest" {
   name    = "otel-ingest"
   comment = "Cribl Edge native OTLP sources (traces/metrics/logs, gRPC+HTTP) from the AI VLAN only"

--- a/modules/firewall/security_groups.tf
+++ b/modules/firewall/security_groups.tf
@@ -388,39 +388,7 @@ resource "proxmox_virtual_environment_cluster_firewall_security_group" "langfuse
   }
 }
 
-resource "proxmox_virtual_environment_cluster_firewall_security_group" "llm_router_services" {
-  name    = "llm-router-svc"
-  comment = "LLM router / LiteLLM proxy API (${local.svc_ports.llm_router_api}) from internal networks"
-
-  dynamic "rule" {
-    for_each = local.llm_router_services_rules
-    content {
-      type    = "in"
-      action  = "ACCEPT"
-      proto   = rule.value.proto
-      dport   = rule.value.dport
-      source  = rule.value.source
-      comment = rule.value.comment
-    }
-  }
-}
-
-resource "proxmox_virtual_environment_cluster_firewall_security_group" "llm_fast_services" {
-  name    = "llm-fast-svc"
-  comment = "LLM fast / llama-swap server API (${local.svc_ports.llm_fast_api}) from internal networks"
-
-  dynamic "rule" {
-    for_each = local.llm_fast_services_rules
-    content {
-      type    = "in"
-      action  = "ACCEPT"
-      proto   = rule.value.proto
-      dport   = rule.value.dport
-      source  = rule.value.source
-      comment = rule.value.comment
-    }
-  }
-}
+# llm_router_services + llm_fast_services groups are in llm_fabric_rules.tf (size gate).
 
 resource "proxmox_virtual_environment_cluster_firewall_security_group" "otel_ingest" {
   name    = "otel-ingest"

--- a/modules/firewall/variables.tf
+++ b/modules/firewall/variables.tf
@@ -105,6 +105,18 @@ variable "langfuse_container_ids" {
   default     = {}
 }
 
+variable "llm_router_container_ids" {
+  description = "Map of LLM router LXC names to IDs (tag-driven: llm-router). LiteLLM proxy fronting the fabric — inbound llm_router_api from internal + outbound internal/HTTPS (llm-fast + off-box model endpoints)."
+  type        = map(number)
+  default     = {}
+}
+
+variable "llm_fast_container_ids" {
+  description = "Map of LLM fast-server LXC names to IDs (tag-driven: llm-fast). GPU llama-swap server — inbound llm_fast_api from internal + outbound internal/HTTPS (model/weight fetch)."
+  type        = map(number)
+  default     = {}
+}
+
 variable "honeypot_container_ids" {
   description = "Map of honeypot LXC names to IDs (honeypot tag): per-VLAN OpenCanary tripwires + the apprise-api notify gateway. Tag-driven, set by root locals."
   type        = map(number)

--- a/tests/ansible_inventory_contract.tftest.hcl
+++ b/tests/ansible_inventory_contract.tftest.hcl
@@ -45,7 +45,7 @@ override_module {
   outputs = {
     vm_id       = 200
     name        = "splunk-aio"
-    ip_address  = "192.168.20.200"
+    ip_address  = "192.168.40.200"
     mac_address = "BC:24:11:00:00:C8"
   }
 }

--- a/tests/locals.tftest.hcl
+++ b/tests/locals.tftest.hcl
@@ -128,8 +128,8 @@ run "vm_ipv4_uses_vlan_cidr" {
   }
 
   assert {
-    condition     = local.vm_ipv4["idrac-kvm"] == "192.168.50.251/24"
-    error_message = "apps-VLAN VM 251 should be 192.168.50.251/24, got ${local.vm_ipv4["idrac-kvm"]}"
+    condition     = local.vm_ipv4["idrac-kvm"] == "192.168.60.251/24"
+    error_message = "apps-VLAN VM 251 should be 192.168.60.251/24, got ${local.vm_ipv4["idrac-kvm"]}"
   }
 }
 
@@ -139,13 +139,13 @@ run "splunk_derived_ip_uses_siem_vlan" {
   command = plan
 
   assert {
-    condition     = local.splunk_derived_ip == "192.168.20.99/24"
-    error_message = "splunk_derived_ip should be siem-VLAN 192.168.20.99/24 (placeholder default splunk_vm_id), got ${local.splunk_derived_ip}"
+    condition     = local.splunk_derived_ip == "192.168.40.99/24"
+    error_message = "splunk_derived_ip should be siem-VLAN 192.168.40.99/24 (placeholder default splunk_vm_id), got ${local.splunk_derived_ip}"
   }
 
   assert {
-    condition     = local.splunk_network_gateway == "192.168.20.1"
-    error_message = "splunk_network_gateway should be siem-VLAN .1 (192.168.20.1), got ${local.splunk_network_gateway}"
+    condition     = local.splunk_network_gateway == "192.168.40.1"
+    error_message = "splunk_network_gateway should be siem-VLAN .1 (192.168.40.1), got ${local.splunk_network_gateway}"
   }
 }
 
@@ -157,7 +157,7 @@ run "splunk_derived_ip_different_id" {
   }
 
   assert {
-    condition     = local.splunk_derived_ip == "192.168.20.205/24"
+    condition     = local.splunk_derived_ip == "192.168.40.205/24"
     error_message = "splunk_derived_ip should track splunk_vm_id (205), got ${local.splunk_derived_ip}"
   }
 }
@@ -188,8 +188,8 @@ run "splunk_network_ips_default_no_containers" {
   }
 
   assert {
-    condition     = contains(local.splunk_network_ips, "192.168.20.99")
-    error_message = "splunk_network_ips should contain splunk VM IP 192.168.20.99 (placeholder default)"
+    condition     = contains(local.splunk_network_ips, "192.168.40.99")
+    error_message = "splunk_network_ips should contain splunk VM IP 192.168.40.99 (placeholder default)"
   }
 }
 
@@ -208,12 +208,12 @@ run "splunk_network_ips_includes_splunk_tagged_container" {
   }
 
   assert {
-    condition     = contains(local.splunk_network_ips, "192.168.20.99")
+    condition     = contains(local.splunk_network_ips, "192.168.40.99")
     error_message = "splunk_network_ips must include splunk VM IP"
   }
 
   assert {
-    condition     = contains(local.splunk_network_ips, "192.168.20.199")
+    condition     = contains(local.splunk_network_ips, "192.168.40.199")
     error_message = "splunk_network_ips must include splunk-tagged container IP on siem VLAN"
   }
 

--- a/tests/splunk_protection.tftest.hcl
+++ b/tests/splunk_protection.tftest.hcl
@@ -44,7 +44,7 @@ override_module {
   outputs = {
     vm_id       = 200
     name        = "splunk-aio"
-    ip_address  = "192.168.20.200"
+    ip_address  = "192.168.40.200"
     mac_address = "BC:24:11:00:00:C8"
   }
 }
@@ -109,7 +109,7 @@ run "splunk_ip_derived_from_vm_id" {
   }
 
   assert {
-    condition     = local.splunk_derived_ip == "192.168.20.205/24"
+    condition     = local.splunk_derived_ip == "192.168.40.205/24"
     error_message = "splunk_derived_ip must track splunk_vm_id (205) on the siem VLAN, got ${local.splunk_derived_ip}"
   }
 }

--- a/variables-network.tf
+++ b/variables-network.tf
@@ -42,13 +42,13 @@ variable "vlan_ids" {
     mgmt      = 5
     bmc       = 8
     compute   = 10
-    siem      = 20
+    siem      = 40
     pipeline  = 25
     data      = 30
-    ai        = 40
-    apps      = 50
+    ai        = 50
+    apps      = 60
     media_svc = 55
-    homeauto  = 60
+    homeauto  = 80
     nonprod   = 90
   }
 }


### PR DESCRIPTION
## Summary

Committed **end-state** for the local LLM fabric: the final `vlan_ids` map, new fast/router service ports, tag-driven firewall rules for the two new guest classes, and refreshed AI examples.

> [!IMPORTANT]
> Applies are sequenced separately via a **transitional `vlan_ids` override** staged in the private `deployment.json`. This PR is the committed end-state and must **not** be applied before that override is in place — do not merge-and-apply out of order.

## Changes

1. **VLAN end-state map** (`variables-network.tf`) — `vlan_ids` default: siem `20→40`, ai `40→50`, apps `50→60`, homeauto `60→80`. All other keys untouched.
2. **Test literals** — updated derived-IP assertions in `tests/locals.tftest.hcl`, `tests/splunk_protection.tftest.hcl`, `tests/ansible_inventory_contract.tftest.hcl` so the committed `192.168.<vlan>.x` third octets track the new ids (siem→40, apps→60).
3. **New service ports** (`constants.tf`) — `llm_fast_api = 10434` (llama-swap OpenAI endpoint), `llm_router_api = 4000` (LiteLLM proxy). Refreshed the stale local-LLM port comment. `ollama_api` retained (retirement phase).
4. **Tag maps** (`locals-llm-fabric.tf`) — `llm_fast_container_ids` (tag `llm-fast`), `llm_router_container_ids` (tag `llm-router`), mirroring `locals-ai-orchestration.tf`.
5. **Firewall** (`modules/firewall/llm_fabric_rules.tf` + two security groups + variables + root wiring) — internal → `llm_router_api` on router guests; internal → `llm_fast_api` on llm-fast guests.
6. **Example refresh** (`deployment.json.example`) — added `llm-fast` (privileged, `/dev/kfd` + `/dev/dri/*` passthrough), `open-webui`, `llm-router-1`; moved dify/langflow/agent-exec/langfuse to tier VMIDs. Example IPs stay `192.168.*` (third octet = new vlan id), node names `proxmox-N`, no real domains.
7. **claude-code/gemini removal** — dropped the retired dev-container references from `docs/ARCHITECTURE.md`. `hermes-agent` plumbing left intact.

## Verification

- `tofu fmt -check -recursive` — clean
- `tofu validate` — success
- `tofu test` (root suite) — **104 passed, 0 failed**

The `modules/firewall` standalone test failure (`ai_network` has no default) is **pre-existing** on `main` — that module's tests run via the root module in CI, which supplies `ai_network`. Unchanged by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLpU9zVuAPzC8aJLGAKhdj