### PR TITLE
fix(tests): repair firewall module test suite and gate it in CI

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -40,6 +40,18 @@ jobs:
         id: test
         run: tofu test -no-color
 
+      # tofu test does not recurse into modules/*/tests — gate module suites
+      # explicitly so they can never silently rot again (#580).
+      - name: OpenTofu Init (firewall module)
+        id: init_firewall
+        run: tofu init -backend=false
+        working-directory: modules/firewall
+
+      - name: OpenTofu Test (firewall module)
+        id: test_firewall
+        run: tofu test -no-color
+        working-directory: modules/firewall
+
       # - name: Terraform Plan
       #   id: plan
       #   run: terraform plan -no-color

--- a/modules/firewall/tests/rule_generation.tftest.hcl
+++ b/modules/firewall/tests/rule_generation.tftest.hcl
@@ -11,6 +11,7 @@ variables {
   management_network = "192.168.10.0/24"
   splunk_network     = "192.168.20.200"
   internal_networks  = ["192.168.0.0/16"]
+  ai_network         = "192.168.50.0/24"
   pipeline_constants = {
     service_ports = {
       haproxy_stats     = 8404
@@ -33,8 +34,8 @@ variables {
       postgres_default       = 5432
       redis_default          = 6379
       ntp                    = 123
-      idrac_kvm_r410         = 5800
-      idrac_kvm_r710         = 5801
+      idrac_kvm_r410         = 5410
+      idrac_kvm_r710         = 5710
       # monitoring ports (own alignment group — longest key in the map)
       smokeping_web      = 80
       speedtest_exporter = 9798
@@ -42,6 +43,24 @@ variables {
       blackbox_exporter  = 9115
       atlas_exporter     = 9400
       irtt               = 2112
+      # LLM fabric + agentgateway (referenced by llm_fabric/agentgateway rules)
+      llm_fast_api       = 10434
+      llm_router_api     = 4000
+      agentgateway_proxy = 8080
+      agentgateway_admin = 15000
+      # AI orchestration + observability (referenced by ai_orchestration rules)
+      n8n_web           = 5678
+      dify_web          = 80
+      langflow_web      = 7860
+      langfuse_web      = 3000
+      langgraph_api     = 8124
+      agent_chat_ui_web = 3000
+      otel_traces_grpc  = 4317
+      otel_traces_http  = 4318
+      otel_metrics_grpc = 4327
+      otel_metrics_http = 4328
+      otel_logs_grpc    = 4337
+      otel_logs_http    = 4338
     }
     syslog_ports = {
       default   = 514


### PR DESCRIPTION
The standalone suite in modules/firewall/tests was pre-broken and never ran:
tofu test only discovers tests/ at the working directory, and the repo-root
CI job never entered modules/firewall, so two independent failures went
undetected:

- the required ai_network variable (no default) was never set, failing the
  run before any assertion executed
- the mock pipeline_constants.service_ports predates the LLM fabric,
  agentgateway, AI-orchestration, and OTLP rule files, so plan-time
  dereferences of those keys failed with 'map does not have an element'

Add the missing variable, extend the mock with every service_ports key the
module dereferences (grep 'svc_ports\.' is the authoritative list), align
the stale idrac mock values with the real constants, and add a dedicated
init+test CI step with working-directory modules/firewall so the module
suite gates every PR from now on. The existing ai-log-ingest security-group
assertions begin executing with this change.

Closes #580

> [!IMPORTANT]
> Closes #580. Wave-1: merge FIRST in this repo (feat/firewall-edge-node-exporter-scrape stacks on it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)