### PR TITLE
fix(vm): ignore clone block to avoid ForceNew on VM re-import

### DIFF
--- a/modules/proxmox-vm/main.tf
+++ b/modules/proxmox-vm/main.tf
@@ -176,6 +176,11 @@ resource "proxmox_virtual_environment_vm" "vms" {
       # pick up the dns block at first boot; existing VMs get resolvers via
       # Ansible post-boot.
       initialization[0].dns,
+      # A cloned VM re-imported (e.g. after a manual VMID move) reports its
+      # `clone` block as a new addition, which is ForceNew — terraform would
+      # destroy+recreate a healthy VM. The clone source only matters at first
+      # creation, so ignore it: imports and template changes never rebuild a VM.
+      clone,
     ]
   }
 


### PR DESCRIPTION
Adds `clone` to the proxmox-vm module `ignore_changes`. A cloned VM re-imported (after a manual VMID move) otherwise shows its clone block as ForceNew, which would destroy+recreate a healthy VM. Applied live during an iac-platform VMID relocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)