### PR TITLE
fix(ci): mask *arr secrets and use heredoc GITHUB_ENV writes in drift workflow

### DIFF
--- a/.github/workflows/servarr-config-drift.yml
+++ b/.github/workflows/servarr-config-drift.yml
@@ -73,14 +73,22 @@ jobs:
 
       - name: Fetch *arr secrets
         # See scripts/fetch-openbao-secrets.sh for how this resolves the vars.
+        # Each value is masked before it ever reaches $GITHUB_ENV, and each
+        # write uses the heredoc-delimiter form with a random delimiter so a
+        # secret containing a literal EOF marker can't inject extra env vars.
         env:
           BAO_ADDR: ${{ secrets.BAO_ADDR }}
           MEDIA_VAULT_ROLE_ID: ${{ secrets.MEDIA_VAULT_ROLE_ID }}
           MEDIA_VAULT_SECRET_ID: ${{ secrets.MEDIA_VAULT_SECRET_ID }}
         run: |
-          ../scripts/fetch-openbao-secrets.sh media -- env \
-            | grep -E '^(SONARR_API_KEY|RADARR_API_KEY|QBITTORRENT_ADMIN_PASSWORD)=' \
-            >> "$GITHUB_ENV"
+          while IFS='=' read -r name value; do
+            echo "::add-mask::${value}"
+            delimiter="EOF_$(uuidgen)"
+            echo "${name}<<${delimiter}" >> "$GITHUB_ENV"
+            echo "${value}" >> "$GITHUB_ENV"
+            echo "${delimiter}" >> "$GITHUB_ENV"
+          done < <(../scripts/fetch-openbao-secrets.sh media -- env \
+            | grep -E '^(SONARR_API_KEY|RADARR_API_KEY|QBITTORRENT_ADMIN_PASSWORD)=')
 
       - name: OpenTofu init (S3 backend)
         env:


### PR DESCRIPTION
## Summary
- Mask each *arr secret (`SONARR_API_KEY`, `RADARR_API_KEY`, `QBITTORRENT_ADMIN_PASSWORD`) with `::add-mask::` before it is written to `$GITHUB_ENV`, so any future step that echoes it can't leak cleartext.
- Write each `$GITHUB_ENV` entry using the heredoc-delimiter form with a random delimiter (`EOF_$(uuidgen)`) instead of a bare `KEY=value` append, closing the multiline-injection gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Assisted-by: Claude:sonnet-5
Claude-Session: https://claude.ai/code/session_01KYQyqzesxqG5L46ozuVf4K