### PR TITLE
feat(ai): add n8n + LangGraph to the AI orchestration tier

### DIFF
--- a/constants.tf
+++ b/constants.tf
@@ -75,11 +75,17 @@ locals {
       # management/xDS/metrics port (fronted by Traefik, internal-only).
       agentgateway_proxy = 8080
       agentgateway_admin = 15000
-      # AI orchestration stack web UIs (Traefik-fronted) — Dify, LangFlow, and
-      # Langfuse (LLM trace/cost/eval). ingress.tf references these constants.
+      # AI orchestration stack web UIs (Traefik-fronted) — n8n, Dify, LangFlow,
+      # LangGraph, and Langfuse (LLM trace/cost/eval). ingress.tf references these.
+      n8n_web      = 5678
       dify_web     = 80
       langflow_web = 7860
       langfuse_web = 3000
+      # LangGraph, self-hosted zero-cloud: `langgraph dev` in-memory server API +
+      # its self-hosted Agent Chat UI (Next.js). langgraph_api is deliberately 8124,
+      # NOT the LangGraph default 8123, which collides with homeassistant_web above.
+      langgraph_api     = 8124
+      agent_chat_ui_web = 3000
       # OpenTelemetry ingest on Cribl Edge — native OTLP sources, one port per
       # signal type (gRPC/HTTP) so Cribl routes by type without inspecting payload.
       # AI orchestration apps (OpenLLMetry) emit here; Cribl forks to Langfuse +

--- a/deployment.json.example
+++ b/deployment.json.example
@@ -25,7 +25,7 @@
   "pools": {
     "logging": { "comment": "Logging and observability infrastructure" },
     "infrastructure": { "comment": "Core infrastructure services" },
-    "ai": { "comment": "AI orchestration tier (Dify, LangFlow, agent-exec)" },
+    "ai": { "comment": "AI orchestration tier (n8n, Dify, LangFlow, LangGraph, agent-exec)" },
     "security": { "comment": "Honeypots and deception sensors (OpenCanary tripwires, T-Pot, apprise notify gateway)" }
   },
 
@@ -352,7 +352,23 @@
       "root_disk": { "size": 16 },
       "features": { "nesting": true }
     },
-    "_ai_orchestration_comment": "AI orchestration tier (AI/ML tier 5). Dify/LangFlow are Docker-in-LXC visual builders; agent-exec is a plain Python LXC running CrewAI + LangChain code with OpenLLMetry. VMIDs follow the 6-digit positional convention (docs vmid-network-tiers); the values here are illustrative. They sit on the 'ai' VLAN (tier 5) and 'siem' VLAN (tier 4) — the committed end-state of the vlan_ids map — addressed DNS-first (dhcp + reserved_host). Each tool's model provider + vector store is configured per its own install standard; Dify keeps its bundled vector store rather than the shared qdrant. Docker guests carry only nesting (the API token cannot set keyctl/fuse on unprivileged LXC; ansible-proxmox adds those via root@pam, same as the media guests). Firewall: ai-orch-svc (UI ports) + native OTLP egress to Cribl Edge; Langfuse adds langfuse-svc (3000). Node placement is set in the live (private) deployment input; the example omits node_name and uses the default.",
+    "_ai_orchestration_comment": "AI orchestration tier (AI/ML tier 5). n8n/Dify/LangFlow are Docker-in-LXC visual builders; LangGraph is a Docker-in-LXC zero-cloud `langgraph dev` (in-memory) server + self-hosted Agent Chat UI; agent-exec is a plain Python LXC running CrewAI + LangChain code with OpenLLMetry. VMIDs follow the 6-digit positional convention (docs vmid-network-tiers); the values here are illustrative. They sit on the 'ai' VLAN (tier 5) and 'siem' VLAN (tier 4) — the committed end-state of the vlan_ids map — addressed DNS-first (dhcp + reserved_host). Each tool's model provider + vector store is configured per its own install standard; Dify keeps its bundled vector store rather than the shared qdrant. Docker guests carry only nesting (the API token cannot set keyctl/fuse on unprivileged LXC; ansible-proxmox adds those via root@pam, same as the media guests). Firewall: ai-orch-svc (UI ports) + native OTLP egress to Cribl Edge; Langfuse adds langfuse-svc (3000). Node placement is set in the live (private) deployment input; the example omits node_name and uses the default.",
+    "n8n": {
+      "vm_id": 505030,
+      "dhcp": true,
+      "reserved_host": 49,
+      "vlan": "ai",
+      "hostname": "n8n",
+      "description": "n8n workflow automation, Community Edition (Docker-in-LXC)",
+      "cpu_cores": 2,
+      "memory_dedicated": 4096,
+      "tags": ["terraform", "container", "ai", "ai-orchestration", "n8n", "docker"],
+      "pool_id": "ai",
+      "unprivileged": true,
+      "root_disk": { "size": 16 },
+      "mount_points": [{ "volume": "local-zfs", "size": "30G", "path": "/opt/n8n" }],
+      "features": { "nesting": true }
+    },
     "dify": {
       "vm_id": 505010,
       "dhcp": true,
@@ -383,6 +399,22 @@
       "unprivileged": true,
       "root_disk": { "size": 16 },
       "mount_points": [{ "volume": "local-zfs", "size": "20G", "path": "/opt/langflow" }],
+      "features": { "nesting": true }
+    },
+    "langgraph": {
+      "vm_id": 505040,
+      "dhcp": true,
+      "reserved_host": 50,
+      "vlan": "ai",
+      "hostname": "langgraph",
+      "description": "LangGraph server (zero-cloud `langgraph dev`, in-memory) + self-hosted Agent Chat UI (Docker-in-LXC)",
+      "cpu_cores": 4,
+      "memory_dedicated": 8192,
+      "tags": ["terraform", "container", "ai", "ai-orchestration", "langgraph", "docker"],
+      "pool_id": "ai",
+      "unprivileged": true,
+      "root_disk": { "size": 24 },
+      "mount_points": [{ "volume": "local-zfs", "size": "30G", "path": "/opt/langgraph" }],
       "features": { "nesting": true }
     },
     "agent-exec": {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -181,7 +181,7 @@ Summary by pool:
 - **`ai`** — `qdrant`, `llamaindex`,
   `hermes-infer` (Ollama LLM inference on the RX 6800 GPU), `hermes-chat`
   (Open WebUI chat frontend), `n8n` (workflow automation), `dify`, `langflow`
-  (LLM orchestration / flow builders), `langgraph` (self-hosted LangGraph server +
+  (LLM orchestration / flow builders), `langgraph` (self-hosted LangGraph +
   Agent Chat UI), `agent-exec` (CrewAI + LangChain runtime with OpenLLMetry tracing)
 - **`media`** (v1 pinned to the primary media node — `node_name`,
   `node_storage`, and ansible inventory label all aligned on that node;
@@ -204,14 +204,12 @@ Notable per-container facts:
   `hermes-chat` runs Open WebUI (`llm` ingress); `ollama` exposes the raw API.
   Full write-up: [local-llm](https://docs.jacobpevans.com/infrastructure/local-llm).
 - The **AI orchestration tier** — `n8n`, `dify`, `langflow`, `langgraph` (all
-  Traefik-fronted) and `agent-exec` on the `ai` VLAN, plus `langfuse` (Langfuse v3
-  observability on the **siem** VLAN, `infrastructure` pool, OTLP ingest
-  `:3000/api/public/otel`) — emits OpenTelemetry to Cribl Edge, which forks traces
-  to Langfuse + Splunk. Each tool's model endpoint resolves by DNS to the
-  OpenAI-compatible LiteLLM router, so the backend is swappable. `langgraph` is
-  self-hosted **zero-cloud** (`langgraph dev`, in-memory) with a self-hosted Agent
-  Chat UI, so no LangSmith account or cloud egress is required; `n8n` is Community
-  Edition (self-hosted for a personal automation playground).
+  Traefik-fronted) and `agent-exec` on the `ai` VLAN, plus `langfuse` (v3
+  observability on the **siem** VLAN, `infrastructure` pool) — emits
+  OpenTelemetry to Cribl Edge, which forks traces to Langfuse + Splunk. Each
+  tool's model endpoint resolves by DNS to the swappable LiteLLM router.
+  `langgraph` is **zero-cloud** (in-memory `langgraph dev`, no LangSmith);
+  `n8n` is self-hosted CE.
 - `mailpit` and `ntfy` run Docker-in-LXC (`nesting: true`, `keyctl: true`) for
   internal notifications.
 - `download-vpn` is an unprivileged LXC with `/dev/net/tun` passed through

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -180,8 +180,9 @@ Summary by pool:
   `splunk-mgmt` (SH + DS + LM + MC + CM)
 - **`ai`** — `qdrant`, `llamaindex`,
   `hermes-infer` (Ollama LLM inference on the RX 6800 GPU), `hermes-chat`
-  (Open WebUI chat frontend), `dify`, `langflow` (LLM orchestration / flow
-  builders), `agent-exec` (CrewAI + LangChain runtime with OpenLLMetry tracing)
+  (Open WebUI chat frontend), `n8n` (workflow automation), `dify`, `langflow`
+  (LLM orchestration / flow builders), `langgraph` (self-hosted LangGraph server +
+  Agent Chat UI), `agent-exec` (CrewAI + LangChain runtime with OpenLLMetry tracing)
 - **`media`** (v1 pinned to the primary media node — `node_name`,
   `node_storage`, and ansible inventory label all aligned on that node;
   v2 lives on the secondary media node) — `download-vpn` (qBittorrent +
@@ -202,13 +203,15 @@ Notable per-container facts:
   from a 120 GB `/var/lib/ollama` volume.
   `hermes-chat` runs Open WebUI (`llm` ingress); `ollama` exposes the raw API.
   Full write-up: [local-llm](https://docs.jacobpevans.com/infrastructure/local-llm).
-- The **AI orchestration tier** — `dify`/`langflow` (Traefik-fronted) and
-  `agent-exec` on the `ai` VLAN, plus `langfuse` (Langfuse v3 observability on the
-  **siem** VLAN, `infrastructure` pool, OTLP ingest `:3000/api/public/otel`) —
-  emits OpenTelemetry to Cribl Edge, which forks traces to Langfuse + Splunk. Each
-  tool's model endpoint resolves by DNS to an OpenAI-compatible runner, so the
-  backend is swappable. **Tools evaluated:** n8n — not adopted; Community Edition
-  gates needed features and paid tiers cost more than self-hosted even on-prem.
+- The **AI orchestration tier** — `n8n`, `dify`, `langflow`, `langgraph` (all
+  Traefik-fronted) and `agent-exec` on the `ai` VLAN, plus `langfuse` (Langfuse v3
+  observability on the **siem** VLAN, `infrastructure` pool, OTLP ingest
+  `:3000/api/public/otel`) — emits OpenTelemetry to Cribl Edge, which forks traces
+  to Langfuse + Splunk. Each tool's model endpoint resolves by DNS to the
+  OpenAI-compatible LiteLLM router, so the backend is swappable. `langgraph` is
+  self-hosted **zero-cloud** (`langgraph dev`, in-memory) with a self-hosted Agent
+  Chat UI, so no LangSmith account or cloud egress is required; `n8n` is Community
+  Edition (self-hosted for a personal automation playground).
 - `mailpit` and `ntfy` run Docker-in-LXC (`nesting: true`, `keyctl: true`) for
   internal notifications.
 - `download-vpn` is an unprivileged LXC with `/dev/net/tun` passed through

--- a/ingress.tf
+++ b/ingress.tf
@@ -34,12 +34,18 @@ locals {
     chat   = { backend = "open-webui", port = local.pipeline_constants.service_ports.open_webui_web }
     qdrant = { backend = "qdrant", port = local.pipeline_constants.vector_db_ports.qdrant_http }
     # AI orchestration stack UIs (ai VLAN) + Langfuse LLM observability (siem VLAN).
-    dify            = { backend = "dify", port = local.pipeline_constants.service_ports.dify_web }
-    langflow        = { backend = "langflow", port = local.pipeline_constants.service_ports.langflow_web }
-    langfuse        = { backend = "langfuse", port = local.pipeline_constants.service_ports.langfuse_web }
-    agentgateway    = { backend = "agentgateway", port = local.pipeline_constants.service_ports.agentgateway_admin }
-    smokeping       = { backend = "smokeping", port = local.pipeline_constants.service_ports.smokeping_web }
-    "haproxy-stats" = { backend = "haproxy", port = local.pipeline_constants.service_ports.haproxy_stats }
+    n8n          = { backend = "n8n", port = local.pipeline_constants.service_ports.n8n_web }
+    dify         = { backend = "dify", port = local.pipeline_constants.service_ports.dify_web }
+    langflow     = { backend = "langflow", port = local.pipeline_constants.service_ports.langflow_web }
+    langfuse     = { backend = "langfuse", port = local.pipeline_constants.service_ports.langfuse_web }
+    agentgateway = { backend = "agentgateway", port = local.pipeline_constants.service_ports.agentgateway_admin }
+    # LangGraph (self-hosted): the `langgraph dev` server API + its Agent Chat UI,
+    # both backed by the one `langgraph` guest. Chat UI is the primary play surface;
+    # the API host also lets browser Studio point its ?baseUrl at it.
+    langgraph        = { backend = "langgraph", port = local.pipeline_constants.service_ports.langgraph_api }
+    "langgraph-chat" = { backend = "langgraph", port = local.pipeline_constants.service_ports.agent_chat_ui_web }
+    smokeping        = { backend = "smokeping", port = local.pipeline_constants.service_ports.smokeping_web }
+    "haproxy-stats"  = { backend = "haproxy", port = local.pipeline_constants.service_ports.haproxy_stats }
   }
 
   # Ingress HA (keepalived VRRP VIP) locals — ingress_vip / ingress_hosts /

--- a/locals-ai-orchestration.tf
+++ b/locals-ai-orchestration.tf
@@ -7,7 +7,7 @@ locals {
   # the full network_cidrs map stays sensitive.
   ai_network = nonsensitive(var.network_cidrs["ai"])
 
-  # AI orchestration LXCs (ai-orchestration tag): Dify, LangFlow, agent-exec.
+  # AI orchestration LXCs (ai-orchestration tag): n8n, Dify, LangFlow, LangGraph, agent-exec.
   # Inbound UI ports from internal + outbound internal/HTTPS (model endpoints,
   # external APIs). agent-exec carries the tag too (egress-only; no UI rule fires).
   ai_orchestration_container_ids = {

--- a/main.tf
+++ b/main.tf
@@ -241,7 +241,7 @@ module "firewall" {
   # Hermes Agent LXC: tagged "hermes-agent" (autonomous agent, broad HTTPS egress)
   hermes_agent_container_ids = local.hermes_agent_container_ids
 
-  # AI orchestration LXCs: tagged "ai-orchestration" (Dify, LangFlow, agent-exec)
+  # AI orchestration LXCs: tagged "ai-orchestration" (n8n, Dify, LangFlow, LangGraph, agent-exec)
   ai_orchestration_container_ids = local.ai_orchestration_container_ids
 
   # Langfuse LLM-observability LXC: tagged "langfuse"

--- a/modules/firewall/ai_orchestration_rules.tf
+++ b/modules/firewall/ai_orchestration_rules.tf
@@ -1,6 +1,6 @@
-# AI orchestration tier firewall resources. The orchestration UIs (Dify,
-# LangFlow) and the agent-exec runtime live on the ai VLAN; Langfuse lives on the
-# siem VLAN. All are DHCP-first guests behind DROP in/out policies, so each gets
+# AI orchestration tier firewall resources. The orchestration UIs (n8n, Dify,
+# LangFlow, LangGraph) and the agent-exec runtime live on the ai VLAN; Langfuse
+# lives on the siem VLAN. All are DHCP-first guests behind DROP in/out policies, so each gets
 # `dhcp = true` (same reason as object_storage_rules.tf). The Cribl Edge OTLP
 # ingest rule (from the ai VLAN) is attached to the pipeline containers in
 # container_rules.tf; this file owns the app-side guests.
@@ -14,12 +14,17 @@ locals {
   # enforced at UniFi; this scopes the Proxmox guest firewall to match.
   ai_src = var.ai_network
 
-  # AI orchestration UIs (Dify, LangFlow) — inbound from internal so admins
-  # reach the builders; egress (model endpoints, external APIs) via outbound
-  # internal/HTTPS groups on the container. Ports DRY from pipeline_constants.
+  # AI orchestration UIs (n8n, Dify, LangFlow, LangGraph) — inbound from internal
+  # so admins reach the builders; egress (model endpoints, external APIs) via
+  # outbound internal/HTTPS groups on the container. LangGraph opens two ports: its
+  # in-memory `langgraph dev` API and the self-hosted Agent Chat UI that fronts it.
+  # Ports DRY from pipeline_constants.
   ai_orchestration_services_rules = [
+    { proto = "tcp", dport = tostring(local.svc_ports.n8n_web), source = local.internal_src, comment = "n8n web UI (TCP ${local.svc_ports.n8n_web}) from internal" },
     { proto = "tcp", dport = tostring(local.svc_ports.langflow_web), source = local.internal_src, comment = "LangFlow web UI (TCP ${local.svc_ports.langflow_web}) from internal" },
     { proto = "tcp", dport = tostring(local.svc_ports.dify_web), source = local.internal_src, comment = "Dify web UI (TCP ${local.svc_ports.dify_web}) from internal" },
+    { proto = "tcp", dport = tostring(local.svc_ports.langgraph_api), source = local.internal_src, comment = "LangGraph server API (TCP ${local.svc_ports.langgraph_api}) from internal" },
+    { proto = "tcp", dport = tostring(local.svc_ports.agent_chat_ui_web), source = local.internal_src, comment = "LangGraph Agent Chat UI (TCP ${local.svc_ports.agent_chat_ui_web}) from internal" },
   ]
 
   # Langfuse — web UI + OTLP-receive on the same port (path-based). Inbound from
@@ -40,7 +45,7 @@ locals {
   ]
 }
 
-# AI orchestration containers (Dify, LangFlow, agent-exec)
+# AI orchestration containers (n8n, Dify, LangFlow, LangGraph, agent-exec)
 
 resource "proxmox_virtual_environment_firewall_options" "ai_orchestration_container" {
   for_each = var.ai_orchestration_container_ids
@@ -72,12 +77,12 @@ resource "proxmox_virtual_environment_firewall_rules" "ai_orchestration_containe
   }
 
   # agent-exec is an egress-only runtime (no web UI) — skip the UI security group
-  # for it so ports 5678/7860/80 are not opened on a guest that never serves them.
+  # for it so the UI ports are not opened on a guest that never serves them.
   dynamic "rule" {
     for_each = each.key != "agent-exec" ? [1] : []
     content {
       security_group = proxmox_virtual_environment_cluster_firewall_security_group.ai_orchestration_services.name
-      comment        = "AI orchestration UIs (Dify, LangFlow)"
+      comment        = "AI orchestration UIs (n8n, Dify, LangFlow, LangGraph)"
     }
   }
 

--- a/modules/firewall/security_groups.tf
+++ b/modules/firewall/security_groups.tf
@@ -356,7 +356,7 @@ resource "proxmox_virtual_environment_cluster_firewall_security_group" "monitori
 
 resource "proxmox_virtual_environment_cluster_firewall_security_group" "ai_orchestration_services" {
   name    = "ai-orch-svc" # Proxmox security-group names max 18 chars
-  comment = "AI orchestration UIs (LangFlow 7860, Dify 80) from internal networks"
+  comment = "AI orchestration UIs (n8n 5678, LangFlow 7860, Dify 80, LangGraph 8124, Agent Chat UI 3000) from internal networks"
 
   dynamic "rule" {
     for_each = local.ai_orchestration_services_rules

--- a/modules/firewall/variables.tf
+++ b/modules/firewall/variables.tf
@@ -100,7 +100,7 @@ variable "hermes_agent_container_ids" {
 }
 
 variable "ai_orchestration_container_ids" {
-  description = "Map of AI orchestration LXC names to IDs (tag-driven: Dify, LangFlow, agent-exec). Inbound UI ports from internal + outbound internal/HTTPS (model endpoints, external APIs)."
+  description = "Map of AI orchestration LXC names to IDs (tag-driven: n8n, Dify, LangFlow, LangGraph, agent-exec). Inbound UI ports from internal + outbound internal/HTTPS (model endpoints, external APIs)."
   type        = map(number)
   default     = {}
 }


### PR DESCRIPTION
## What

Adds two guests to the AI orchestration tier (`ai` VLAN, `ai` pool):

- **n8n** (`505030`, host-offset 49) — Community Edition, self-hosted. Reverses
  #501's drop: n8n is wanted for a personal automation playground, where the CE
  feature gates don't matter.
- **langgraph** (`505040`, host-offset 50) — new, self-hosted **zero-cloud**
  LangGraph: a `langgraph dev` in-memory server plus a self-hosted Agent Chat UI.
  No LangSmith key, no `beacon.langchain.com` egress.

Both carry the existing `ai-orchestration` tag, so they inherit the firewall
security group, Cribl OTLP egress, and the ansible inventory group with no new
module wiring.

## Changes

| File | Change |
| --- | --- |
| `deployment.json.example` | n8n + langgraph example guests; pool + tier comments |
| `constants.tf` | `n8n_web=5678`, `langgraph_api=8124` (not 8123 — collides with `homeassistant_web`), `agent_chat_ui_web=3000` |
| `modules/firewall/ai_orchestration_rules.tf` + `security_groups.tf` | open the 3 new UI ports on `ai-orch-svc` from internal |
| `ingress.tf` | `n8n.<domain>`, `langgraph.<domain>` (API), `langgraph-chat.<domain>` (UI) — each auto-fronted by the Traefik wildcard cert + a Technitium A record |
| `docs/ARCHITECTURE.md` | reverse the "n8n not adopted" note; add LangGraph |
| `locals-ai-orchestration.tf`, `main.tf`, `modules/firewall/variables.tf` | accuracy-only comment updates |

The live private container definitions (`deployment.json` in the S3 store) are
promoted separately at apply time; this PR carries the sanitized example + the
committed HCL.

## Verification

- `tofu fmt` / `tofu validate` — clean
- `tofu test` — 107 passed, 0 failed
- pre-commit — checkov, tflint, secret-detection, fmt, validate, tofu-test all pass
- Live-reachability + seed flows verified at converge (see the AI-stack bring-up runbook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
