### PR TITLE
feat(aws-infra): gate pve public A record off by default (split-horizon DNS)

### DIFF
--- a/aws-infra/main.tf
+++ b/aws-infra/main.tf
@@ -24,14 +24,15 @@ module "route53_records" {
   count  = var.enable_route53_dns ? 1 : 0
   source = "./modules/route53-records"
 
-  route53_zone_id      = var.route53_zone_id
-  proxmox_domain       = var.proxmox_domain
-  proxmox_ip_address   = var.proxmox_ip_address
-  proxmox_ip_addresses = var.proxmox_ip_addresses
-  route53_cnames       = var.route53_cnames
-  route53_a_records    = var.route53_a_records
-  dns_ttl              = var.dns_ttl
-  environment          = var.environment
+  route53_zone_id          = var.route53_zone_id
+  proxmox_domain           = var.proxmox_domain
+  proxmox_ip_address       = var.proxmox_ip_address
+  proxmox_ip_addresses     = var.proxmox_ip_addresses
+  route53_cnames           = var.route53_cnames
+  route53_a_records        = var.route53_a_records
+  publish_proxmox_public_a = var.publish_proxmox_public_a
+  dns_ttl                  = var.dns_ttl
+  environment              = var.environment
 }
 
 # Future AWS resources go here:

--- a/aws-infra/modules/route53-records/main.tf
+++ b/aws-infra/modules/route53-records/main.tf
@@ -12,7 +12,14 @@ terraform {
 
 # A Record for Proxmox VE UI
 # Points the Proxmox domain to all active Proxmox API endpoints.
+# Gated OFF by default: the Proxmox endpoints are RFC1918 hosts, so publishing
+# them in the PUBLIC hosted zone leaks internal IPs. Internal clients resolve
+# pve.<domain> via Technitium (authoritative for the pve subdomain zone), so the
+# public record is unnecessary. Flip publish_proxmox_public_a=true only if an
+# off-LAN consumer genuinely needs it. Cert renewal is unaffected — lego DNS-01
+# writes only _acme-challenge.* TXT, never this A record.
 resource "aws_route53_record" "proxmox" {
+  count = var.publish_proxmox_public_a ? 1 : 0
   #checkov:skip=CKV2_AWS_23: Proxmox is on-premises infrastructure with a static IP; AWS alias resource is architecturally inapplicable
   zone_id = var.route53_zone_id
   name    = var.proxmox_domain

--- a/aws-infra/modules/route53-records/outputs.tf
+++ b/aws-infra/modules/route53-records/outputs.tf
@@ -1,16 +1,16 @@
 output "proxmox_record_fqdn" {
-  description = "Fully qualified domain name of the Proxmox A record"
-  value       = aws_route53_record.proxmox.fqdn
+  description = "Fully qualified domain name of the Proxmox A record (null when not published)"
+  value       = one(aws_route53_record.proxmox[*].fqdn)
 }
 
 output "proxmox_record_name" {
-  description = "Name of the Proxmox A record"
-  value       = aws_route53_record.proxmox.name
+  description = "Name of the Proxmox A record (null when not published)"
+  value       = one(aws_route53_record.proxmox[*].name)
 }
 
 output "proxmox_record_ttl" {
-  description = "TTL of the Proxmox A record"
-  value       = aws_route53_record.proxmox.ttl
+  description = "TTL of the Proxmox A record (null when not published)"
+  value       = one(aws_route53_record.proxmox[*].ttl)
 }
 
 output "proxmox_ip_address" {

--- a/aws-infra/modules/route53-records/variables.tf
+++ b/aws-infra/modules/route53-records/variables.tf
@@ -40,6 +40,12 @@ variable "proxmox_ip_addresses" {
   }
 }
 
+variable "publish_proxmox_public_a" {
+  description = "Publish the pve apex A record (RFC1918 node IPs) in the PUBLIC Route53 zone. Default false: internal clients resolve pve.<domain> via Technitium, so publishing it here only leaks internal IPs."
+  type        = bool
+  default     = false
+}
+
 variable "dns_ttl" {
   description = "DNS TTL in seconds for the A record"
   type        = number

--- a/aws-infra/terragrunt.hcl
+++ b/aws-infra/terragrunt.hcl
@@ -36,6 +36,10 @@ inputs = {
   proxmox_ip_addresses = compact(split(",", get_env("PROXMOX_IP_ADDRESSES", get_env("PROXMOX_IP_ADDRESS", ""))))
   aws_region           = get_env("AWS_REGION", "us-east-1")
   environment          = get_env("ENVIRONMENT", "homelab")
+  # Keep the pve apex A record OUT of the public zone by default (it holds RFC1918
+  # node IPs; internal clients resolve pve.<domain> via Technitium). Flip to true
+  # via env only if an off-LAN consumer genuinely needs the public record.
+  publish_proxmox_public_a = tobool(get_env("PUBLISH_PROXMOX_PUBLIC_A", "false"))
   # Service-alias CNAMEs: comma-separated "label=target.fqdn" pairs, e.g.
   # ROUTE53_CNAMES="llm-large=host.example.com". Values live in Doppler so no
   # hostname literal is committed. Entries without "=" (including blank or

--- a/aws-infra/variables.tf
+++ b/aws-infra/variables.tf
@@ -75,6 +75,12 @@ variable "proxmox_ip_addresses" {
   }
 }
 
+variable "publish_proxmox_public_a" {
+  description = "Publish the pve apex A record (RFC1918 node IPs) in the PUBLIC Route53 zone. Default false: internal clients resolve pve.<domain> via Technitium, so publishing it here only leaks internal IPs."
+  type        = bool
+  default     = false
+}
+
 variable "dns_ttl" {
   description = "DNS TTL in seconds for the A record"
   type        = number


### PR DESCRIPTION
## What

Completes the split-horizon DNS remediation: internal names resolve only via Technitium (LAN), and the internal-leaking records are removed from the public Route53 zone.

- Add `publish_proxmox_public_a` (bool, default **false**) and gate `aws_route53_record.proxmox` with `count`. The pve apex A record published RFC1918 node IPs in the **public** zone; internal clients resolve `pve.${PROXMOX_SUBDOMAIN}` via Technitium (authoritative for the pve subdomain zone), so the public record only leaked internal addressing.
- Expose `PUBLISH_PROXMOX_PUBLIC_A` env override in `terragrunt.hcl` for one-flag reversibility (no code change to re-publish).
- `jevans-ms` A + `llm-large` CNAME were already removed by clearing their `ROUTE53_A_RECORDS` / `ROUTE53_CNAMES` Doppler secrets to empty.

## Applied state (already live)

The apply was executed under owner approval, staged + verified:

| Record | Before | After |
| --- | --- | --- |
| `pve.${DOMAIN}` A (RFC1918 ×3) | public | **removed** |
| `jevans-ms.${DOMAIN}` A | public | **removed** |
| `llm-large.${DOMAIN}` CNAME | public | **removed** |

Route53 API: **18 records** (was 21), exactly the 3 leaks gone. All other public/mail/delegation records untouched.

## Safety

- **Internal resolution intact** (verified via client path + Technitium): pve, pve1, jevans-ms, llm-large, splunk.pve all still resolve on-LAN; apex/www/docs still resolve.
- **Public exposure gone** (verified via DoH, off-LAN): purged names return NXDOMAIN.
- **Certs unaffected**: lego DNS-01 writes only `_acme-challenge.* TXT`; all three `_acme-challenge` TXTs retained in Route53. apex/www ACM + docs Mintlify untouched.
- Fully reversible: restore the two Doppler secrets and/or set `PUBLISH_PROXMOX_PUBLIC_A=true`, then re-apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)