### PR TITLE
feat(ingress): front Splunk HEC at splunk-hec.<domain> on the TLS entrypoint

### DIFF
--- a/ingress.tf
+++ b/ingress.tf
@@ -118,6 +118,18 @@ locals {
         port         = local.pipeline_constants.service_ports.splunk_mgmt
         scheme       = "https"
         insecure_tls = true
+      },
+      {
+        # Splunk HEC (8088) fronted at splunk-hec.<domain> on the standard
+        # TLS entrypoint. HEC senders (the Cribl edges) must use this name:
+        # splunk.<domain> resolves to Traefik, which serves nothing on a raw
+        # 8088, so a sender dialing <name>:8088 black-holes. Same HTTPS
+        # self-signed backend treatment as the two routes above.
+        name         = "splunk-hec"
+        ip           = split("/", local.splunk_derived_ip)[0]
+        port         = local.pipeline_constants.service_ports.splunk_hec
+        scheme       = "https"
+        insecure_tls = true
       }
     ],
     # Proxmox cluster UI apex (the ingress subdomain apex), load-balanced.

--- a/ingress.tf
+++ b/ingress.tf
@@ -124,7 +124,7 @@ locals {
         # TLS entrypoint. HEC senders (the Cribl edges) must use this name:
         # splunk.<domain> resolves to Traefik, which serves nothing on a raw
         # 8088, so a sender dialing <name>:8088 black-holes. Same HTTPS
-        # self-signed backend treatment as the two routes above.
+        # self-signed backend treatment as the other Splunk routes above.
         name         = "splunk-hec"
         ip           = split("/", local.splunk_derived_ip)[0]
         port         = local.pipeline_constants.service_ports.splunk_hec


### PR DESCRIPTION
## Summary
- HEC senders previously dialed `splunk.<domain>:8088` — that alias resolves to Traefik, which serves nothing on a raw 8088, so every HEC POST from the Cribl edges black-holed (284 MB queue backlog; ansible-proxmox-apps#588).
- Adds a `splunk-hec` ingress entry on the standard TLS entrypoint, same HTTPS self-signed backend treatment as `splunk-mgmt`.

## Deploy order (after merge)
1. `terragrunt apply` (ingress output) → traefik + technitium_dns converges.
2. Repoint the `cribl_edge` splunk_hec output URL to `https://splunk-hec.<domain>/services/collector/event` (companion apps PR) and converge the edges — the queued backlog then drains.

## Testing
- `tofu fmt`/`validate` green; `tofu test`: 105 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLpU9zVuAPzC8aJLGAKhdj