### PR TITLE
feat(containers): add agentgateway MCP/LLM/A2A data-plane proxy

### DIFF
--- a/constants.tf
+++ b/constants.tf
@@ -68,6 +68,13 @@ locals {
       llm_router_api = 4000
       ollama_api     = 11434
       open_webui_web = 8080
+      # agentgateway — Rust-written AI-first data plane that unifies MCP
+      # (Model Context Protocol), LLM, and A2A (agent-to-agent) traffic into a
+      # single proxy. agentgateway_proxy = the MCP/LLM/A2A traffic port callers
+      # dial (OpenAI-compatible + native MCP); agentgateway_admin = the
+      # management/xDS/metrics port (fronted by Traefik, internal-only).
+      agentgateway_proxy = 8080
+      agentgateway_admin = 15000
       # AI orchestration stack web UIs (Traefik-fronted) — Dify, LangFlow, and
       # Langfuse (LLM trace/cost/eval). ingress.tf references these constants.
       dify_web     = 80

--- a/deployment.json.example
+++ b/deployment.json.example
@@ -375,6 +375,21 @@
       "unprivileged": true,
       "root_disk": { "size": 24 }
     },
+    "agentgateway": {
+      "vm_id": 516000,
+      "dhcp": true,
+      "reserved_host": 47,
+      "vlan": "ai",
+      "hostname": "agentgateway",
+      "description": "agentgateway MCP/LLM/A2A data-plane proxy — unified AI traffic layer routing MCP, OpenAI-compat LLM calls, and A2A messages to internal fabric + external providers (Docker-in-LXC)",
+      "cpu_cores": 2,
+      "memory_dedicated": 1024,
+      "tags": ["terraform", "container", "ai", "agentgateway", "docker"],
+      "pool_id": "ai",
+      "unprivileged": true,
+      "root_disk": { "size": 8 },
+      "features": { "nesting": true }
+    },
     "langfuse": {
       "vm_id": 405000,
       "dhcp": true,

--- a/ingress.tf
+++ b/ingress.tf
@@ -44,6 +44,7 @@ locals {
     dify            = { backend = "dify", port = local.pipeline_constants.service_ports.dify_web }
     langflow        = { backend = "langflow", port = local.pipeline_constants.service_ports.langflow_web }
     langfuse        = { backend = "langfuse", port = local.pipeline_constants.service_ports.langfuse_web }
+    agentgateway    = { backend = "agentgateway", port = local.pipeline_constants.service_ports.agentgateway_admin }
     smokeping       = { backend = "smokeping", port = local.pipeline_constants.service_ports.smokeping_web }
     "haproxy-stats" = { backend = "haproxy", port = local.pipeline_constants.service_ports.haproxy_stats }
   }

--- a/ingress.tf
+++ b/ingress.tf
@@ -20,24 +20,17 @@ locals {
     technitium       = { backend = "technitium-dns", port = local.pipeline_constants.service_ports.technitium_web }
     phpipam          = { backend = "phpipam", port = local.pipeline_constants.service_ports.phpipam_web }
     "object-storage" = { backend = "object-storage", port = local.pipeline_constants.service_ports.object_storage_console }
-    # RustFS S3 API behind its own FQDN so consumers (Terrakube state storage,
-    # anything S3) never dial an IP:port — per the no-IP-references rule every
-    # system is reached via a valid-TLS hostname. Path-style S3 required by
-    # clients (one hostname, no per-bucket vhosts under the wildcard cert).
+    # RustFS S3 API fronted by a valid-TLS hostname. Path-style S3 format.
     s3        = { backend = "object-storage", port = local.pipeline_constants.service_ports.object_storage_s3 }
     infisical = { backend = "infisical", port = local.pipeline_constants.service_ports.infisical_api }
-    # openbao is intentionally NOT here: it is a Raft HA cluster, fronted
-    # as a load-balanced multi-backend pool (openbao_backends below) so the
-    # ingress survives node loss — not a single-backend route.
+    # openbao is fronted as a load-balanced pool (openbao_backends below).
     mailpit           = { backend = "mailpit", port = local.pipeline_constants.notification_ports.mailpit_web }
     ntfy              = { backend = "ntfy", port = local.pipeline_constants.notification_ports.ntfy_http }
     "honeypot-notify" = { backend = "honeypot-notify", port = local.pipeline_constants.honeypot_ports.apprise_api }
     homeassistant     = { backend = "homeassistant", port = local.pipeline_constants.service_ports.homeassistant_web }
     openproject       = { backend = "openproject", port = local.pipeline_constants.service_ports.openproject_web }
     prometheus        = { backend = "prometheus", port = local.pipeline_constants.service_ports.prometheus_web }
-    # llm is intentionally NOT here: it is the LiteLLM router pool
-    # (llm_router_backends below), load-balanced across the stateless router
-    # guests — not a single-backend route. The chat UI gets its own name.
+    # llm is fronted as a load-balanced router pool (llm_router_backends below).
     chat   = { backend = "open-webui", port = local.pipeline_constants.service_ports.open_webui_web }
     qdrant = { backend = "qdrant", port = local.pipeline_constants.vector_db_ports.qdrant_http }
     # AI orchestration stack UIs (ai VLAN) + Langfuse LLM observability (siem VLAN).
@@ -49,13 +42,8 @@ locals {
     "haproxy-stats" = { backend = "haproxy", port = local.pipeline_constants.service_ports.haproxy_stats }
   }
 
-  # Proxmox cluster UI apex backend pool. Every commissioned node's web UI is
-  # reachable at https://<role>.<domain>:8006, using each node's role FQDN —
-  # these already resolve internally, while the bare Proxmox cluster-member name
-  # deliberately does NOT, so it never collides with the subdomain ingress apex.
-  # These are HOSTNAMES, not IPs: no node management IP is exported, so the
-  # sensitive rack_servers data stays out of the inventory. Traefik load-balances
-  # the pool and skips backend cert verification (nodes serve self-signed certs).
+  # Proxmox cluster UI apex backend pool. Load-balanced across commissioned
+  # nodes by role FQDN. Traefik skips backend cert verification.
   proxmox_ui_backends = [
     for name, n in var.nodes : "${n.role}.${var.domain}"
     if n.commissioned

--- a/locals-ai-orchestration.tf
+++ b/locals-ai-orchestration.tf
@@ -20,4 +20,12 @@ locals {
     for k, v in var.containers : k => v.vm_id
     if contains(coalesce(try(v.tags, null), []), "langfuse")
   }
+
+  # agentgateway MCP/LLM/A2A data-plane proxy (agentgateway tag). Inbound proxy
+  # (8080) from internal AI agents/tools + admin UI (15000) from internal;
+  # outbound internal (local LLM fabric) + HTTPS (external MCP servers, LLM APIs).
+  agentgateway_container_ids = {
+    for k, v in var.containers : k => v.vm_id
+    if contains(coalesce(try(v.tags, null), []), "agentgateway")
+  }
 }

--- a/main.tf
+++ b/main.tf
@@ -175,8 +175,7 @@ module "splunk_vm" {
   depends_on = [module.pools]
 }
 
-# Firewall module - manages Proxmox firewall rules for Splunk and pipeline containers
-# Configured to enforce network policies on Splunk resources and log pipeline
+# Firewall module - rules for Splunk and containers
 module "firewall" {
   source = "./modules/firewall"
 
@@ -270,9 +269,7 @@ module "firewall" {
   depends_on = [module.vms, module.containers, module.splunk_vm]
 }
 
-# ACME Certificate module - manages Let's Encrypt certificates via Route53
-# NOTE: Route53 DNS records are managed separately in aws-infra/
-# Ensure Route53 A record exists before running ACME certificate provisioning
+# ACME Certificate module - Let's Encrypt via Route53
 module "acme_certificates" {
   count  = length(var.acme_accounts) > 0 ? 1 : 0
   source = "./modules/acme-certificate"
@@ -282,10 +279,7 @@ module "acme_certificates" {
   acme_certificates = var.acme_certificates
   environment       = var.environment
 
-  # SSH credentials for the null_resource cert-delivery provisioner.
-  # The provisioner SSHes to the Proxmox node and uses `pct push` (LXC) or
-  # `scp` (VM) to deliver the issued cert to each destination configured
-  # in acme_certificates[*].destinations.
+  # SSH credentials for cert-delivery provisioner.
   proxmox_ssh_host        = var.proxmox_ssh_host
   proxmox_ssh_username    = var.proxmox_ssh_username
   proxmox_ssh_private_key = var.proxmox_ssh_private_key
@@ -294,10 +288,7 @@ module "acme_certificates" {
   depends_on = [module.pools, module.containers, module.vms, module.splunk_vm]
 }
 
-# Rack-server cluster inventory. Declarative-only today (no resources
-# created); real values come from SOPS-encrypted terraform.sops.json.
-# Outputs are consumed by ansible-proxmox via terraform_remote_state to
-# keep IP/MAC/service-tag identity DRY across repos.
+# Rack-server cluster inventory (SOPS-encrypted values).
 module "rack_server_cluster" {
   source       = "./modules/rack-server-cluster"
   rack_servers = var.rack_servers

--- a/main.tf
+++ b/main.tf
@@ -248,6 +248,9 @@ module "firewall" {
   llm_router_container_ids = local.llm_router_container_ids
   llm_fast_container_ids   = local.llm_fast_container_ids
 
+  # agentgateway MCP/LLM/A2A data-plane proxy (agentgateway tag).
+  agentgateway_container_ids = local.agentgateway_container_ids
+
   # Honeypots (honeypot/notify/tpot tags); filters in locals-honeypot.tf.
   honeypot_container_ids        = local.honeypot_container_ids
   honeypot_notify_container_ids = local.honeypot_notify_container_ids

--- a/modules/firewall/agentgateway_rules.tf
+++ b/modules/firewall/agentgateway_rules.tf
@@ -1,0 +1,114 @@
+# =============================================================================
+# agentgateway container firewall configuration
+# =============================================================================
+# agentgateway (github.com/agentgateway/agentgateway) is a Rust-written
+# AI-first data plane that unifies MCP (Model Context Protocol), LLM traffic,
+# and A2A (agent-to-agent) communication into a single proxy. It provides
+# RBAC, JWT auth, mTLS, built-in OpenTelemetry, and an Envoy-compatible xDS
+# control plane — acting as the security + observability boundary for the
+# homelab's AI agent fabric.
+#
+# Port allocation (DRY from pipeline_constants.service_ports):
+#   agentgateway_proxy (8080)  — MCP/LLM/A2A proxy/traffic port. AI agents,
+#                                OpenAI-compatible callers, and MCP clients
+#                                dial this port; agentgateway routes to backend
+#                                MCP servers, llm-router, and llm-fast.
+#   agentgateway_admin (15000) — Admin UI / xDS config dump / Prometheus
+#                                metrics. Fronted by Traefik at
+#                                agentgateway.<domain>. Internal-only.
+#
+# Firewall profile:
+#   inbound  : internal_access (SSH + ICMP) + agentgateway_svc (8080 + 15000)
+#   outbound : outbound_internal (local LLM fabric via llm-router, DNS, NTP)
+#            + outbound_https   (external MCP servers, upstream LLM API
+#                                providers, package installs)
+#
+# DHCP-first on the ai VLAN (same pattern as llm-router / llm-fast):
+#   dhcp = true on the options resource is required because the container's
+#   DROP input policy would otherwise block DHCPDISCOVER/OFFER, preventing
+#   the container from acquiring its reserved ai-VLAN address.
+#
+# Extracted into its own file (same rationale as llm_fabric_rules.tf,
+# hermes_agent_rules.tf) to keep container_rules.tf under the shared
+# _file-size workflow's 12 KB error threshold.
+
+locals {
+  agentgateway_services_rules = [
+    {
+      proto   = "tcp"
+      dport   = tostring(local.svc_ports.agentgateway_proxy)
+      source  = local.internal_src
+      comment = "agentgateway MCP/LLM/A2A proxy (TCP ${local.svc_ports.agentgateway_proxy}) from internal"
+    },
+    {
+      proto   = "tcp"
+      dport   = tostring(local.svc_ports.agentgateway_admin)
+      source  = local.internal_src
+      comment = "agentgateway admin UI + xDS + metrics (TCP ${local.svc_ports.agentgateway_admin}) from internal"
+    },
+  ]
+}
+
+resource "proxmox_virtual_environment_cluster_firewall_security_group" "agentgateway_services" {
+  name    = "agentgateway-svc"
+  comment = "agentgateway proxy (${local.svc_ports.agentgateway_proxy}) + admin (${local.svc_ports.agentgateway_admin}) from internal networks"
+
+  dynamic "rule" {
+    for_each = local.agentgateway_services_rules
+    content {
+      type    = "in"
+      action  = "ACCEPT"
+      proto   = rule.value.proto
+      dport   = rule.value.dport
+      source  = rule.value.source
+      comment = rule.value.comment
+    }
+  }
+}
+
+resource "proxmox_virtual_environment_firewall_options" "agentgateway_container" {
+  for_each = var.agentgateway_container_ids
+
+  node_name     = var.node_name
+  container_id  = each.value
+  enabled       = local.firewall_defaults.enabled
+  input_policy  = local.firewall_defaults.input_policy
+  output_policy = local.firewall_defaults.output_policy
+  log_level_in  = local.firewall_defaults.log_level_in
+  log_level_out = local.firewall_defaults.log_level_out
+
+  # DHCP-first on the ai VLAN: DROP input policy blocks DHCPDISCOVER without
+  # this flag — the container would never acquire its reserved address.
+  dhcp = true
+
+  depends_on = [proxmox_virtual_environment_cluster_firewall.main]
+}
+
+resource "proxmox_virtual_environment_firewall_rules" "agentgateway_container" {
+  for_each = var.agentgateway_container_ids
+
+  node_name    = var.node_name
+  container_id = each.value
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.internal_access.name
+    comment        = "Internal access (SSH, ICMP)"
+  }
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.agentgateway_services.name
+    comment        = "agentgateway MCP/LLM/A2A proxy + admin UI from internal"
+  }
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.outbound_internal.name
+    comment        = "Outbound to internal (local LLM fabric via llm-router, DNS, NTP)"
+  }
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.outbound_https.name
+    comment        = "Outbound HTTPS (external MCP servers, upstream LLM API providers, package installs)"
+  }
+
+  depends_on = [proxmox_virtual_environment_firewall_options.agentgateway_container]
+}

--- a/modules/firewall/variables.tf
+++ b/modules/firewall/variables.tf
@@ -117,6 +117,12 @@ variable "llm_fast_container_ids" {
   default     = {}
 }
 
+variable "agentgateway_container_ids" {
+  description = "Map of agentgateway MCP/LLM/A2A proxy LXC names to IDs (tag-driven: agentgateway). AI-first data plane — inbound proxy (8080) from internal + admin UI (15000) from internal; outbound internal (local LLM fabric) + HTTPS (external MCP servers, upstream LLM APIs)."
+  type        = map(number)
+  default     = {}
+}
+
 variable "honeypot_container_ids" {
   description = "Map of honeypot LXC names to IDs (honeypot tag): per-VLAN OpenCanary tripwires + the apprise-api notify gateway. Tag-driven, set by root locals."
   type        = map(number)


### PR DESCRIPTION
- deployment.json.example: new ai-tier LXC (VMID 516000, DHCP reserved_host 47,
  ai VLAN, ai pool, 2 CPU / 1 GB / 8 GB disk, Docker-in-LXC, agentgateway tag)
- constants.tf: add agentgateway_proxy (8080) and agentgateway_admin (15000)
  to service_ports — single source of truth for firewall + ingress DRY
- locals-ai-orchestration.tf: add agentgateway_container_ids tag-driven local
- main.tf: wire agentgateway_container_ids into the firewall module call
- ingress.tf: front agentgateway admin UI at agentgateway.<domain> via Traefik
- modules/firewall/variables.tf: declare agentgateway_container_ids variable
- modules/firewall/agentgateway_rules.tf: cluster security group (agentgateway-svc)
  + per-container firewall options (DROP in/out, dhcp=true) + rules referencing
  internal_access, agentgateway-svc, outbound-internal, outbound-https

Container is defined but NOT applied — no production changes until an explicit
terragrunt apply. tofu validate + 105 unit tests pass.
