### PR TITLE
fix(firewall): outbound HTTPS for vectordb + rag containers

### DIFF
--- a/modules/firewall/container_rules.tf
+++ b/modules/firewall/container_rules.tf
@@ -283,6 +283,11 @@ resource "proxmox_virtual_environment_firewall_rules" "vectordb_container" {
     comment        = "Outbound to internal only"
   }
 
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.outbound_https.name
+    comment        = "Outbound HTTPS (Docker install/images)"
+  }
+
   depends_on = [proxmox_virtual_environment_firewall_options.vectordb_container]
 }
 
@@ -319,6 +324,11 @@ resource "proxmox_virtual_environment_firewall_rules" "rag_container" {
   rule {
     security_group = proxmox_virtual_environment_cluster_firewall_security_group.outbound_internal.name
     comment        = "Outbound to internal only"
+  }
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.outbound_https.name
+    comment        = "Outbound HTTPS (pip/PyPI installs)"
   }
 
   depends_on = [proxmox_virtual_environment_firewall_options.rag_container]


### PR DESCRIPTION
First converge of the rebuilt fabric guests failed on qdrant (`Add Docker GPG key` → `download.docker.com` unreachable): `vectordb_container` and `rag_container` rules only allow outbound-internal, unlike every sibling fabric map (llm_router/llm_fast/ai_orchestration all include `outbound_https`). qdrant installs Docker and llamaindex installs from PyPI, so both need the same egress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLpU9zVuAPzC8aJLGAKhdj