### PR TITLE
feat(aws-infra): env-driven service-alias CNAMEs in the public zone

### DIFF
--- a/aws-infra/main.tf
+++ b/aws-infra/main.tf
@@ -28,6 +28,7 @@ module "route53_records" {
   proxmox_domain       = var.proxmox_domain
   proxmox_ip_address   = var.proxmox_ip_address
   proxmox_ip_addresses = var.proxmox_ip_addresses
+  route53_cnames       = var.route53_cnames
   dns_ttl              = var.dns_ttl
   environment          = var.environment
 }

--- a/aws-infra/modules/route53-records/main.tf
+++ b/aws-infra/modules/route53-records/main.tf
@@ -25,3 +25,18 @@ resource "aws_route53_record" "proxmox" {
     prevent_destroy = false # Set to true in production
   }
 }
+
+# Service-alias CNAMEs at the zone apex (e.g. a capability name pointing at
+# the host that serves it). Labels are relative to the hosted zone; values
+# arrive via ROUTE53_CNAMES (terragrunt env input), never as committed
+# literals. ACME DNS-01 clients that locate the hosted zone by stripping one
+# label need these aliases placed directly under the public zone.
+resource "aws_route53_record" "service_cnames" {
+  for_each = var.route53_cnames
+
+  zone_id = var.route53_zone_id
+  name    = each.key
+  type    = "CNAME"
+  ttl     = var.dns_ttl
+  records = [each.value]
+}

--- a/aws-infra/modules/route53-records/variables.tf
+++ b/aws-infra/modules/route53-records/variables.tf
@@ -51,6 +51,12 @@ variable "dns_ttl" {
   }
 }
 
+variable "route53_cnames" {
+  description = "Map of service-alias CNAME records: record label (relative to the zone) -> target FQDN"
+  type        = map(string)
+  default     = {}
+}
+
 variable "environment" {
   description = "Environment name for tagging and organization"
   type        = string

--- a/aws-infra/terragrunt.hcl
+++ b/aws-infra/terragrunt.hcl
@@ -36,6 +36,13 @@ inputs = {
   proxmox_ip_addresses = compact(split(",", get_env("PROXMOX_IP_ADDRESSES", get_env("PROXMOX_IP_ADDRESS", ""))))
   aws_region           = get_env("AWS_REGION", "us-east-1")
   environment          = get_env("ENVIRONMENT", "homelab")
+  # Service-alias CNAMEs: comma-separated "label=target.fqdn" pairs, e.g.
+  # ROUTE53_CNAMES="llm-large=host.example.com". Values live in Doppler so no
+  # hostname literal is committed.
+  route53_cnames = {
+    for pair in compact(split(",", get_env("ROUTE53_CNAMES", ""))) :
+    trimspace(split("=", pair)[0]) => trimspace(split("=", pair)[1])
+  }
 }
 
 # Terragrunt will generate provider.tf with AWS provider settings

--- a/aws-infra/terragrunt.hcl
+++ b/aws-infra/terragrunt.hcl
@@ -38,10 +38,13 @@ inputs = {
   environment          = get_env("ENVIRONMENT", "homelab")
   # Service-alias CNAMEs: comma-separated "label=target.fqdn" pairs, e.g.
   # ROUTE53_CNAMES="llm-large=host.example.com". Values live in Doppler so no
-  # hostname literal is committed.
+  # hostname literal is committed. Entries without "=" (including blank or
+  # whitespace-only fragments from stray commas) are ignored rather than
+  # crashing evaluation on an out-of-bounds index.
   route53_cnames = {
-    for pair in compact(split(",", get_env("ROUTE53_CNAMES", ""))) :
+    for pair in compact([for p in split(",", get_env("ROUTE53_CNAMES", "")) : trimspace(p)]) :
     trimspace(split("=", pair)[0]) => trimspace(split("=", pair)[1])
+    if strcontains(pair, "=")
   }
 }
 

--- a/aws-infra/variables.tf
+++ b/aws-infra/variables.tf
@@ -96,10 +96,11 @@ variable "route53_cnames" {
 
   validation {
     condition = alltrue([
-      for target in values(var.route53_cnames) :
-      can(regex("^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)*$", target))
+      for label, target in var.route53_cnames :
+      can(regex("^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$", lower(label)))
+      && can(regex("^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)*\\.?$", lower(target)))
     ])
-    error_message = "Every CNAME target must be a valid fully qualified domain name."
+    error_message = "Every CNAME entry must be a single record label mapped to a valid FQDN (optional trailing dot)."
   }
 }
 

--- a/aws-infra/variables.tf
+++ b/aws-infra/variables.tf
@@ -86,6 +86,23 @@ variable "dns_ttl" {
   }
 }
 
+# Service-alias CNAMEs at the public zone apex (name label -> target FQDN).
+# Values come from the ROUTE53_CNAMES environment variable via terragrunt —
+# no hostname literal is ever committed here.
+variable "route53_cnames" {
+  description = "Map of service-alias CNAME records: record label (relative to the zone) -> target FQDN"
+  type        = map(string)
+  default     = {}
+
+  validation {
+    condition = alltrue([
+      for target in values(var.route53_cnames) :
+      can(regex("^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)*$", target))
+    ])
+    error_message = "Every CNAME target must be a valid fully qualified domain name."
+  }
+}
+
 # General
 
 variable "environment" {


### PR DESCRIPTION
## Summary
- New `route53_cnames` map — parsed from the `ROUTE53_CNAMES` env var by terragrunt (comma-separated `label=target` pairs) — creates CNAME records at the hosted-zone apex.
- First consumer: the `llm-large` capability alias for the Studio serving gate. Its Caddy route53 ACME client locates the hosted zone by stripping one label, so the alias must live directly under the public zone (the gate's cert already covers it); the router pool then dials the alias with valid TLS.
- Values live in Doppler; no hostname literal is committed.

## Testing
- `tofu fmt`/`validate` green; full `tofu test` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLpU9zVuAPzC8aJLGAKhdj