### PR TITLE
fix(inventory): allow non-apex pooled ingress in publish precondition

### DIFF
--- a/inventory_publish.tf
+++ b/inventory_publish.tf
@@ -138,7 +138,7 @@ resource "aws_s3_object" "ansible_inventory" {
         for e in local.ansible_inventory.ingress :
         try(e.name, "") != "" && try(e.port, 0) > 0 && (
           try(e.ip, "") != "" ||
-          length(try(e.backends, [])) > 0
+          try(length(e.backends) > 0, false)
         )
       ])
       error_message = "One or more ingress entries are malformed — each needs a name, a port > 0, and either a non-empty ip (single-backend route) or a non-empty backends pool (load-balanced route, apex or not — e.g. the openbao HA pool). Inspect ingress.tf."

--- a/inventory_publish.tf
+++ b/inventory_publish.tf
@@ -138,10 +138,10 @@ resource "aws_s3_object" "ansible_inventory" {
         for e in local.ansible_inventory.ingress :
         try(e.name, "") != "" && try(e.port, 0) > 0 && (
           try(e.ip, "") != "" ||
-          (try(e.apex, false) && length(try(e.backends, [])) > 0)
+          length(try(e.backends, [])) > 0
         )
       ])
-      error_message = "One or more ingress entries are malformed — each needs a name, a port > 0, and either a non-empty ip (service route) or apex=true with a non-empty backends pool. Inspect ingress.tf."
+      error_message = "One or more ingress entries are malformed — each needs a name, a port > 0, and either a non-empty ip (single-backend route) or a non-empty backends pool (load-balanced route, apex or not — e.g. the openbao HA pool). Inspect ingress.tf."
     }
   }
 }


### PR DESCRIPTION
Load-balanced non-apex ingress entries (backends pool, no single `ip` — e.g. the openbao HA pool from #531) fail the `aws_s3_object.ansible_inventory` precondition, blocking every plan/apply. Accept any entry with a non-empty backends pool, apex or not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLpU9zVuAPzC8aJLGAKhdj