### PR TITLE
feat(media): add Sortarr insights dashboard to ingress + port constants

### DIFF
--- a/constants.tf
+++ b/constants.tf
@@ -174,6 +174,7 @@ locals {
       radarr_web      = 7878
       plex_web        = 32400
       seerr_web       = 5055
+      sortarr_web     = 8787
     }
   }
 }

--- a/ingress.tf
+++ b/ingress.tf
@@ -14,6 +14,7 @@ locals {
     seerr            = { backend = "seerr", port = local.pipeline_constants.media_ports.seerr_web }
     sonarr           = { backend = "sonarr", port = local.pipeline_constants.media_ports.sonarr_web }
     radarr           = { backend = "radarr", port = local.pipeline_constants.media_ports.radarr_web }
+    sortarr          = { backend = "sortarr", port = local.pipeline_constants.media_ports.sortarr_web }
     qbittorrent      = { backend = "download-vpn", port = local.pipeline_constants.media_ports.qbittorrent_web }
     prowlarr         = { backend = "download-vpn", port = local.pipeline_constants.media_ports.prowlarr_web }
     technitium       = { backend = "technitium-dns", port = local.pipeline_constants.service_ports.technitium_web }


### PR DESCRIPTION
## Summary
- Adds `sortarr_web = 8787` to the `media_ports` constants (single source of truth for the port, consumed downstream by `ansible-proxmox-apps`).
- Adds the `sortarr` ingress route so `https://sortarr.<domain>` fronts the container's web UI, following the existing `seerr` pattern.

Sortarr ([Jaredharper1/Sortarr](https://github.com/Jaredharper1/Sortarr)) is a read-only media-library insights dashboard that overlays Sonarr/Radarr/Plex data — it never moves, renames, or deletes media.

Provisioning the actual Docker-in-LXC container is a private `deployment.json` addition (this repo's committed `deployment.json.example` intentionally contains no media apps today, matching the existing sonarr/radarr/seerr/plex precedent). The downstream Ansible deploy role is in a companion PR: dryvist/ansible-proxmox-apps#TBD.

## Test plan
- [x] `tofu fmt -check` — clean
- [x] `terragrunt validate` — succeeds
- [x] `tofu test` (via terragrunt) — 98 passed / 7 failed, identical pass/fail counts to unmodified `main` (the 7 failures are pre-existing environmental drift from real SOPS values vs. placeholder-expecting tests, unrelated to this change)
- [ ] After the private `deployment.json` gains the `sortarr` container entry: `terragrunt apply` provisions the LXC and republishes inventory, carrying the route to Traefik + DNS