### PR TITLE
feat(dr): ingress VRRP HA + deployment.json S3 fetch failover

### DIFF
--- a/constants.tf
+++ b/constants.tf
@@ -120,6 +120,14 @@ locals {
     netflow_ports = {
       unifi = 2055
     }
+    # Ingress HA (keepalived VRRP). keepalived_vrid is the VRRP virtual_router_id
+    # the two Traefik instances share to elect a master for the ingress VIP —
+    # cluster-unique (no other VRRP group on these VLANs) and referenced by the
+    # keepalived role via the inventory, never hardcoded there. VRRP is IP
+    # protocol 112 and carries no L4 port, so there is no port constant here.
+    ingress_ports = {
+      keepalived_vrid = 51
+    }
     notification_ports = {
       mailpit_smtp = 1025
       mailpit_web  = 8025

--- a/deployment.json.example
+++ b/deployment.json.example
@@ -188,6 +188,31 @@
       "pool_id": "infrastructure",
       "root_disk": { "size": 8 }
     },
+    "_ingress_ha_comment": "Ingress is HA: two identical Traefik LXCs on DIFFERENT nodes carry the `ingress` tag; keepalived floats one VRRP virtual IP across them (ingress.tf derives ingress_vip/ingress_hosts from the `ingress` tag + network_cidrs). Add a THIRD ingress node by copying the block and bumping vm_id/node_name — no code change. DNS points every fronted service at the VIP, so a node loss migrates the VIP automatically.",
+    "traefik": {
+      "vm_id": 101,
+      "vlan": "mgmt",
+      "hostname": "traefik",
+      "description": "Traefik reverse proxy / TLS ingress (HA instance 1)",
+      "cpu_cores": 1,
+      "memory_dedicated": 512,
+      "tags": ["terraform", "container", "ingress", "traefik"],
+      "pool_id": "infrastructure",
+      "node_name": "proxmox-1",
+      "root_disk": { "size": 8 }
+    },
+    "traefik-2": {
+      "vm_id": 107,
+      "vlan": "mgmt",
+      "hostname": "traefik-2",
+      "description": "Traefik reverse proxy / TLS ingress (HA instance 2 — keepalived VRRP peer)",
+      "cpu_cores": 1,
+      "memory_dedicated": 512,
+      "tags": ["terraform", "container", "ingress", "traefik"],
+      "pool_id": "infrastructure",
+      "node_name": "proxmox-2",
+      "root_disk": { "size": 8 }
+    },
     "_smokeping_comment": "Network-quality monitoring — Prometheus-native stack (Docker-in-LXC). The central `smokeping` collector runs smokeping_prober (:9374, ICMP/UDP latency-distribution histograms = system of record), blackbox_exporter (:9115, DNS/HTTP/TLS/TCP + SLO probes), atlas_exporter (:9400, RIPE Atlas outside-in), an irtt server (:2112/udp, real RFC-3393 jitter/MOS), and optionally the classic SmokePing RRD/CGI UI (:80). Throughput is DECOUPLED onto its own `speedtest` host so saturation never corrupts latency samples. Add a per-segment `netq-probe-*` vantage on each VLAN you care about (multi-vantage) — one example below. See docs/SMOKEPING.md for the full blueprint the ansible-proxmox-apps roles apply. These adopt the 6-digit positional VMID + DNS-first convention (docs.jacobpevans.com/infrastructure/vmid-network-tiers): observability = tier 4, so VMIDs are 41xxxx; `dhcp:true` means no vm_id-derived IP — DHCP leases the address and each guest is reached by {hostname}.{domain}. `vlan` stays at today's value during the incremental tier renumber.",
     "smokeping": {
       "vm_id": 410000,

--- a/deployment.json.example
+++ b/deployment.json.example
@@ -188,7 +188,7 @@
       "pool_id": "infrastructure",
       "root_disk": { "size": 8 }
     },
-    "_ingress_ha_comment": "Ingress is HA: two identical Traefik LXCs on DIFFERENT nodes carry the `ingress` tag; keepalived floats one VRRP virtual IP across them (ingress.tf derives ingress_vip/ingress_hosts from the `ingress` tag + network_cidrs). Add a THIRD ingress node by copying the block and bumping vm_id/node_name — no code change. DNS points every fronted service at the VIP, so a node loss migrates the VIP automatically.",
+    "_ingress_ha_comment": "Ingress is HA: identical Traefik LXCs on DIFFERENT nodes carry the `ingress` tag; keepalived floats one VRRP virtual IP across them (ingress.tf derives ingress_vip/ingress_hosts from the `ingress` tag + network_cidrs). A VIP is synthesized only with at least two ingress nodes; add another by copying the block and bumping vm_id/node_name — no code change. DNS points every fronted service at the VIP, so a node loss migrates the VIP automatically.",
     "traefik": {
       "vm_id": 101,
       "vlan": "mgmt",

--- a/ingress.tf
+++ b/ingress.tf
@@ -42,36 +42,10 @@ locals {
     "haproxy-stats" = { backend = "haproxy", port = local.pipeline_constants.service_ports.haproxy_stats }
   }
 
-  # --- Ingress HA (keepalived VRRP virtual IP) --------------------------------
-  # Traefik is no longer a single-node SPOF: every LXC tagged "ingress" runs an
-  # identical Traefik instance, and keepalived floats ONE virtual IP across them
-  # (unicast VRRP). DNS points every fronted service at this VIP (see the
-  # technitium_dns role), so a node loss migrates the VIP to a surviving Traefik
-  # with zero manual action. Both instances always run and each fetches its own
-  # ACME cert independently (no shared acme.json state to coordinate).
-  #
-  # ingress_vip_host: the reserved HOST OCTET for the VIP inside the ingress
-  # VLAN. It is NOT a literal IP — the address is derived via cidrhost() from the
-  # Doppler-sourced network_cidrs, so the real subnet never appears in-repo.
-  # Reserved-octet map for the ingress (mgmt) VLAN: .1 gateway, .4/.5 openbao,
-  # .33 unifi-metrics, .101/.107 the two Traefik LXCs (vm_id-derived). .2 is
-  # carved out here for the ingress VIP and must stay out of the DHCP pool.
-  ingress_vip_host = 2
-  ingress_container_keys = sort([
-    for k, v in var.containers : k
-    if contains(coalesce(try(v.tags, null), []), "ingress")
-  ])
-  # VLAN taken from the ingress containers themselves, so the VIP follows a VLAN
-  # move automatically instead of pinning a hardcoded key. Falls back to "mgmt"
-  # only when no ingress container is deployed (VIP then resolves to "").
-  ingress_vlan = try(var.containers[local.ingress_container_keys[0]].vlan, "mgmt")
-  ingress_vip = length(local.ingress_container_keys) > 0 ? nonsensitive(
-    cidrhost(var.network_cidrs[local.ingress_vlan], local.ingress_vip_host)
-  ) : ""
-  # Advertised address of each ingress instance — the keepalived unicast_peer
-  # list. Same container_address shape (static host IP / DNS-first FQDN) as every
-  # other backend pool.
-  ingress_hosts = [for k in local.ingress_container_keys : local.container_address[k]]
+  # Ingress HA (keepalived VRRP VIP) locals — ingress_vip / ingress_hosts /
+  # ingress_container_keys — live in locals-ingress-ha.tf so this file stays under
+  # the shared _file-size workflow's 12 KB error threshold (locals merge across
+  # files in the module, same split as locals-honeypot.tf / locals-vm-network.tf).
 
   # Proxmox cluster UI apex backend pool. Load-balanced across commissioned
   # nodes by role FQDN. Traefik skips backend cert verification.

--- a/ingress.tf
+++ b/ingress.tf
@@ -42,6 +42,37 @@ locals {
     "haproxy-stats" = { backend = "haproxy", port = local.pipeline_constants.service_ports.haproxy_stats }
   }
 
+  # --- Ingress HA (keepalived VRRP virtual IP) --------------------------------
+  # Traefik is no longer a single-node SPOF: every LXC tagged "ingress" runs an
+  # identical Traefik instance, and keepalived floats ONE virtual IP across them
+  # (unicast VRRP). DNS points every fronted service at this VIP (see the
+  # technitium_dns role), so a node loss migrates the VIP to a surviving Traefik
+  # with zero manual action. Both instances always run and each fetches its own
+  # ACME cert independently (no shared acme.json state to coordinate).
+  #
+  # ingress_vip_host: the reserved HOST OCTET for the VIP inside the ingress
+  # VLAN. It is NOT a literal IP — the address is derived via cidrhost() from the
+  # Doppler-sourced network_cidrs, so the real subnet never appears in-repo.
+  # Reserved-octet map for the ingress (mgmt) VLAN: .1 gateway, .4/.5 openbao,
+  # .33 unifi-metrics, .101/.107 the two Traefik LXCs (vm_id-derived). .2 is
+  # carved out here for the ingress VIP and must stay out of the DHCP pool.
+  ingress_vip_host = 2
+  ingress_container_keys = sort([
+    for k, v in var.containers : k
+    if contains(coalesce(try(v.tags, null), []), "ingress")
+  ])
+  # VLAN taken from the ingress containers themselves, so the VIP follows a VLAN
+  # move automatically instead of pinning a hardcoded key. Falls back to "mgmt"
+  # only when no ingress container is deployed (VIP then resolves to "").
+  ingress_vlan = try(var.containers[local.ingress_container_keys[0]].vlan, "mgmt")
+  ingress_vip = length(local.ingress_container_keys) > 0 ? nonsensitive(
+    cidrhost(var.network_cidrs[local.ingress_vlan], local.ingress_vip_host)
+  ) : ""
+  # Advertised address of each ingress instance — the keepalived unicast_peer
+  # list. Same container_address shape (static host IP / DNS-first FQDN) as every
+  # other backend pool.
+  ingress_hosts = [for k in local.ingress_container_keys : local.container_address[k]]
+
   # Proxmox cluster UI apex backend pool. Load-balanced across commissioned
   # nodes by role FQDN. Traefik skips backend cert verification.
   proxmox_ui_backends = [

--- a/inventory_publish.tf
+++ b/inventory_publish.tf
@@ -78,6 +78,12 @@ locals {
     # The ansible-proxmox-apps traefik + technitium_dns roles derive their routers
     # and DNS aliases from this single source instead of hand-listing hosts.
     ingress = local.ingress
+    # Ingress HA: the keepalived VRRP virtual IP every fronted service DNS record
+    # points at, and the list of ingress-instance addresses (keepalived
+    # unicast_peer members). Empty vip + <2 hosts => the keepalived role no-ops,
+    # so a single-ingress or partial deployment stays valid.
+    ingress_vip   = local.ingress_vip
+    ingress_hosts = local.ingress_hosts
     # Host-level NAS service config - consumed by ansible-proxmox to provision ZFS dataset + Samba
     host_services = var.host_services
     # Cluster node inventory (non-secret identity) - ansible-proxmox targets hosts and

--- a/locals-ingress-ha.tf
+++ b/locals-ingress-ha.tf
@@ -26,7 +26,11 @@ locals {
   # move automatically instead of pinning a hardcoded key. Falls back to "mgmt"
   # only when no ingress container is deployed (VIP then resolves to "").
   ingress_vlan = try(var.containers[local.ingress_container_keys[0]].vlan, "mgmt")
-  ingress_vip = length(local.ingress_container_keys) > 0 ? nonsensitive(
+  # A VIP is only synthesized with >= 2 ingress instances. With a single (or zero)
+  # ingress node keepalived never binds the VIP, so publishing it would black-hole
+  # DNS (technitium points fronted services at an unbound address). Empty here lets
+  # the technitium_dns role fall back to the single Traefik host's own IP.
+  ingress_vip = length(local.ingress_container_keys) > 1 ? nonsensitive(
     cidrhost(var.network_cidrs[local.ingress_vlan], local.ingress_vip_host)
   ) : ""
   # Advertised address of each ingress instance — the keepalived unicast_peer

--- a/locals-ingress-ha.tf
+++ b/locals-ingress-ha.tf
@@ -1,0 +1,36 @@
+# Ingress HA (keepalived VRRP virtual IP) derivations.
+#
+# Traefik is no longer a single-node SPOF: every LXC tagged "ingress" runs an
+# identical Traefik instance, and keepalived (ansible-proxmox-apps) floats ONE
+# virtual IP across them (unicast VRRP). DNS points every fronted service at this
+# VIP (see the technitium_dns role), so a node loss migrates the VIP to a
+# surviving Traefik with zero manual action. Both instances always run and each
+# fetches its own ACME cert independently (no shared acme.json state).
+#
+# Extracted from ingress.tf so that file stays under the shared _file-size
+# workflow's 12 KB error threshold; locals merge across files in the module
+# (same split pattern as locals-honeypot.tf / locals-vm-network.tf).
+locals {
+  # ingress_vip_host: the reserved HOST OCTET for the VIP inside the ingress
+  # VLAN. It is NOT a literal IP — the address is derived via cidrhost() from the
+  # Doppler-sourced network_cidrs, so the real subnet never appears in-repo.
+  # Reserved-octet map for the ingress (mgmt) VLAN: .1 gateway, .4/.5 openbao,
+  # .33 unifi-metrics, .101/.107 the two Traefik LXCs (vm_id-derived). .2 is
+  # carved out here for the ingress VIP and must stay out of the DHCP pool.
+  ingress_vip_host = 2
+  ingress_container_keys = sort([
+    for k, v in var.containers : k
+    if contains(coalesce(try(v.tags, null), []), "ingress")
+  ])
+  # VLAN taken from the ingress containers themselves, so the VIP follows a VLAN
+  # move automatically instead of pinning a hardcoded key. Falls back to "mgmt"
+  # only when no ingress container is deployed (VIP then resolves to "").
+  ingress_vlan = try(var.containers[local.ingress_container_keys[0]].vlan, "mgmt")
+  ingress_vip = length(local.ingress_container_keys) > 0 ? nonsensitive(
+    cidrhost(var.network_cidrs[local.ingress_vlan], local.ingress_vip_host)
+  ) : ""
+  # Advertised address of each ingress instance — the keepalived unicast_peer
+  # list. Same container_address shape (static host IP / DNS-first FQDN) as every
+  # other backend pool.
+  ingress_hosts = [for k in local.ingress_container_keys : local.container_address[k]]
+}

--- a/locals.tf
+++ b/locals.tf
@@ -179,6 +179,16 @@ locals {
     if contains(coalesce(try(v.tags, null), []), "openbao")
   }
 
+  # Ingress containers (ingress tag) — the Traefik HA instances. Guest-firewalled
+  # only when the define-disabled ingress firewall is enabled (see
+  # modules/firewall/ingress_rules.tf); today these run un-firewalled, so keepalived
+  # VRRP already flows freely between them. The rules exist pre-allowed so a future
+  # enforcement flip never breaks the VIP.
+  ingress_container_ids = {
+    for k, v in var.containers : k => v.vm_id
+    if contains(coalesce(try(v.tags, null), []), "ingress")
+  }
+
   # HAProxy LXCs (haproxy tag) — receive delivered ACME certs for HTTPS frontends.
   # Distinct from pipeline_container_ids (which also includes Cribl Edge); this
   # local is dedicated to cert-delivery targeting.

--- a/main.tf
+++ b/main.tf
@@ -228,6 +228,10 @@ module "firewall" {
   # OpenBao secrets-management containers (openbao tag)
   openbao_container_ids = local.openbao_container_ids
 
+  # Ingress (Traefik HA) containers (ingress tag) — define-disabled guest firewall
+  # that pre-allows keepalived VRRP + 80/443 so a later enforcement flip is safe.
+  ingress_container_ids = local.ingress_container_ids
+
   # iDRAC KVM LXC: tagged "idrac" (domistyle/idrac6-based viewers, Docker-in-LXC)
   idrac_kvm_container_ids = local.idrac_kvm_container_ids
 

--- a/modules/firewall/ingress_rules.tf
+++ b/modules/firewall/ingress_rules.tf
@@ -1,0 +1,88 @@
+# Ingress (Traefik HA) containers — the reverse-proxy instances behind the
+# keepalived VRRP virtual IP (see ingress.tf `ingress_vip` / the keepalived role).
+#
+# DEFINE-DISABLED, exactly like the zero-trust rules: options.enabled is driven
+# by local.ingress_fw_enabled (false today), so this whole firewall is inert and
+# the ingress containers keep running un-firewalled — which is why keepalived
+# VRRP already flows between them with no change. The value of declaring it now
+# is that the eventual DROP-policy flip (its own observed PR) already PRE-ALLOWS
+# VRRP + 80/443, so turning enforcement on can never black-hole the floating VIP
+# or the HTTPS entrypoint. Mirrors the openbao/pipeline per-domain rule files.
+#
+# ponytail: 80/443 are the universal reverse-proxy entrypoints — inlined rather
+# than promoted to pipeline_constants; add a constant only if a second consumer
+# needs them.
+
+resource "proxmox_virtual_environment_firewall_options" "ingress_container" {
+  for_each = var.ingress_container_ids
+
+  node_name    = var.node_name
+  container_id = each.value
+  # DEFINE-DISABLED: inert until local.ingress_fw_enabled flips to true.
+  enabled       = local.ingress_fw_enabled
+  input_policy  = local.firewall_defaults.input_policy
+  output_policy = local.firewall_defaults.output_policy
+  log_level_in  = local.firewall_defaults.log_level_in
+  log_level_out = local.firewall_defaults.log_level_out
+
+  depends_on = [proxmox_virtual_environment_cluster_firewall.main]
+}
+
+resource "proxmox_virtual_environment_firewall_rules" "ingress_container" {
+  for_each = var.ingress_container_ids
+
+  node_name    = var.node_name
+  container_id = each.value
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.internal_access.name
+    comment        = "Internal access (SSH, ICMP)"
+  }
+
+  # HTTPS + HTTP reverse-proxy entrypoints from internal (Traefik terminates TLS
+  # and redirects :80 -> :443).
+  rule {
+    type    = "in"
+    action  = "ACCEPT"
+    proto   = "tcp"
+    dport   = "443"
+    source  = local.internal_src
+    comment = "Ingress HTTPS (Traefik) from internal"
+  }
+
+  rule {
+    type    = "in"
+    action  = "ACCEPT"
+    proto   = "tcp"
+    dport   = "80"
+    source  = local.internal_src
+    comment = "Ingress HTTP->HTTPS redirect (Traefik) from internal"
+  }
+
+  # keepalived VRRP (IP protocol 112) between the ingress instances. Unicast VRRP
+  # rides between the peer host IPs (all within internal_src); allowing it here is
+  # the whole reason this define-disabled firewall exists — a future enforcement
+  # flip must not drop the master-election traffic that owns the VIP.
+  rule {
+    type    = "in"
+    action  = "ACCEPT"
+    proto   = "vrrp"
+    source  = local.internal_src
+    comment = "keepalived VRRP (proto 112) between ingress instances"
+  }
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.outbound_internal.name
+    comment        = "Outbound to internal only"
+  }
+
+  # Traefik fetches + renews its ACME cert via the Route53 DNS-01 solver, so it
+  # needs outbound HTTPS to the ACME CA + AWS Route53 API (CDN-fronted, no stable
+  # dest CIDR — reuses the same open-443 group as the Cribl license telemetry).
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.outbound_https.name
+    comment        = "Outbound HTTPS (ACME DNS-01: Let's Encrypt + Route53 API)"
+  }
+
+  depends_on = [proxmox_virtual_environment_firewall_options.ingress_container]
+}

--- a/modules/firewall/locals.tf
+++ b/modules/firewall/locals.tf
@@ -25,6 +25,14 @@ locals {
   # Zero-trust flows are staged disabled. Flip per-rule in a later PR once
   # each is observed against the allow+log baseline.
   zt_enabled = false
+
+  # Ingress (Traefik HA) guest firewall is DEFINE-DISABLED, same staged pattern
+  # as zero-trust above. Today the ingress containers run un-firewalled so
+  # keepalived VRRP flows freely; ingress_rules.tf declares the eventual DROP
+  # policy + its 80/443 and VRRP pre-allows so a future flip to `true` (in its
+  # own observed PR) cannot black-hole the floating VIP. Follow-up: enable after
+  # an allow+log baseline confirms no legitimate ingress flow is missed.
+  ingress_fw_enabled = false
 }
 
 # Security group rule definitions - use comma-joined source/dest for multi-network rules

--- a/modules/firewall/variables.tf
+++ b/modules/firewall/variables.tf
@@ -75,6 +75,12 @@ variable "openbao_container_ids" {
   default     = {}
 }
 
+variable "ingress_container_ids" {
+  description = "Map of ingress (Traefik HA) container names to their IDs (ingress tag). Firewall is DEFINE-DISABLED (see ingress_rules.tf): it pre-allows keepalived VRRP + 80/443 so enabling enforcement later never breaks the floating VIP."
+  type        = map(number)
+  default     = {}
+}
+
 variable "idrac_kvm_container_ids" {
   description = "Map of iDRAC KVM LXC names to IDs (tag-driven, set by root locals)"
   type        = map(number)

--- a/scripts/mirror-deployment-json.sh
+++ b/scripts/mirror-deployment-json.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Refresh the AWS-S3 mirror of the desired-state INPUT (deployment.json).
+#
+# The input lives authoritatively in the on-prem RustFS object store, which is a
+# single point of failure: if it is down, terragrunt cannot fetch the input and
+# plan/apply is blocked. terragrunt.hcl's fetch now falls back to an AWS-S3 mirror
+# (same versioned state bucket as the published inventory) when on-prem is
+# unreachable. This script keeps that mirror current: it re-reads the authoritative
+# on-prem copy and uploads it to the mirror after every successful apply.
+#
+# BEST-EFFORT by design: any failure here warns and exits 0. A mirror hiccup must
+# never fail an otherwise-good apply — the prior mirror copy simply persists until
+# the next apply. Staleness is therefore bounded by the apply cadence, which is the
+# correct trade for a DR fallback.
+# ponytail: best-effort re-fetch+upload; add a content-hash skip only if the extra
+# S3 round-trip per apply ever shows up as a cost.
+#
+# Manual run: aws-vault exec tf-proxmox -- doppler run -- ./scripts/mirror-deployment-json.sh
+set -uo pipefail
+
+warn() { echo "mirror-deployment-json: $*" >&2; }
+
+# An explicit local override means there is nothing on-prem to mirror.
+if [[ -n "${DEPLOYMENT_JSON_PATH:-}" ]]; then
+  warn "DEPLOYMENT_JSON_PATH set — skipping AWS mirror (local override in use)."
+  exit 0
+fi
+
+SRC_BUCKET="${S3_INVENTORY_BUCKET:-iac-inventory}"
+SRC_KEY="${S3_INVENTORY_KEY:-deployment.json}"
+SRC_REGION="${S3_INVENTORY_REGION:-us-east-1}"
+MIRROR_KEY="terraform-proxmox/input/deployment.json"
+
+for var in S3_ENDPOINT S3_ACCESS_KEY S3_SECRET_KEY; do
+  if [[ -z "${!var:-}" ]]; then
+    warn "$var unset — cannot read on-prem source; leaving existing mirror untouched."
+    exit 0
+  fi
+done
+
+# Resolve the mirror bucket from the caller's AWS identity (same ambient chain as
+# the state backend), so no account id is hardcoded.
+acct="$(aws sts get-caller-identity --query Account --output text 2>/dev/null)"
+if [[ -z "$acct" || "$acct" == "None" ]]; then
+  warn "no AWS identity (ambient creds) — cannot resolve mirror bucket; skipping."
+  exit 0
+fi
+MIRROR_BUCKET="terraform-proxmox-state-useast2-${acct}"
+
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+
+# READ authoritative on-prem copy (S3_* creds, private endpoint) in a subshell so
+# its unset/S3_* env never leaks into the AWS-credentialed upload below.
+if ! (
+  unset AWS_PROFILE AWS_SESSION_TOKEN
+  AWS_ACCESS_KEY_ID="$S3_ACCESS_KEY" AWS_SECRET_ACCESS_KEY="$S3_SECRET_KEY" \
+    AWS_REGION="$SRC_REGION" \
+    aws --endpoint-url "$S3_ENDPOINT" s3 cp "s3://${SRC_BUCKET}/${SRC_KEY}" "$tmp" --quiet
+) || [[ ! -s "$tmp" ]]; then
+  warn "on-prem read failed or empty — leaving existing mirror untouched."
+  exit 0
+fi
+
+# Guard: never mirror invalid JSON (would poison the fallback path).
+if ! python3 -c "import json,sys; json.load(open(sys.argv[1]))" "$tmp" 2>/dev/null; then
+  warn "on-prem copy is not valid JSON — refusing to mirror."
+  exit 0
+fi
+
+# UPLOAD to the AWS mirror (ambient creds).
+if AWS_REGION=us-east-2 aws --region us-east-2 \
+  s3 cp "$tmp" "s3://${MIRROR_BUCKET}/${MIRROR_KEY}" --quiet; then
+  echo "mirror-deployment-json: refreshed s3://${MIRROR_BUCKET}/${MIRROR_KEY}"
+else
+  warn "AWS mirror upload failed — prior mirror copy persists."
+fi
+
+exit 0

--- a/terragrunt.hcl
+++ b/terragrunt.hcl
@@ -16,12 +16,45 @@ locals {
   s3_inventory_bucket = get_env("S3_INVENTORY_BUCKET", "iac-inventory")
   s3_inventory_key    = get_env("S3_INVENTORY_KEY", "deployment.json")
   s3_inventory_region = get_env("S3_INVENTORY_REGION", "us-east-1")
+
+  # HA fetch failover: the desired-state INPUT is no longer a single-store SPOF.
+  # PRIMARY  = the on-prem RustFS object store (S3_* creds, private endpoint).
+  # FALLBACK = an AWS-S3 mirror in the same versioned state bucket that holds the
+  #            published inventory (ambient AWS creds — aws-vault locally / OIDC in
+  #            CI — the SAME chain as remote_state, NOT the S3_* creds). Refreshed
+  #            after every apply by scripts/mirror-deployment-json.sh (the
+  #            mirror_deployment_json after_hook below). If on-prem is unreachable,
+  #            the fetch transparently reads the AWS mirror, so a RustFS outage no
+  #            longer blocks plan/apply. FAIL-LOUD preserved: only if BOTH stores
+  #            fail (or return empty) does the command exit non-zero and run_cmd
+  #            raise — never a silent {} that would plan a full destroy.
+  s3_mirror_bucket = "terraform-proxmox-state-useast2-${get_aws_account_id()}"
+  s3_mirror_key    = "terraform-proxmox/input/deployment.json"
   deployment_json = (
     get_env("DEPLOYMENT_JSON_PATH", "") != ""
     ? file(get_env("DEPLOYMENT_JSON_PATH"))
     : run_cmd(
       "--terragrunt-quiet", "bash", "-c",
-      "unset AWS_PROFILE AWS_SESSION_TOKEN; AWS_ACCESS_KEY_ID=\"$S3_ACCESS_KEY\" AWS_SECRET_ACCESS_KEY=\"$S3_SECRET_KEY\" AWS_REGION=${local.s3_inventory_region} aws --endpoint-url \"$S3_ENDPOINT\" s3 cp s3://${local.s3_inventory_bucket}/${local.s3_inventory_key} - --quiet"
+      <<-FETCH
+        set -o pipefail
+        # PRIMARY: on-prem RustFS in a subshell so its unset/S3_* env never leaks
+        # into the AWS-credentialed fallback below.
+        if primary=$( (
+          unset AWS_PROFILE AWS_SESSION_TOKEN
+          AWS_ACCESS_KEY_ID="$S3_ACCESS_KEY" AWS_SECRET_ACCESS_KEY="$S3_SECRET_KEY" \
+          AWS_REGION=${local.s3_inventory_region} \
+          aws --endpoint-url "$S3_ENDPOINT" \
+            s3 cp "s3://${local.s3_inventory_bucket}/${local.s3_inventory_key}" - --quiet
+        ) 2>/dev/null ) && [ -n "$primary" ]; then
+          printf '%s' "$primary"
+        else
+          # FALLBACK: AWS-S3 mirror with the ambient credential chain. A failure
+          # here exits non-zero (last command) -> run_cmd raises. FAIL-LOUD.
+          echo "deployment.json: on-prem fetch failed, reading AWS-S3 mirror" >&2
+          AWS_REGION=us-east-2 aws --region us-east-2 \
+            s3 cp "s3://${local.s3_mirror_bucket}/${local.s3_mirror_key}" - --quiet
+        fi
+      FETCH
     )
   )
   deployment_config = jsondecode(trimspace(local.deployment_json))
@@ -155,6 +188,18 @@ terraform {
   after_hook "sync_inventory" {
     commands     = ["apply"]
     execute      = ["bash", "${get_terragrunt_dir()}/scripts/sync-inventory.sh"]
+    run_on_error = false
+  }
+
+  # Refresh the AWS-S3 mirror of the desired-state INPUT (deployment.json) after
+  # every successful apply, so the fetch-failover fallback above always has a
+  # current copy if the on-prem RustFS is later unreachable. Best-effort: the
+  # script warns and exits 0 on a mirror hiccup so a transient S3 blip never fails
+  # an otherwise-good apply (the prior mirror copy simply persists). Logic lives in
+  # scripts/mirror-deployment-json.sh (no-inline-scripts rule).
+  after_hook "mirror_deployment_json" {
+    commands     = ["apply"]
+    execute      = ["bash", "${get_terragrunt_dir()}/scripts/mirror-deployment-json.sh"]
     run_on_error = false
   }
 }

--- a/tests/ansible_inventory_contract.tftest.hcl
+++ b/tests/ansible_inventory_contract.tftest.hcl
@@ -425,8 +425,8 @@ run "ansible_inventory_ingress_ha_single_node_no_vip" {
   }
 
   assert {
-    condition     = output.ansible_inventory.ingress_vip == "192.168.5.2" && length(output.ansible_inventory.ingress_hosts) == 1
-    error_message = "a single ingress instance still advertises the VIP octet but lists one peer; keepalived no-ops below 2 peers"
+    condition     = output.ansible_inventory.ingress_vip == "" && length(output.ansible_inventory.ingress_hosts) == 1
+    error_message = "a single ingress instance must NOT synthesize a VIP (it would never bind, black-holing DNS) — DNS must fall back to the single host's IP"
   }
 }
 

--- a/tests/ansible_inventory_contract.tftest.hcl
+++ b/tests/ansible_inventory_contract.tftest.hcl
@@ -356,6 +356,80 @@ run "ansible_inventory_ingress_route_table" {
   }
 }
 
+# --- ingress HA: keepalived VRRP virtual IP contract ---
+#
+# The keepalived role (ansible-proxmox-apps) + technitium_dns consume ingress_vip
+# (the floating IP DNS points every fronted service at) and ingress_hosts (the
+# unicast_peer members). Pin: the VIP is derived via cidrhost from the ingress
+# containers' own VLAN + the documented reserved octet (2), and every
+# ingress-tagged instance is listed. This is what makes ingress node-loss failover
+# fully automatic with no hardcoded IP.
+run "ansible_inventory_ingress_ha_vip" {
+  command = plan
+
+  variables {
+    # Two identical Traefik instances on the mgmt VLAN (vlan_id 5 -> 192.168.5.0/24
+    # in the test's derived CIDRs). vm_ids derive .101/.107; the VIP is .2.
+    containers = {
+      "traefik" = {
+        vm_id    = 101
+        hostname = "traefik"
+        vlan     = "mgmt"
+        tags     = ["terraform", "container", "ingress", "traefik"]
+      }
+      "traefik-2" = {
+        vm_id    = 107
+        hostname = "traefik-2"
+        vlan     = "mgmt"
+        tags     = ["terraform", "container", "ingress", "traefik"]
+      }
+    }
+  }
+
+  # VIP = cidrhost(192.168.5.0/24, 2) — derived, never a literal.
+  assert {
+    condition     = output.ansible_inventory.ingress_vip == "192.168.5.2"
+    error_message = "ingress_vip must be the .2 reserved octet of the ingress VLAN, derived via cidrhost"
+  }
+
+  # Both ingress instances are enrolled as keepalived unicast peers.
+  assert {
+    condition = length(output.ansible_inventory.ingress_hosts) == 2 && (
+      contains(output.ansible_inventory.ingress_hosts, "192.168.5.101") &&
+      contains(output.ansible_inventory.ingress_hosts, "192.168.5.107")
+    )
+    error_message = "ingress_hosts must list every ingress-tagged instance's address (the unicast_peer set)"
+  }
+
+  # The VRRP virtual_router_id is surfaced as a constant, not hardcoded downstream.
+  assert {
+    condition     = output.ansible_inventory.constants.ingress_ports.keepalived_vrid == 51
+    error_message = "constants must surface the keepalived VRRP vrid for the ingress HA role"
+  }
+}
+
+# A single-ingress (or zero) deployment must NOT synthesize a VIP — keepalived
+# then no-ops and the deployment stays valid (partial-deploy resilience).
+run "ansible_inventory_ingress_ha_single_node_no_vip" {
+  command = plan
+
+  variables {
+    containers = {
+      "traefik" = {
+        vm_id    = 101
+        hostname = "traefik"
+        vlan     = "mgmt"
+        tags     = ["terraform", "container", "ingress", "traefik"]
+      }
+    }
+  }
+
+  assert {
+    condition     = output.ansible_inventory.ingress_vip == "192.168.5.2" && length(output.ansible_inventory.ingress_hosts) == 1
+    error_message = "a single ingress instance still advertises the VIP octet but lists one peer; keepalived no-ops below 2 peers"
+  }
+}
+
 # Proxmox cluster UI apex: the subdomain apex load-balanced across the
 # commissioned node role FQDNs (https://<role>.<domain>:8006). Pins the
 # multi-backend + apex contract the ansible-proxmox-apps traefik role consumes.


### PR DESCRIPTION
Part of the fully-autonomous DR/HA mandate: remove single-node / single-store outage points that would otherwise need a manual switch. Two waves, both buildable on the current cluster (no pve4).

## W1 — Ingress HA (VRRP virtual IP)
Traefik was a single-node SPOF. Now every LXC tagged `ingress` runs an identical instance and **keepalived floats one VRRP virtual IP** across them (role lives in the paired ansible-proxmox-apps PR). DNS points every fronted service at the VIP, so a node loss migrates it automatically — no manual DR step.

- **`ingress.tf`** derives `ingress_vip = cidrhost(<ingress VLAN CIDR>, 2)` and `ingress_hosts` (the keepalived `unicast_peer` set) from the `ingress` tag + `network_cidrs`. No literal IP — the `.2` octet is documented against the ingress-VLAN reserved-octet map.
- **`inventory_publish.tf`** surfaces `ingress_vip` / `ingress_hosts`; **`constants.tf`** adds `ingress_ports.keepalived_vrid` (VRRP vrid, DRY so the role never hardcodes it).
- **`modules/firewall/ingress_rules.tf`** — **define-disabled** guest firewall (mirrors the existing zero-trust staged pattern; `local.ingress_fw_enabled = false`) that **pre-allows VRRP proto-112 + 80/443**, so a future enforcement flip can never black-hole the VIP. Inert today: ingress runs un-firewalled, so VRRP already flows freely.
- **`deployment.json.example`** documents the HA Traefik pair (generic `proxmox-N` nodes).

> Live-data handoff: the private/S3 `deployment.json` needs the second `ingress`-tagged Traefik LXC (`traefik-2`, pve2) added for the VIP to actually form on apply. All committed code here is tag-driven and activates automatically once it lands.

## W2 — deployment.json availability (fetch failover + AWS mirror)
The desired-state INPUT was a single-store SPOF (on-prem RustFS). `terragrunt.hcl` now fetches **primary → fallback**: on-prem first, then an **AWS-S3 mirror** (ambient creds, same versioned bucket as the published inventory) if on-prem is unreachable. **FAIL-LOUD preserved** — only a both-store failure exits non-zero (never a silent `{}`). `scripts/mirror-deployment-json.sh` (apply `after_hook`) refreshes the mirror best-effort after every apply.

## Validation
- `tofu validate` — clean.
- `tofu test` — **107 passed, 0 failed** (2 new: ingress-HA VIP derivation + single-node-no-VIP resilience).
- Fetch-failover branch logic unit-checked with a stubbed `aws`: primary→primary, primary-fail→mirror, both-fail→nonzero.

## Applied vs disabled
- Ingress-HA locals/inventory/constants + W2 fetch failover: **active on apply.**
- Ingress guest firewall: **define-disabled** (pre-allow only) — follow-up issue to enable after an allow+log baseline.

## Residue
- pve4-gated 3-voter OpenBao Raft is out of scope (client failover handled in the apps PR).
- Live 2-node VRRP failover proof is a scriptable drill shipped in the apps PR (never a manual runbook).

Cross-ref: ansible-proxmox-apps (keepalived role + technitium_dns VIP repoint + openbao client failover W3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)