### PR TITLE
fix(firewall): allow DHCP on hermes-agent so it leases behind DROP

### DIFF
--- a/modules/firewall/hermes_agent_rules.tf
+++ b/modules/firewall/hermes_agent_rules.tf
@@ -29,6 +29,13 @@ resource "proxmox_virtual_environment_firewall_options" "hermes_agent_container"
   log_level_in  = local.firewall_defaults.log_level_in
   log_level_out = local.firewall_defaults.log_level_out
 
+  # hermes-agent is a DHCP-first guest (no static ip_config; leases its reserved
+  # ai-VLAN address by MAC). Behind DROP in/out policies it needs its own
+  # DHCPDISCOVER/OFFER allowed or it never leases — same reason as
+  # ai_orchestration_rules.tf. (Previously supplied by the ai-orchestration tag;
+  # required here now that hermes_agent is the sole manager of this ruleset.)
+  dhcp = true
+
   depends_on = [proxmox_virtual_environment_cluster_firewall.main]
 }
 


### PR DESCRIPTION
## What

Add `dhcp = true` to the `hermes_agent_container` firewall_options resource.

## Why

`hermes-agent` (VMID 517000) has no static `ip_config` — it is a DHCP-first guest that leases its reserved ai-VLAN address (10.0.50.46) by MAC. Behind the DROP input/output firewall policies, the guest needs its own DHCPDISCOVER/OFFER allowed or it never leases.

This allowance was previously supplied by the `ai-orchestration` tag's firewall_options resource. `hermes-agent` is being changed (in the private `deployment.json`) to drop the `ai-orchestration` tag so the purpose-built `hermes_agent` firewall group becomes the **sole** manager of its ruleset — ending a two-resources-fighting-one-ruleset conflict. Once that tag is gone, the `dhcp = true` allowance must live in the `hermes_agent` group, or the next apply would flip the live container's `dhcp` off and risk breaking its lease.

Mirrors the identical `dhcp = true` rationale already documented in `ai_orchestration_rules.tf`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)