### PR TITLE
feat(telemetry): per-source Cribl ports + universal logging firewall rules

### DIFF
--- a/constants-ai-log.tf
+++ b/constants-ai-log.tf
@@ -1,0 +1,25 @@
+# AI / LLM log-ingest ports — one dedicated Cribl TCP-JSON receiver per source
+# family, HAProxy-fronted (LB to the Cribl Stream pair, mirroring the claude S2S
+# path). Cribl best practice is a dedicated port per source so routing is by
+# listener, not payload inspection. The backend flow reuses the existing
+# cribl_s2s (10300) receiver on Stream; these frontends are opened on the
+# pipeline (HAProxy) containers by the ai-log-ingest security group.
+#
+# Split into its own file (referenced from constants.tf as local.ai_log_ports)
+# so constants.tf stays under the shared _file-size 12 KB error threshold;
+# locals merge across files in the module. The Splunk index each lands in is
+# noted inline; new indexes (codex, openbao_audit) are created in ansible-splunk
+# in a later phase — see the WS3-max tracking issue.
+locals {
+  ai_log_ports = {
+    claude_code    = 10311 # MacBook claude-code IO logs      -> index=claude
+    codex_cli      = 10312 # MacBook codex CLI logs           -> index=codex (new)
+    agy_cli        = 10313 # MacBook agy/antigravity CLI logs -> index=gemini
+    copilot_cli    = 10314 # MacBook GitHub Copilot logs      -> index=openai
+    vscode         = 10315 # VS Code telemetry                -> index=vscode
+    macstudio_llm  = 10321 # Mac Studio llama-swap + vllm-mlx -> index=llm
+    macstudio_gate = 10322 # Mac Studio caddy LLM-gate access -> index=llm
+    homelab_llm    = 10323 # homelab llama_cpp + llm_router   -> index=llm
+    openbao_audit  = 10331 # OpenBao file audit device        -> index=openbao_audit (new)
+  }
+}

--- a/constants.tf
+++ b/constants.tf
@@ -164,24 +164,9 @@ locals {
       qdrant_grpc = 6334
     }
     # AI / LLM log-ingest ports — one dedicated Cribl TCP-JSON receiver per source
-    # family, HAProxy-fronted (LB to the Cribl Stream pair, mirroring the claude S2S
-    # path). Cribl best practice is a dedicated port per source so routing is by
-    # listener, not payload inspection. The backend flow reuses the existing
-    # cribl_s2s (10300) receiver on Stream; these frontends are opened on the
-    # pipeline (HAProxy) containers by the ai-log-ingest security group. Splunk
-    # index each lands in is noted; new indexes (codex, openbao_audit) are created
-    # in ansible-splunk in a later phase — see the WS3-max tracking issue.
-    ai_log_ports = {
-      claude_code    = 10311 # MacBook claude-code IO logs      -> index=claude
-      codex_cli      = 10312 # MacBook codex CLI logs           -> index=codex (new)
-      agy_cli        = 10313 # MacBook agy/antigravity CLI logs -> index=gemini
-      copilot_cli    = 10314 # MacBook GitHub Copilot logs      -> index=openai
-      vscode         = 10315 # VS Code telemetry                -> index=vscode
-      macstudio_llm  = 10321 # Mac Studio llama-swap + vllm-mlx -> index=llm
-      macstudio_gate = 10322 # Mac Studio caddy LLM-gate access -> index=llm
-      homelab_llm    = 10323 # homelab llama_cpp + llm_router   -> index=llm
-      openbao_audit  = 10331 # OpenBao file audit device        -> index=openbao_audit (new)
-    }
+    # family (defined in constants-ai-log.tf to keep this file under the shared
+    # _file-size 12 KB gate; locals merge across files in the module).
+    ai_log_ports = local.ai_log_ports
     # IaC automation platform (Terrakube + Semaphore UI) on the iac-platform VM
     # (docker compose, mgmt VLAN, pve3). Host ports published by the compose
     # stack; ingress.tf fronts each behind its own <name>.<domain> route. The

--- a/constants.tf
+++ b/constants.tf
@@ -22,6 +22,26 @@ locals {
     # push (Path A). T-Pot reuses the same frontend with its sourcetype set by
     # the Cribl Edge pipeline. See docs/HONEYPOTS.md + docs/SPLUNK_INDEXES.md.
     honeypot = { standard = 519, high = 1519, index = "honeypot", sourcetype = "honeypot:opencanary" }
+    # UniFi firewall/IPS/threat syslog, split from the admin/system stream above so
+    # security events land in the dedicated `firewall` index instead of being buried
+    # in `unifi`. standard 520 = HAProxy frontend; high 1520 = Cribl Edge backend.
+    # Until the controller can target a second syslog destination, the split is done
+    # Cribl-side by sourcetype routing on the shared 514 receiver; this family gives
+    # the eventual dedicated receiver a stable, pre-allowed port.
+    unifi_fw = { standard = 520, high = 1520, index = "firewall", sourcetype = "ubiquiti:firewall" }
+    # macOS host syslog (MacBook + Mac Studio). Own family so Mac logs stop sharing
+    # the UniFi backend port (1514) they currently point at; lands in `os` alongside
+    # linux/windows, distinguished by sourcetype. standard 521 = HAProxy frontend;
+    # high 1521 = Cribl Edge backend.
+    macos = { standard = 521, high = 1521, index = "os", sourcetype = "syslog:macos" }
+    # Technitium DNS query logs (per-VLAN resolvers). Dedicated family so DNS
+    # visibility for threat-hunting lands in its own `dns` index. standard 522 =
+    # HAProxy frontend; high 1522 = Cribl Edge backend.
+    dns_query = { standard = 522, high = 1522, index = "dns", sourcetype = "technitium:dnsquery" }
+    # L7 proxy access logs (Traefik ingress + HAProxy). Dedicated `proxy` index for
+    # ingress/L7 visibility. standard 523 = HAProxy frontend; high 1523 = Cribl Edge
+    # backend. Traefik and HAProxy are distinguished by sourcetype in the pipeline.
+    proxy = { standard = 523, high = 1523, index = "proxy", sourcetype = "haproxy" }
   }
 
   pipeline_constants = {
@@ -142,6 +162,25 @@ locals {
     vector_db_ports = {
       qdrant_http = 6333
       qdrant_grpc = 6334
+    }
+    # AI / LLM log-ingest ports — one dedicated Cribl TCP-JSON receiver per source
+    # family, HAProxy-fronted (LB to the Cribl Stream pair, mirroring the claude S2S
+    # path). Cribl best practice is a dedicated port per source so routing is by
+    # listener, not payload inspection. The backend flow reuses the existing
+    # cribl_s2s (10300) receiver on Stream; these frontends are opened on the
+    # pipeline (HAProxy) containers by the ai-log-ingest security group. Splunk
+    # index each lands in is noted; new indexes (codex, openbao_audit) are created
+    # in ansible-splunk in a later phase — see the WS3-max tracking issue.
+    ai_log_ports = {
+      claude_code    = 10311 # MacBook claude-code IO logs      -> index=claude
+      codex_cli      = 10312 # MacBook codex CLI logs           -> index=codex (new)
+      agy_cli        = 10313 # MacBook agy/antigravity CLI logs -> index=gemini
+      copilot_cli    = 10314 # MacBook GitHub Copilot logs      -> index=openai
+      vscode         = 10315 # VS Code telemetry                -> index=vscode
+      macstudio_llm  = 10321 # Mac Studio llama-swap + vllm-mlx -> index=llm
+      macstudio_gate = 10322 # Mac Studio caddy LLM-gate access -> index=llm
+      homelab_llm    = 10323 # homelab llama_cpp + llm_router   -> index=llm
+      openbao_audit  = 10331 # OpenBao file audit device        -> index=openbao_audit (new)
     }
     # IaC automation platform (Terrakube + Semaphore UI) on the iac-platform VM
     # (docker compose, mgmt VLAN, pve3). Host ports published by the compose

--- a/modules/firewall/ai_log_ingest_rules.tf
+++ b/modules/firewall/ai_log_ingest_rules.tf
@@ -1,0 +1,44 @@
+# AI / LLM log-ingest security group.
+#
+# One dedicated Cribl TCP-JSON receiver per AI-log source family (MacBook AI
+# tools, Mac Studio LLM stack, homelab LLM fabric, OpenBao audit). All are
+# HAProxy-fronted TCP frontends the sources dial; HAProxy load-balances to the
+# Cribl Stream pair over the existing cribl_s2s (10300) backend (already opened
+# by cribl_stream_services_rules). This group only opens the per-source
+# frontends on the pipeline (HAProxy) containers — see the attachment in
+# pipeline_container_rules.tf.
+#
+# Rule data lives here (not in locals.tf) so that file stays under the shared
+# _file-size 12 KB error threshold. local.svc_ports / local.internal_src are
+# defined in locals.tf — cross-file local refs resolve within the module.
+#
+# DRY: every port is sourced from var.pipeline_constants.ai_log_ports; the rule
+# set expands automatically when a new source family is added to that map. All
+# ports are TCP (Cribl TCP-JSON), inbound from internal RFC1918 networks.
+locals {
+  ai_log_ingest_rules = [
+    for name, port in local.ai_log_ports : {
+      proto   = "tcp"
+      dport   = tostring(port)
+      source  = local.internal_src
+      comment = "AI log ingest ${name} (TCP ${port}) from internal"
+    }
+  ]
+}
+
+resource "proxmox_virtual_environment_cluster_firewall_security_group" "ai_log_ingest" {
+  name    = "ai-log-ingest"
+  comment = "AI/LLM log-ingest TCP-JSON frontends (MacBook tools, Mac Studio LLM, homelab LLM, OpenBao audit) from internal networks"
+
+  dynamic "rule" {
+    for_each = local.ai_log_ingest_rules
+    content {
+      type    = "in"
+      action  = "ACCEPT"
+      proto   = rule.value.proto
+      dport   = rule.value.dport
+      source  = rule.value.source
+      comment = rule.value.comment
+    }
+  }
+}

--- a/modules/firewall/locals.tf
+++ b/modules/firewall/locals.tf
@@ -54,6 +54,7 @@ locals {
   vector_db_ports    = var.pipeline_constants.vector_db_ports
   netflow_ports      = var.pipeline_constants.netflow_ports
   honeypot_ports     = var.pipeline_constants.honeypot_ports
+  ai_log_ports       = var.pipeline_constants.ai_log_ports
 
   # Syslog ports — derived from syslog_port_map so that adding a new source
   # family auto-expands the firewall surface. standard = app-facing HAProxy

--- a/modules/firewall/pipeline_container_rules.tf
+++ b/modules/firewall/pipeline_container_rules.tf
@@ -45,6 +45,11 @@ resource "proxmox_virtual_environment_firewall_rules" "pipeline_container" {
   }
 
   rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.ai_log_ingest.name
+    comment        = "AI/LLM log-ingest TCP-JSON frontends (HAProxy -> Cribl Stream)"
+  }
+
+  rule {
     security_group = proxmox_virtual_environment_cluster_firewall_security_group.outbound_internal.name
     comment        = "Outbound to internal only"
   }

--- a/modules/firewall/tests/rule_generation.tftest.hcl
+++ b/modules/firewall/tests/rule_generation.tftest.hcl
@@ -70,6 +70,17 @@ variables {
       qdrant_http = 6333
       qdrant_grpc = 6334
     }
+    ai_log_ports = {
+      claude_code    = 10311
+      codex_cli      = 10312
+      agy_cli        = 10313
+      copilot_cli    = 10314
+      vscode         = 10315
+      macstudio_llm  = 10321
+      macstudio_gate = 10322
+      homelab_llm    = 10323
+      openbao_audit  = 10331
+    }
     honeypot_ports = {
       apprise_api = 8000
       ftp         = 21
@@ -494,6 +505,36 @@ run "honeypot_decoy_rules_track_constants_and_split_proto" {
   assert {
     condition     = length([for r in local.honeypot_services_rules : r if r.proto == "udp"]) == 4
     error_message = "honeypot_services_rules must include exactly 4 UDP decoys (snmp/sip/tftp/ntp), got ${length([for r in local.honeypot_services_rules : r if r.proto == "udp"])}"
+  }
+}
+
+run "ai_log_ingest_rules_track_constants" {
+  command = plan
+
+  variables {
+    internal_networks = ["192.168.10.0/24", "192.168.20.0/24"]
+  }
+
+  # One TCP rule per ai_log_ports entry (9 here), all sourced from the joined nets.
+  assert {
+    condition     = length(local.ai_log_ingest_rules) == length(var.pipeline_constants.ai_log_ports)
+    error_message = "ai_log_ingest_rules must have one rule per ai_log_ports entry, got ${length(local.ai_log_ingest_rules)}"
+  }
+
+  assert {
+    condition     = alltrue([for r in local.ai_log_ingest_rules : r.proto == "tcp"])
+    error_message = "all ai_log_ingest_rules must be TCP"
+  }
+
+  assert {
+    condition     = alltrue([for r in local.ai_log_ingest_rules : r.source == "192.168.10.0/24,192.168.20.0/24"])
+    error_message = "ai_log_ingest_rules source must be the comma-joined internal networks"
+  }
+
+  # dports track the constants map exactly (no literals).
+  assert {
+    condition     = alltrue([for r in local.ai_log_ingest_rules : contains([for p in values(var.pipeline_constants.ai_log_ports) : tostring(p)], r.dport)])
+    error_message = "every ai_log_ingest rule dport must come from pipeline_constants.ai_log_ports"
   }
 }
 

--- a/modules/firewall/variables.tf
+++ b/modules/firewall/variables.tf
@@ -178,6 +178,7 @@ variable "pipeline_constants" {
     notification_ports = map(number)
     vector_db_ports    = map(number)
     honeypot_ports     = map(number)
+    ai_log_ports       = map(number)
   })
 }
 


### PR DESCRIPTION
## What

Source-of-truth layer for the estate-wide observability program: every logging source that should reach Splunk gets its **own dedicated Cribl ingest port** (Cribl best practice — route by listener, not payload), and the guest-layer firewall is pre-opened so the flows are allowed on apply.

This PR is **constants + firewall only**. No apply. Downstream Cribl / HAProxy / Technitium / nix-darwin / ansible-splunk PRs consume these constants. It changes live firewall on apply, so leaving open for orchestrator review.

## Why (current state, measured live)

Only two sources actually flow to Splunk at volume today — UniFi syslog (`unifi`, ~14.6M/7d) and Linux host syslog (`os`, ~1.2M/7d). Every AI/LLM/OTEL/metric path is **zero or stale**: `claude` went silent in the last 7d, and `llm`/`otel`/`openai`/`vscode`/`mac_perf` plus both metric indexes are empty. UniFi admin vs firewall events are not split (all buried in `unifi`). Full audit matrix + top-10 gaps are in the tracking issue.

## Changes

`constants.tf` — `pipeline_constants`:

- **`syslog_port_map`** — four new HAProxy-fronted syslog families (standard frontend + high Cribl Edge backend + index/sourcetype). These auto-expand the derived syslog firewall surface to 514-523 / 1514-1523:
  | family | ports | index |
  | --- | --- | --- |
  | `unifi_fw` | 520/1520 | firewall (split threat/IPS from admin) |
  | `macos` | 521/1521 | os (correct home for Mac host syslog) |
  | `dns_query` | 522/1522 | dns (Technitium query logs) |
  | `proxy` | 523/1523 | proxy (Traefik + HAProxy access logs) |
- **`service_ports.ai_log_ports`** — new sub-map, one dedicated TCP-JSON receiver per AI-log source (MacBook claude/codex/agy/copilot/vscode, Mac Studio llama-swap+vllm+gate, homelab llama_cpp+llm_router, OpenBao audit), ports 10311-10331. HAProxy-fronted; backend reuses the existing `cribl_s2s` (10300) receiver on the Stream pair.

`modules/firewall/`:

- New **`ai-log-ingest`** cluster security group — one TCP allow per `ai_log_ports` entry from internal networks — attached to the pipeline (HAProxy) containers. The new syslog families need **no** new firewall code: the `syslog` group derives its port list from `syslog_port_map`, so it expands automatically.
- `ai_log_ports` threaded through the module `pipeline_constants` object type + aliased in locals; new mock entries and a rule-generation assertion in the module test.

## Verification

- `tofu fmt -check -recursive` — clean
- `tofu validate` — Success
- `tofu test` (root, real constants through the module) — **107 passed, 0 failed**
- pre-commit (fmt, checkov, tflint, tofu-test, secret scan) — all pass
- No new tflint warnings (all new declarations are used)

## Not in scope (tracked in the issue's phased checklist)

New Splunk indexes (`dns`, `proxy`, `codex`, `openbao_audit`, metric `host_metrics`/`llm_metrics`) in ansible-splunk; Cribl source/pipeline wiring per port; nix-darwin macOS-syslog repoint off the UniFi backend port; UniFi netflow/syslog-as-IaC; the OTLP-delivers-zero fix (separately owned). The matching `tofu-unifi` inter-VLAN rules ship `enabled = false` (provider rule-index gap — do not enable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011cXrVfFqrTQdYqZvAHpE8j