### PR TITLE
chore(servarr-config): source secrets from OpenBao, not Doppler

### DIFF
--- a/.github/workflows/servarr-config-drift.yml
+++ b/.github/workflows/servarr-config-drift.yml
@@ -71,6 +71,17 @@ jobs:
         with:
           doppler-token: ${{ secrets.DOPPLER_TOKEN }}
 
+      - name: Fetch *arr secrets
+        # See scripts/fetch-openbao-secrets.sh for how this resolves the vars.
+        env:
+          BAO_ADDR: ${{ secrets.BAO_ADDR }}
+          MEDIA_VAULT_ROLE_ID: ${{ secrets.MEDIA_VAULT_ROLE_ID }}
+          MEDIA_VAULT_SECRET_ID: ${{ secrets.MEDIA_VAULT_SECRET_ID }}
+        run: |
+          ../scripts/fetch-openbao-secrets.sh media -- env \
+            | grep -E '^(SONARR_API_KEY|RADARR_API_KEY|QBITTORRENT_ADMIN_PASSWORD)=' \
+            >> "$GITHUB_ENV"
+
       - name: OpenTofu init (S3 backend)
         env:
           # The one read-only AWS account (read counterpart of the tf-proxmox
@@ -88,11 +99,12 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ steps.doppler.outputs.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ steps.doppler.outputs.AWS_SECRET_ACCESS_KEY }}
           TF_VAR_sonarr_url: ${{ steps.doppler.outputs.SONARR_URL }}
-          TF_VAR_sonarr_api_key: ${{ steps.doppler.outputs.SONARR_API_KEY }}
           TF_VAR_radarr_url: ${{ steps.doppler.outputs.RADARR_URL }}
-          TF_VAR_radarr_api_key: ${{ steps.doppler.outputs.RADARR_API_KEY }}
           TF_VAR_qbittorrent_host: ${{ steps.doppler.outputs.QBITTORRENT_HOST }}
-          TF_VAR_qbittorrent_password: ${{ steps.doppler.outputs.QBITTORRENT_ADMIN_PASSWORD }}
+          # These 3 came from OpenBao (previous step), not Doppler.
+          TF_VAR_sonarr_api_key: ${{ env.SONARR_API_KEY }}
+          TF_VAR_radarr_api_key: ${{ env.RADARR_API_KEY }}
+          TF_VAR_qbittorrent_password: ${{ env.QBITTORRENT_ADMIN_PASSWORD }}
         # -lock=false: a read-only drift plan must never block a real apply.
         run: tofu plan -input=false -lock=false -detailed-exitcode
 

--- a/scripts/fetch-openbao-secrets.sh
+++ b/scripts/fetch-openbao-secrets.sh
@@ -6,6 +6,12 @@
 # same script, two repos (no shared-script mechanism between them yet). If you
 # change one, change both.
 #
+# ponytail: iac-platform's scripts/openbao-exec-env.sh solves the identical
+# problem with the same curl+jq approach and left "extract a shared helper if
+# a 3rd consumer appears" as a deferred decision. This is that 3rd+ consumer —
+# extracting a shared helper (nix-devenv?) is a reasonable follow-up, not done
+# here to keep this change scoped.
+#
 # This is a drop-in link in the SAME chain as `doppler run --` — it sits
 # between it and whatever it wraps, and does exactly the same job: get
 # secrets into the process environment before the wrapped command starts.
@@ -47,7 +53,8 @@ shift
 shift
 [[ $# -lt 1 ]] && usage
 
-domain_env=$(printf '%s' "$domain" | tr '[:lower:]-' '[:upper:]_')
+domain_env="${domain^^}"
+domain_env="${domain_env//-/_}"
 
 role_id_var="${domain_env}_VAULT_ROLE_ID"
 secret_id_var="${domain_env}_VAULT_SECRET_ID"
@@ -59,11 +66,13 @@ if [[ -z "${BAO_ADDR:-}" || -z "$role_id" || -z "$secret_id" ]]; then
   exec "$@"
 fi
 
+login_payload=$(jq -n --arg r "$role_id" --arg s "$secret_id" '{role_id: $r, secret_id: $s}')
 login_resp=$(curl -sS -m 10 -X POST \
-  -d "{\"role_id\":\"$role_id\",\"secret_id\":\"$secret_id\"}" \
+  -H "Content-Type: application/json" \
+  -d "$login_payload" \
   "$BAO_ADDR/v1/auth/approle/login")
-client_token=$(printf '%s' "$login_resp" | jq -r '.auth.client_token // empty')
-unset login_resp role_id secret_id
+client_token=$(jq -r '.auth.client_token // empty' <<< "$login_resp")
+unset login_resp login_payload role_id secret_id
 
 if [[ -z "$client_token" ]]; then
   echo "fetch-openbao-secrets.sh: AppRole login failed for domain '$domain' — refusing to run with a possibly-stale environment. Check ${role_id_var}/${secret_id_var}." >&2
@@ -72,7 +81,11 @@ fi
 
 list_resp=$(curl -sS -m 10 -H "X-Vault-Token: $client_token" -X LIST \
   "$BAO_ADDR/v1/secret/metadata/apps/$domain")
-mapfile -t keys < <(printf '%s' "$list_resp" | jq -r '.data.keys[]? // empty')
+if jq -e '.errors | select(. != null and length > 0)' <<< "$list_resp" >/dev/null; then
+  echo "fetch-openbao-secrets.sh: failed to list secrets under apps/$domain: $(jq -r '.errors | join(", ")' <<< "$list_resp")" >&2
+  exit 1
+fi
+mapfile -t keys < <(jq -r '.data.keys[]? // empty' <<< "$list_resp")
 unset list_resp
 
 if [[ ${#keys[@]} -eq 0 ]]; then
@@ -82,12 +95,19 @@ fi
 for key in "${keys[@]}"; do
   data_resp=$(curl -sS -m 10 -H "X-Vault-Token: $client_token" \
     "$BAO_ADDR/v1/secret/data/apps/$domain/$key")
+  if ! jq -e '.data.data' <<< "$data_resp" >/dev/null; then
+    echo "fetch-openbao-secrets.sh: failed to read secret '$key' under apps/$domain" >&2
+    exit 1
+  fi
   # Export every field in this KV entry as its own env var (field names are
   # already the UPPER_SNAKE var names the apps expect, e.g. SONARR_API_KEY).
-  while IFS='=' read -r field_name field_value; do
-    [[ -z "$field_name" ]] && continue
+  # Null-terminated reads so multiline/embedded-'=' secret values survive intact.
+  while IFS= read -r -d '' entry; do
+    [[ -z "$entry" ]] && continue
+    field_name="${entry%%=*}"
+    field_value="${entry#*=}"
     export "$field_name=$field_value"
-  done < <(printf '%s' "$data_resp" | jq -r '.data.data // {} | to_entries[] | "\(.key)=\(.value)"')
+  done < <(jq -j '.data.data | to_entries[] | "\(.key)=\(.value)\u0000"' <<< "$data_resp")
   unset data_resp
 done
 unset client_token keys key

--- a/scripts/fetch-openbao-secrets.sh
+++ b/scripts/fetch-openbao-secrets.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Fetch a resource-domain's secrets from OpenBao and export them as plain
+# environment variables, then exec the wrapped command.
+#
+# KEEP IN SYNC with ansible-proxmox-apps/scripts/fetch-openbao-secrets.sh —
+# same script, two repos (no shared-script mechanism between them yet). If you
+# change one, change both.
+#
+# This is a drop-in link in the SAME chain as `doppler run --` — it sits
+# between it and whatever it wraps, and does exactly the same job: get
+# secrets into the process environment before the wrapped command starts.
+# Nothing downstream (a Terraform `TF_VAR_x`, a CI step) can tell OpenBao was
+# involved at all — swap this script for a different one and the config is
+# unchanged.
+#
+# Usage:
+#   fetch-openbao-secrets.sh <domain> -- <command> [args...]
+#
+# Reads from its OWN environment (supplied by whatever already-established
+# secret-zero layer wraps this script — Doppler today):
+#   BAO_ADDR                      - OpenBao API endpoint
+#   <DOMAIN>_VAULT_ROLE_ID        - AppRole role_id for this domain
+#   <DOMAIN>_VAULT_SECRET_ID      - AppRole secret_id for this domain
+# <DOMAIN> is the domain name, uppercased, hyphens turned to underscores
+# (e.g. "media" -> MEDIA) — matching the naming the ansible-proxmox-apps
+# roles/openbao_secrets role already uses for the same AppRoles.
+#
+# Discovers this domain's secret paths by LISTing secret/metadata/apps/<domain>
+# (the media AppRole's policy already grants read+list on that subtree) rather
+# than hardcoding a path list here — one fewer thing to keep in sync as new
+# app KV entries are added under a domain.
+#
+# SKIPS CLEANLY: if BAO_ADDR or this domain's role_id/secret_id envs are
+# unset, this is a no-op passthrough (execs the wrapped command unmodified).
+
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 <domain> -- <command> [args...]" >&2
+  exit 1
+}
+
+[[ $# -lt 1 ]] && usage
+domain="$1"
+shift
+[[ ${1:-} == "--" ]] || usage
+shift
+[[ $# -lt 1 ]] && usage
+
+domain_env=$(printf '%s' "$domain" | tr '[:lower:]-' '[:upper:]_')
+
+role_id_var="${domain_env}_VAULT_ROLE_ID"
+secret_id_var="${domain_env}_VAULT_SECRET_ID"
+role_id="${!role_id_var:-}"
+secret_id="${!secret_id_var:-}"
+
+if [[ -z "${BAO_ADDR:-}" || -z "$role_id" || -z "$secret_id" ]]; then
+  # Not configured for this domain yet — pass through unchanged.
+  exec "$@"
+fi
+
+login_resp=$(curl -sS -m 10 -X POST \
+  -d "{\"role_id\":\"$role_id\",\"secret_id\":\"$secret_id\"}" \
+  "$BAO_ADDR/v1/auth/approle/login")
+client_token=$(printf '%s' "$login_resp" | jq -r '.auth.client_token // empty')
+unset login_resp role_id secret_id
+
+if [[ -z "$client_token" ]]; then
+  echo "fetch-openbao-secrets.sh: AppRole login failed for domain '$domain' — refusing to run with a possibly-stale environment. Check ${role_id_var}/${secret_id_var}." >&2
+  exit 1
+fi
+
+list_resp=$(curl -sS -m 10 -H "X-Vault-Token: $client_token" -X LIST \
+  "$BAO_ADDR/v1/secret/metadata/apps/$domain")
+mapfile -t keys < <(printf '%s' "$list_resp" | jq -r '.data.keys[]? // empty')
+unset list_resp
+
+if [[ ${#keys[@]} -eq 0 ]]; then
+  echo "fetch-openbao-secrets.sh: no secrets found under apps/$domain — continuing with the existing environment unchanged." >&2
+fi
+
+for key in "${keys[@]}"; do
+  data_resp=$(curl -sS -m 10 -H "X-Vault-Token: $client_token" \
+    "$BAO_ADDR/v1/secret/data/apps/$domain/$key")
+  # Export every field in this KV entry as its own env var (field names are
+  # already the UPPER_SNAKE var names the apps expect, e.g. SONARR_API_KEY).
+  while IFS='=' read -r field_name field_value; do
+    [[ -z "$field_name" ]] && continue
+    export "$field_name=$field_value"
+  done < <(printf '%s' "$data_resp" | jq -r '.data.data // {} | to_entries[] | "\(.key)=\(.value)"')
+  unset data_resp
+done
+unset client_token keys key
+
+exec "$@"

--- a/servarr-config/README.md
+++ b/servarr-config/README.md
@@ -17,7 +17,7 @@ the main terragrunt workspace, so it never touches the cluster/container state.
 | `devopsarr/sonarr` provider | `~> 3.4` |
 | `devopsarr/radarr` provider | `~> 2.3` |
 | Network | the runner must reach the Sonarr/Radarr APIs (LAN/CI; not the VPN-locked Prowlarr) |
-| Secrets | Sonarr/Radarr API keys + qBittorrent password from the secret store |
+| Secrets | Sonarr/Radarr API keys + qBittorrent password, as environment variables (e.g. a local `.env`) |
 
 ## Scope (phase 1)
 
@@ -42,10 +42,10 @@ Out of scope for this module (owned elsewhere):
 ## Usage
 
 ```bash
-cp terraform.tfvars.example local.auto.tfvars   # gitignored; fill from secret store
+cp terraform.tfvars.example local.auto.tfvars   # gitignored; non-secret values only
 # bucket embeds the AWS account id, so it is passed at init (never committed):
 tofu init -backend-config="bucket=terraform-proxmox-state-useast2-$(aws sts get-caller-identity --query Account --output text)"
-tofu plan                                        # drift detection — exit 2 = drift
+tofu plan   # drift detection — exit 2 = drift
 ```
 
 State lives in S3 (`terraform-proxmox/servarr-config/terraform.tfstate`). The live
@@ -57,9 +57,14 @@ scheduled CI workflow was considered and rejected as disproportionate for a
 module this small (automating it against the LAN-only *arr APIs would need a
 self-hosted runner + a read-only state credential + an enable gate).
 
-Real values (URLs, API keys, qBittorrent password) come from the secret store
-(SOPS / Doppler / env), never committed. The example file uses RFC1918
-placeholders only.
+`sonarr_url`/`radarr_url`/`qbittorrent_host` are non-secret config (in
+`local.auto.tfvars`, gitignored). `sonarr_api_key`/`radarr_api_key`/
+`qbittorrent_password` are secrets, supplied as plain environment variables
+(`TF_VAR_sonarr_api_key`, etc.) — however you manage that (a `.env` you source
+locally, your CI's secret store, ...). `scripts/fetch-openbao-secrets.sh` is
+this homelab's own way of landing those env vars before `tofu` runs; swap it
+for anything that sets the same variables. The example file uses RFC1918
+placeholders only, never committed.
 
 ## Adopting an already-configured instance (import, don't clobber)
 
@@ -90,18 +95,19 @@ history) while the annotation still flags that drift coverage is off.
 
 It runs on the **self-hosted `terraform` runner** because the *arr APIs are on
 the homelab LAN. It is **off by default**; activation is gated on the repo
-variable `SERVARR_DRIFT_ENABLED` and these secrets, supplied via the same
-`dopplerhq/secrets-fetch-action` pattern the rest of CI uses:
+variable `SERVARR_DRIFT_ENABLED`. Required repo secrets/variables:
 
 | Where | Key | Note |
 | --- | --- | --- |
 | Repo variable | `SERVARR_DRIFT_ENABLED` | set to `true` to enable |
-| Repo secret | `DOPPLER_TOKEN` | Doppler service token (project + config scoped) |
-| Doppler | `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` | the **read-only** AWS account — the read counterpart of the `tf-proxmox` write role (one read role per write role). Plan runs `-lock=false`, so it needs S3 read only, no DynamoDB |
-| Doppler | `SONARR_URL`, `SONARR_API_KEY`, `RADARR_URL`, `RADARR_API_KEY` | *arr endpoints + keys |
-| Doppler | `QBITTORRENT_HOST`, `QBITTORRENT_ADMIN_PASSWORD` | download-client check |
-| Doppler | `AWS_ACCOUNT_ID` | already present; builds the bucket name (no aws CLI on the runner) |
-| Doppler | `NTFY_BASE_URL` | optional; without it, the job failure is the only signal |
+| Repo secret | `DOPPLER_TOKEN` | fetches the non-secret endpoints + AWS state credential |
+| Repo secret | `BAO_ADDR`, `MEDIA_VAULT_ROLE_ID`, `MEDIA_VAULT_SECRET_ID` | fetches `SONARR_API_KEY`/`RADARR_API_KEY`/`QBITTORRENT_ADMIN_PASSWORD` (see `scripts/fetch-openbao-secrets.sh`) |
+
+`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` are the **read-only** AWS account —
+the read counterpart of the `tf-proxmox` write role (one read role per write
+role). Plan runs `-lock=false`, so it needs S3 read only, no DynamoDB.
+`SONARR_URL`/`RADARR_URL`/`QBITTORRENT_HOST` and `NTFY_BASE_URL` (optional
+alerting) are plain config, not secrets.
 
 The read-only AWS account is the one genuinely new principal. It can read state
 (which contains the *arr keys), so keep it read-only — one shared read role


### PR DESCRIPTION
## Summary
- Consolidates three secret values (previously duplicated across Doppler and SOPS) into OpenBao's `media` domain, eliminating drift risk between stores.
- Adds `scripts/fetch-openbao-secrets.sh` (aligned with the copy in the sibling repo) and integrates it into the CI drift-detection workflow.
- Updates README to describe secrets generically (plain env vars) rather than naming the backend.
- Script hardened per review feedback to improve error handling and portability.

## Changes
- `.github/workflows/servarr-config-drift.yml` — wires in OpenBao secret fetch step (replaces Doppler fetch).
- `scripts/fetch-openbao-secrets.sh` — new script to authenticate to OpenBao and extract secrets.
- `servarr-config/README.md` — removed backend-specific language, documented as standard env-var consumption.

## Test Plan
- [x] Lint checks (pre-commit yaml/whitespace/hardcoded-secrets, shellcheck on script) pass.
- [x] `tofu plan` against live state shows zero changes — confirms OpenBao-sourced secrets match deployed config.
- [x] Live end-to-end verification: downstream apps authenticate successfully with OpenBao-sourced credentials.
- [ ] CI drift workflow activation blocked on three new repo secrets (`BAO_ADDR`, `MEDIA_VAULT_ROLE_ID`, `MEDIA_VAULT_SECRET_ID`); workflow remains gated behind `SERVARR_DRIFT_ENABLED` until configured.