### PR TITLE
fix(firewall): allow DHCP on vectordb + rag container options

### DIFF
--- a/modules/firewall/container_rules.tf
+++ b/modules/firewall/container_rules.tf
@@ -256,6 +256,9 @@ resource "proxmox_virtual_environment_firewall_options" "vectordb_container" {
   log_level_in  = local.firewall_defaults.log_level_in
   log_level_out = local.firewall_defaults.log_level_out
 
+  # DHCP-first guest behind DROP policies (same reason as llm_fabric_rules.tf).
+  dhcp = true
+
   depends_on = [proxmox_virtual_environment_cluster_firewall.main]
 }
 
@@ -295,6 +298,9 @@ resource "proxmox_virtual_environment_firewall_options" "rag_container" {
   output_policy = local.firewall_defaults.output_policy
   log_level_in  = local.firewall_defaults.log_level_in
   log_level_out = local.firewall_defaults.log_level_out
+
+  # DHCP-first guest behind DROP policies (same reason as llm_fabric_rules.tf).
+  dhcp = true
 
   depends_on = [proxmox_virtual_environment_cluster_firewall.main]
 }


### PR DESCRIPTION
qdrant and llamaindex are DHCP-first guests (LLM fabric rebuild) but `vectordb_container` / `rag_container` firewall options predate the rebuild and lack `dhcp = true` — with `policy_in: DROP` the containers never obtain a lease (verified live: link UP, no address, dhclient timeout; the sibling `llm_router_container` options with `dhcp = true` lease fine on the same node + VLAN).

Same pattern as `llm_fabric_rules.tf` and `ai_orchestration_rules.tf`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLpU9zVuAPzC8aJLGAKhdj