### PR TITLE
docs(secrets): reconcile OpenBao RBAC + keychain secret-zero + snapshots

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -109,7 +109,7 @@ flowchart TD
     subgraph Runtime["Runtime Secrets (Active)"]
         DOP[Doppler]
         AV[aws-vault<br/>Profile: terraform]
-        KC[macOS Keychain<br/>ai-secrets keychain]
+        KC[dedicated auto-locking keychain<br/>per-domain OpenBao AppRole creds]
     end
 
     subgraph Sync["Secrets Sync (Active)"]
@@ -132,7 +132,7 @@ flowchart TD
     DOP -->|secrets-sync| DS
     DS -->|repository secrets| GHA
     AV -->|AWS_* creds| TF
-    KC -->|API keys| AI
+    KC -->|AppRole creds| AI
     SOPS -->|terraform.sops.json| TF
 ```
 

--- a/docs/SECRETS_HIERARCHY.md
+++ b/docs/SECRETS_HIERARCHY.md
@@ -11,11 +11,12 @@ contents migrate into OpenBao, and Infisical is decommissioned. See
 ## KV v2 hierarchy (mount `secret/`)
 
 ```text
-secret/infra/      proxmox/  aws/  network/        # IaC kernel — Terraform writes
-secret/platform/   dns/ traefik/ object-storage/ splunk/ cribl/ infisical/
+secret/infra/      proxmox/  aws/  network/        # IaC kernel — terraform-apply writes
+secret/platform/   dns/ traefik/ object-storage/ compute/ splunk/ cribl/ terrakube/
 secret/apps/       media/ monitoring/ home-automation/
-secret/ai/         hermes/ agents/                 # LLM stack + AI-agent creds
+secret/ai/         router/ llm-large/ qdrant/ open-webui/ hermes/ agents/
 secret/ci/         github/ doppler-sync/
+secret/public/     domain/                         # non-exploitable facts (see below)
 ```
 
 Each path is `secret/<category>/<service>/<key>`. New static secrets are written
@@ -24,18 +25,33 @@ consumer is proven against OpenBao.
 
 ## RBAC groups
 
-| Identity | Auth method | Read | Write | Notes |
-| --- | --- | --- | --- | --- |
-| `terraform` | AppRole | `secret/infra/*`, `secret/platform/*` | same + manage engines | The IaC identity; creds in Doppler tier-0 |
-| `ansible` | AppRole | `secret/platform/*`, `secret/apps/*` | — | Config-management pulls |
-| `ai-readonly` | AppRole | `secret/ai/*`, `secret/apps/*` | — | **No `secret/infra/*`.** Default AI-agent group; creds in the `ai-secrets` keychain |
-| `ai-elevated` | AppRole | `ai-readonly` + `secret/platform/*` | — | Trusted infra-touching agents; still no write, no kernel |
-| `ci` | JWT/OIDC | scoped CI paths | — | Keyless from GitHub Actions |
-| operator | root / OIDC | break-glass | all | Root token on paper; OIDC/userpass later |
+RBAC is split by **resource domain** — one least-privilege AppRole per consumer,
+so a compromise of any one credential is scoped to that domain's secrets:
 
-AI agents are deliberately **read-only** and walled off from the infra kernel
-(`secret/infra/*` — Proxmox API token, AWS state creds, network CIDRs). Two broad
-groups for now: `ai-readonly` (default) and `ai-elevated` (broader read).
+| Identity | Read | Write | Notes |
+| --- | --- | --- | --- |
+| `terraform-apply` | `secret/infra/*`, `secret/platform/{dns,traefik}` | same | Human-triggered IaC apply; isolated from Terrakube's untrusted-plan surface |
+| `terrakube-plan` | `secret/platform/terrakube` only | — | VCS-driven plan runs treated as hostile; **never** `secret/infra/*` |
+| `ansible-converge` | `secret/platform/*`, `secret/apps/*` | — | Config-management pulls; no infra kernel |
+| `observability` | `secret/platform/{splunk,cribl}` | — | Splunk + Cribl |
+| `local-cloud` | `secret/platform/{object-storage,compute}` | — | S3/object-storage + compute |
+| `monitoring` | `secret/apps/monitoring` | — | Metrics/exporters |
+| `media` | `secret/apps/media` | — | Media stack |
+| `local-llm` | `secret/ai/*` | — | LLM serving stack (router, models, vector DB) |
+| `ai-readonly` | `secret/ai/*`, `secret/apps/*` | — | **No `secret/infra/*`.** Default AI **agent** identity |
+| `ai-elevated` | `ai-readonly` + `secret/platform/*` | — | Trusted infra-touching agents; still no write, no kernel |
+| `snapshot` | `sys/storage/raft/snapshot` | — | Least-privilege backup identity (the snapshot daemon) |
+| `public` | `secret/public/*` | — | Non-exploitable facts; creds ship ambiently, never keychain-gated (see below) |
+| `ci` | scoped CI paths (JWT/OIDC) | — | Keyless from GitHub Actions |
+| operator | break-glass (root / OIDC) | all | Root token on paper; OIDC/userpass later |
+
+Each AppRole is bound to a `secret_id_bound_cidrs` scoped to its consumer's
+subnet (cheap hardening). `terraform-apply` is deliberately walled off from
+`terrakube-plan`: Terrakube executes VCS-driven (potentially untrusted) plans,
+so it gets a read-only, `secret/platform/terrakube`-only identity that can never
+rewrite `secret/infra/*` that Ansible later trusts. AI **agents** (`ai-readonly`
+/ `ai-elevated`) are read-only and walled off from the infra kernel; the LLM
+**serving** stack is a separate `local-llm` identity, not an agent identity.
 
 ## Secret-zero — stays OUT of OpenBao (in Doppler T3)
 
@@ -46,9 +62,36 @@ in the Doppler strict tier (T3), never in OpenBao:
 - The **static seal key** (`OPENBAO_STATIC_SEAL_KEY` + `OPENBAO_STATIC_SEAL_KEY_ID`).
 - The **flow-lock AppRole `secret_id`** — the credential to acquire the global
   flow-lock lease that OpenBao arbitrates.
-- The OpenBao AppRole `role_id`/`secret_id` (`VAULT_ROLE_ID`/`VAULT_SECRET_ID`).
+- The OpenBao AppRole `role_id`/`secret_id` per domain.
 - Proxmox API token (`PROXMOX_VE_*`).
 - AWS state-backend credentials (S3 + DynamoDB lock).
+
+## Secret-zero delivery — the keychain lock IS the access boundary
+
+Each domain's AppRole `role_id`/`secret_id` is delivered to a consuming machine
+as its own item in a **dedicated, auto-locking secret store** (on macOS, a
+dedicated keychain with a 72-hour auto-lock; on Linux guests, a root-only `0600`
+EnvironmentFile / systemd credential). **The store's lock state is the entire
+access boundary — not the AppRole SecretID's own TTL.** While locked, no process
+can read the credential at all; once unlocked (one human prompt every ~3 days on
+macOS), a **user-domain agent** reads each domain's credential and publishes it
+into the session environment, so any subsequently spawned consumer inherits it
+ambiently with no store access of its own. A non-expiring SecretID is therefore
+the correct design here, not a flaw: the boundary is read-access to the store,
+scoped one domain per credential, with bound CIDRs and recorded SecretID
+accessors for clean single-credential revocation if one is ever suspected
+compromised.
+
+### The `public` domain — no unlock at all
+
+`secret/public/*` holds **sensitive-but-not-exploitable facts** that don't belong
+in a public repo yet aren't secrets in the security sense — the canonical example
+being the internal domain/subdomain. Nothing is compromised by any internal
+process reading them, so they must not sit behind the same gate as real secrets.
+OpenBao (like Vault) has no truly-unauthenticated KV read path, so this is a
+single fixed low-privilege `public` AppRole whose creds are **not** keychain-gated
+— they ship ambiently the same way other non-secret internal config already does,
+bound to internal RFC1918 CIDRs so they are useless if ever exfiltrated off-LAN.
 
 ## Resilience (never lost, near-zero unavailability)
 
@@ -59,9 +102,15 @@ in the Doppler strict tier (T3), never in OpenBao:
   or backup compromise yields the key and thus the vault. Encrypt the underlying
   VM/LXC disks at the Proxmox host (LUKS or ZFS native encryption) so the key —
   and the Raft data it unseals — is protected at rest on disk and in snapshots.
-- **Automated encrypted snapshots** → on-prem `s3` bucket `openbao-snapshots` +
-  NAS + offsite-encrypted. Snapshots are encrypted at rest; restore needs the
-  seal key (Doppler) OR the recovery shares (paper).
+- **Automated raft snapshots** — an on-box systemd timer takes a snapshot on the
+  active node only (leader-gated at runtime), authenticated with the
+  least-privilege `snapshot` AppRole, integrity-checked (`gzip -t`), and kept
+  under the ZFS/PBS-backed data volume that already replicates **off-box**;
+  failures page via the deadman/ntfy stack. A second off-box copy into the
+  on-prem `s3` bucket `openbao-snapshots` (with a `HeadObject`/size/sha256
+  verify — never trusting the S3 ETag) and a full restore-to-scratch drill are
+  tracked follow-ups; restore needs the seal key (Doppler) OR the recovery
+  shares (paper).
 - **Paper break-glass** — recovery shares (5, threshold 3) + initial root token,
   transcribed to paper and split across custodians.
 

--- a/docs/SECRETS_ROADMAP.md
+++ b/docs/SECRETS_ROADMAP.md
@@ -13,15 +13,12 @@ machine/AI runtime, cloud secret-zero, or a human-only vault:
 | **T3** | Doppler (SaaS) | Strict cloud tier: OpenBao secret-zero + rare user-approved keys-to-kingdom | Only for rare, explicitly user-approved operations |
 | **T4** | Bitwarden | Human-only vault | **Never** — no AI or automation identity ever reads T4 |
 
-This supersedes the earlier design in two specific ways, called out in full
-under [Superseded designs](#superseded-designs):
-
-- The **OpenBao / Infisical domain-split is dead.** OpenBao is the single
-  machine/IaC/runtime engine. Infisical's contents migrate into OpenBao and
-  Infisical is decommissioned.
-- **Proton Pass is out of the machine architecture.** It stays a personal,
-  human tool only; it holds no machine or AI secret-zero. Bitwarden (T4) is the
-  human-only tier of record.
+This supersedes the earlier design in two ways, detailed under
+[Superseded designs](#superseded-designs): the **OpenBao / Infisical
+domain-split is dead** (OpenBao is the single machine/IaC/runtime engine;
+Infisical migrates in and is decommissioned), and **Proton Pass is out of the
+machine architecture** (a personal human-only tool holding no machine secret-zero;
+Bitwarden (T4) is the human tier of record).
 
 ## Current State
 
@@ -33,12 +30,10 @@ secret-zero plus a small set of rare, user-approved keys-to-kingdom values.
 Routine machine and AI runtime secrets migrate out of Doppler into OpenBao
 (T2) over time — see [Migration sequence](#migration-sequence).
 
-**How it works today:**
-
-- Secrets stored in Doppler projects, organized by config (dev/stg/prd)
-- Injected at runtime via `doppler run --` command wrapper
-- BPG Proxmox provider reads `PROXMOX_VE_*` env vars directly
-- Configured once at bare repo root; all worktrees inherit automatically
+**How it works today:** secrets live in Doppler projects (dev/stg/prd configs),
+injected at runtime via `doppler run --`; the BPG Proxmox provider reads
+`PROXMOX_VE_*` directly. Configured once at the bare repo root — all worktrees
+inherit.
 
 ### ACTIVE: aws-vault (AWS Credential Management)
 
@@ -47,11 +42,8 @@ four-tier storage hierarchy — it is a local credential broker, not a secrets
 store. Its bootstrap creds are secret-zero (T3) and are a candidate for OpenBao
 dynamic AWS credentials (T2) later.
 
-**How it works:**
-
-- Credentials stored in macOS Keychain
-- Temporary STS sessions via `aws-vault exec <profile> --`
-- Never written to `~/.aws/credentials`
+**How it works:** credentials live in the macOS Keychain; `aws-vault exec
+<profile> --` mints temporary STS sessions, never written to `~/.aws/credentials`.
 
 ## The four tiers (end-state)
 
@@ -101,15 +93,14 @@ the **global flow-lock lease authority** (below).
 
 **Architecture:**
 
-- **Self-hosted on a Proxmox LXC** on the apps VLAN, backed by Raft storage with
-  automated snapshots. (HA quorum can be added later; the LXC is the initial
-  target.)
+- **Self-hosted on Proxmox LXCs** on the management VLAN, Raft storage with
+  automated snapshots. A **2-node Raft cluster** is live; a 3rd voter is planned.
 - **On-prem static-key auto-unseal (no cloud)** — nodes self-unseal on reboot
   from a 32-byte AES-256 seal key in a `0600` EnvironmentFile, sourced from the
   Doppler strict tier (T3). This is the chosen seal model; there is no AWS-KMS
   dependency.
-- **Automated encrypted Raft snapshots** → on-prem `s3` bucket
-  `openbao-snapshots` + NAS + offsite-encrypted.
+- **Automated raft snapshots** — an on-box leader-gated timer, integrity-checked,
+  on the ZFS/PBS-backed volume that replicates off-box; an `s3` copy is a follow-up.
 - **Paper break-glass** — recovery shares + initial root token transcribed to
   paper and split across custodians.
 
@@ -135,8 +126,11 @@ acquire the lease:
 | `OPENBAO_STATIC_SEAL_KEY` | 32-byte AES-256 auto-unseal key (base64) |
 | `OPENBAO_STATIC_SEAL_KEY_ID` | Seal-key rotation id (e.g. `YYYYMMDD-1`) |
 | flow-lock AppRole `secret_id` | Credential to acquire the global flow-lock lease |
-| `VAULT_ADDR` | OpenBao API address |
-| `VAULT_ROLE_ID` / `VAULT_SECRET_ID` | Terraform AppRole credentials |
+| `BAO_ADDR` (`VAULT_ADDR`) | OpenBao API address |
+| `terraform-apply` AppRole `role_id`/`secret_id` | The IaC-apply identity's credential |
+
+Other domains' creds are delivered via the auto-locking keychain (lock =
+boundary), per [SECRETS_HIERARCHY.md](./SECRETS_HIERARCHY.md).
 
 ### T3 — Doppler (strict cloud tier: secret-zero + keys-to-kingdom)
 
@@ -182,15 +176,13 @@ core engine is up — see [Migration sequence](#migration-sequence).
 
 Two earlier directions are **superseded** and must not be reintroduced:
 
-- **OpenBao / Infisical domain-split — DEAD.** The plan to run OpenBao (machine
-  engine) and Infisical (human UI + developer hub) as two domain-split systems
-  with no sync between them **does not ship**. OpenBao is the single engine.
-  Infisical's contents migrate into OpenBao and Infisical is decommissioned.
-  See [INFISICAL_PLANNING.md](./INFISICAL_PLANNING.md) (superseded banner).
-- **Proton Pass as tier-0 root-of-trust / AI keychain — SUPERSEDED.** Proton
-  Pass is **out of the machine architecture**. It is a personal, human-only tool
-  and holds no machine or AI secret-zero. The human tier of record is Bitwarden
-  (T4); machine secret-zero lives in Doppler (T3). See
+- **OpenBao / Infisical domain-split — DEAD.** Running OpenBao and Infisical as
+  two un-synced domain-split systems does not ship; OpenBao is the single engine
+  and Infisical's contents migrate in before it is decommissioned. See
+  [INFISICAL_PLANNING.md](./INFISICAL_PLANNING.md) (superseded banner).
+- **Proton Pass as tier-0 root-of-trust / AI keychain — SUPERSEDED.** Out of the
+  machine architecture: a personal human-only tool holding no machine secret-zero.
+  Human tier of record is Bitwarden (T4); machine secret-zero is Doppler (T3). See
   [PROTON_PASS_STRATEGY.md](./PROTON_PASS_STRATEGY.md) (superseded banner).
 
 ## Migration sequence
@@ -227,8 +219,8 @@ T1  SOPS + Age — git-committed deployment config (not credentials)
         (proxmox_node, IPs, networks, container/VM definitions)
 
 T2  OpenBao — PRIMARY machine + AI runtime engine + flow-lock authority
-├── AppRole (VAULT_ROLE_ID/SECRET_ID) ──→ Terraform / Ansible reads
-├── least-privilege AI AppRoles ────────→ Claude Code / cloud agents (read-only)
+├── per-domain AppRoles ──────────────→ terraform-apply / ansible-converge / etc.
+├── AI-agent AppRoles (read-only) ─────→ Claude Code / cloud agents (no infra kernel)
 ├── SSH engine ───────────────────────→ short-TTL automation certs (ai/ansible/ci)
 └── flow-lock lease ──────────────────→ serializes infra-mutating flows
     (secret-zero stays in Doppler T3 — see below)
@@ -243,5 +235,5 @@ T4  Bitwarden — human-only vault
 
 Operational (orthogonal to the tier hierarchy):
   aws-vault (local) ──→ STS sessions ──→ Terraform S3 backend
-  macOS ai-secrets keychain ──→ AI-agent OpenBao AppRole bootstrap ──→ T2
+  auto-locking keychain (72h, lock = boundary) ──→ per-domain AppRole creds ──→ T2
 ```


### PR DESCRIPTION
## Summary
Reconciles the canonical secrets docs with the OpenBao autonomous-secrets design (Phase 5 of that effort). Docs-only; no code.

- **`SECRETS_HIERARCHY.md`**
  - 5-identity RBAC table → the **12-identity domain split** (`terraform-apply`, `terrakube-plan`, `ansible-converge`, `observability`, `local-cloud`, `monitoring`, `media`, `local-llm`, `ai-readonly`, `ai-elevated`, `snapshot`, `public`), with `terrakube-plan` explicitly walled off from `secret/infra/*` (VCS-driven plans treated as hostile).
  - New KV paths for the domains + `secret/public/*`.
  - New **"Secret-zero delivery"** section: the auto-locking keychain / `0600` EnvironmentFile **lock state is the access boundary**, not the AppRole SecretID's TTL; plus the ambient-creds `public` domain for non-exploitable facts.
  - Snapshot resilience reconciled to the real implementation: on-box leader-gated timer + `gzip -t` integrity + ZFS/PBS off-box replication, with the RustFS S3 second copy + restore drill as tracked follow-ups (never trusting the S3 ETag).
- **`SECRETS_ROADMAP.md`**: 2-node Raft live (3rd voter planned) on the management VLAN; per-domain AppRole delivery via keychain; standardize `BAO_ADDR`; updated secrets-flow summary.
- **`ARCHITECTURE.md`**: secrets-chain diagram keychain node updated.

This documents the **target design** the openbao role provisions; the implementing PRs are in `ansible-proxmox-apps` (#540 RBAC, #542 fetch, #553 snapshots) and `nix-darwin` (#1493 keychain). No real IPs/hostnames/node names.

## Verification
- [x] `markdownlint-cli2` — 0 errors on all 3 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)