### PR TITLE
feat(firewall): dual pipeline+siem zero-trust sources for the VLAN-40 rebuild

### DIFF
--- a/modules/firewall/pipeline_container_rules.tf
+++ b/modules/firewall/pipeline_container_rules.tf
@@ -107,7 +107,7 @@ resource "proxmox_virtual_environment_firewall_rules" "pipeline_container" {
     action  = "ACCEPT"
     proto   = "tcp"
     dport   = local.pipeline_syslog_range
-    source  = local.zt_src["pipeline"]
+    source  = join(",", compact([local.zt_src["pipeline"], local.zt_src["siem"]]))
     comment = "ZT: Cribl backend intra-pipeline"
   }
 
@@ -117,7 +117,7 @@ resource "proxmox_virtual_environment_firewall_rules" "pipeline_container" {
     action  = "ACCEPT"
     proto   = "tcp"
     dport   = tostring(local.svc_ports.cribl_s2s)
-    source  = local.zt_src["pipeline"]
+    source  = join(",", compact([local.zt_src["pipeline"], local.zt_src["siem"]]))
     comment = "ZT: Cribl S2S intra-pipeline"
   }
 

--- a/modules/firewall/splunk_container_rules.tf
+++ b/modules/firewall/splunk_container_rules.tf
@@ -56,7 +56,7 @@ resource "proxmox_virtual_environment_firewall_rules" "splunk_container" {
     action  = "ACCEPT"
     proto   = "tcp"
     dport   = tostring(local.svc_ports.splunk_hec)
-    source  = local.zt_src["pipeline"]
+    source  = join(",", compact([local.zt_src["pipeline"], local.zt_src["siem"]]))
     comment = "ZT: Splunk HEC from pipeline"
   }
 

--- a/tests/firewall_filtering.tftest.hcl
+++ b/tests/firewall_filtering.tftest.hcl
@@ -84,9 +84,9 @@ run "haproxy_tagged_container_in_pipeline_ids" {
   variables {
     containers = {
       "haproxy" = {
-        vm_id    = 190
+        vm_id    = 421040
         hostname = "haproxy"
-        vlan     = "pipeline"
+        vlan     = "siem"
         tags     = ["terraform", "haproxy", "container"]
       }
     }
@@ -98,8 +98,8 @@ run "haproxy_tagged_container_in_pipeline_ids" {
   }
 
   assert {
-    condition     = local.pipeline_container_ids["haproxy"] == 190
-    error_message = "pipeline_container_ids['haproxy'] should be vm_id 190"
+    condition     = local.pipeline_container_ids["haproxy"] == 421040
+    error_message = "pipeline_container_ids['haproxy'] should be vm_id 421040"
   }
 }
 
@@ -109,9 +109,9 @@ run "cribl_edge_tagged_container_in_pipeline_ids" {
   variables {
     containers = {
       "cribl-edge" = {
-        vm_id    = 181
+        vm_id    = 423040
         hostname = "cribl-edge"
-        vlan     = "pipeline"
+        vlan     = "siem"
         tags     = ["terraform", "cribl", "edge", "container"]
       }
     }
@@ -123,8 +123,8 @@ run "cribl_edge_tagged_container_in_pipeline_ids" {
   }
 
   assert {
-    condition     = local.pipeline_container_ids["cribl-edge"] == 181
-    error_message = "pipeline_container_ids['cribl-edge'] should be vm_id 181"
+    condition     = local.pipeline_container_ids["cribl-edge"] == 423040
+    error_message = "pipeline_container_ids['cribl-edge'] should be vm_id 423040"
   }
 }
 
@@ -207,9 +207,9 @@ run "cribl_without_edge_not_in_pipeline_ids" {
   variables {
     containers = {
       "cribl-stream" = {
-        vm_id    = 171
+        vm_id    = 425040
         hostname = "cribl-stream"
-        vlan     = "pipeline"
+        vlan     = "siem"
         tags     = ["terraform", "cribl", "stream", "container"]
       }
     }
@@ -229,9 +229,9 @@ run "cribl_stream_tagged_container_in_cribl_stream_ids" {
   variables {
     containers = {
       "cribl-stream" = {
-        vm_id    = 171
+        vm_id    = 425040
         hostname = "cribl-stream"
-        vlan     = "pipeline"
+        vlan     = "siem"
         tags     = ["terraform", "cribl", "stream", "pipeline", "container"]
       }
     }
@@ -243,8 +243,8 @@ run "cribl_stream_tagged_container_in_cribl_stream_ids" {
   }
 
   assert {
-    condition     = local.cribl_stream_container_ids["cribl-stream"] == 171
-    error_message = "cribl_stream_container_ids['cribl-stream'] should be vm_id 171"
+    condition     = local.cribl_stream_container_ids["cribl-stream"] == 425040
+    error_message = "cribl_stream_container_ids['cribl-stream'] should be vm_id 425040"
   }
 
   assert {
@@ -259,9 +259,9 @@ run "cribl_edge_not_in_cribl_stream_ids" {
   variables {
     containers = {
       "cribl-edge-01" = {
-        vm_id    = 180
+        vm_id    = 423040
         hostname = "cribl-edge-01"
-        vlan     = "pipeline"
+        vlan     = "siem"
         tags     = ["terraform", "cribl", "edge", "pipeline", "container"]
       }
     }
@@ -360,21 +360,21 @@ run "pipeline_and_stream_containers_mutually_exclusive" {
   variables {
     containers = {
       "haproxy" = {
-        vm_id    = 175
+        vm_id    = 421040
         hostname = "haproxy"
-        vlan     = "pipeline"
+        vlan     = "siem"
         tags     = ["terraform", "haproxy", "pipeline", "container"]
       }
       "cribl-edge-01" = {
-        vm_id    = 180
+        vm_id    = 423040
         hostname = "cribl-edge-01"
-        vlan     = "pipeline"
+        vlan     = "siem"
         tags     = ["terraform", "cribl", "edge", "pipeline", "container"]
       }
       "cribl-stream" = {
-        vm_id    = 171
+        vm_id    = 425040
         hostname = "cribl-stream"
-        vlan     = "pipeline"
+        vlan     = "siem"
         tags     = ["terraform", "cribl", "stream", "pipeline", "container"]
       }
     }

--- a/tests/firewall_filtering.tftest.hcl
+++ b/tests/firewall_filtering.tftest.hcl
@@ -84,10 +84,12 @@ run "haproxy_tagged_container_in_pipeline_ids" {
   variables {
     containers = {
       "haproxy" = {
-        vm_id    = 421040
-        hostname = "haproxy"
-        vlan     = "siem"
-        tags     = ["terraform", "haproxy", "container"]
+        vm_id         = 421040
+        dhcp          = true
+        reserved_host = 21
+        hostname      = "haproxy"
+        vlan          = "siem"
+        tags          = ["terraform", "haproxy", "container"]
       }
     }
   }
@@ -109,10 +111,12 @@ run "cribl_edge_tagged_container_in_pipeline_ids" {
   variables {
     containers = {
       "cribl-edge" = {
-        vm_id    = 423040
-        hostname = "cribl-edge"
-        vlan     = "siem"
-        tags     = ["terraform", "cribl", "edge", "container"]
+        vm_id         = 423040
+        dhcp          = true
+        reserved_host = 23
+        hostname      = "cribl-edge"
+        vlan          = "siem"
+        tags          = ["terraform", "cribl", "edge", "container"]
       }
     }
   }
@@ -207,10 +211,12 @@ run "cribl_without_edge_not_in_pipeline_ids" {
   variables {
     containers = {
       "cribl-stream" = {
-        vm_id    = 425040
-        hostname = "cribl-stream"
-        vlan     = "siem"
-        tags     = ["terraform", "cribl", "stream", "container"]
+        vm_id         = 425040
+        dhcp          = true
+        reserved_host = 25
+        hostname      = "cribl-stream"
+        vlan          = "siem"
+        tags          = ["terraform", "cribl", "stream", "container"]
       }
     }
   }
@@ -229,10 +235,12 @@ run "cribl_stream_tagged_container_in_cribl_stream_ids" {
   variables {
     containers = {
       "cribl-stream" = {
-        vm_id    = 425040
-        hostname = "cribl-stream"
-        vlan     = "siem"
-        tags     = ["terraform", "cribl", "stream", "pipeline", "container"]
+        vm_id         = 425040
+        dhcp          = true
+        reserved_host = 25
+        hostname      = "cribl-stream"
+        vlan          = "siem"
+        tags          = ["terraform", "cribl", "stream", "pipeline", "container"]
       }
     }
   }
@@ -259,10 +267,12 @@ run "cribl_edge_not_in_cribl_stream_ids" {
   variables {
     containers = {
       "cribl-edge-01" = {
-        vm_id    = 423040
-        hostname = "cribl-edge-01"
-        vlan     = "siem"
-        tags     = ["terraform", "cribl", "edge", "pipeline", "container"]
+        vm_id         = 423040
+        dhcp          = true
+        reserved_host = 23
+        hostname      = "cribl-edge-01"
+        vlan          = "siem"
+        tags          = ["terraform", "cribl", "edge", "pipeline", "container"]
       }
     }
   }
@@ -360,22 +370,28 @@ run "pipeline_and_stream_containers_mutually_exclusive" {
   variables {
     containers = {
       "haproxy" = {
-        vm_id    = 421040
-        hostname = "haproxy"
-        vlan     = "siem"
-        tags     = ["terraform", "haproxy", "pipeline", "container"]
+        vm_id         = 421040
+        dhcp          = true
+        reserved_host = 21
+        hostname      = "haproxy"
+        vlan          = "siem"
+        tags          = ["terraform", "haproxy", "pipeline", "container"]
       }
       "cribl-edge-01" = {
-        vm_id    = 423040
-        hostname = "cribl-edge-01"
-        vlan     = "siem"
-        tags     = ["terraform", "cribl", "edge", "pipeline", "container"]
+        vm_id         = 423040
+        dhcp          = true
+        reserved_host = 23
+        hostname      = "cribl-edge-01"
+        vlan          = "siem"
+        tags          = ["terraform", "cribl", "edge", "pipeline", "container"]
       }
       "cribl-stream" = {
-        vm_id    = 425040
-        hostname = "cribl-stream"
-        vlan     = "siem"
-        tags     = ["terraform", "cribl", "stream", "pipeline", "container"]
+        vm_id         = 425040
+        dhcp          = true
+        reserved_host = 25
+        hostname      = "cribl-stream"
+        vlan          = "siem"
+        tags          = ["terraform", "cribl", "stream", "pipeline", "container"]
       }
     }
   }

--- a/tests/locals.tftest.hcl
+++ b/tests/locals.tftest.hcl
@@ -553,10 +553,12 @@ run "cribl_stream_ids_picks_up_stream_tagged" {
   variables {
     containers = {
       "cribl-stream" = {
-        vm_id    = 425040
-        hostname = "cribl-stream"
-        vlan     = "siem"
-        tags     = ["terraform", "cribl", "stream", "container"]
+        vm_id         = 425040
+        dhcp          = true
+        reserved_host = 25
+        hostname      = "cribl-stream"
+        vlan          = "siem"
+        tags          = ["terraform", "cribl", "stream", "container"]
       }
     }
   }

--- a/tests/locals.tftest.hcl
+++ b/tests/locals.tftest.hcl
@@ -87,7 +87,10 @@ run "container_ipv4_uses_vlan_cidr" {
   variables {
     containers = {
       "technitium-dns" = { vm_id = 103, hostname = "technitium-dns", vlan = "dns" }
-      "haproxy"        = { vm_id = 175, hostname = "haproxy", vlan = "pipeline" }
+      # Rebuilt pipeline-tier guest: siem VLAN (40), DHCP-first with a positional
+      # VMID (candidate id — final allocation confirmed against the private
+      # allocation table before the rebuild apply).
+      "haproxy" = { vm_id = 421040, hostname = "haproxy", vlan = "siem", dhcp = true, reserved_host = 21 }
     }
   }
 
@@ -101,9 +104,16 @@ run "container_ipv4_uses_vlan_cidr" {
     error_message = "dns-VLAN gateway should be 192.168.2.1, got ${local.container_gateway["technitium-dns"]}"
   }
 
+  # DHCP-first guest short-circuits cidrhost — the positional VMID must never
+  # be interpreted as a /24 host number.
   assert {
-    condition     = local.container_ipv4["haproxy"] == "192.168.25.175/24"
-    error_message = "pipeline-VLAN container 175 should be 192.168.25.175/24, got ${local.container_ipv4["haproxy"]}"
+    condition     = local.container_ipv4["haproxy"] == "dhcp"
+    error_message = "dhcp-first siem-VLAN guest must pass through as 'dhcp', got ${local.container_ipv4["haproxy"]}"
+  }
+
+  assert {
+    condition     = local.container_reserved_ip["haproxy"] == "192.168.40.21"
+    error_message = "siem-VLAN reserved_host 21 must yield 192.168.40.21, got ${local.container_reserved_ip["haproxy"]}"
   }
 }
 
@@ -543,9 +553,9 @@ run "cribl_stream_ids_picks_up_stream_tagged" {
   variables {
     containers = {
       "cribl-stream" = {
-        vm_id    = 182
+        vm_id    = 425040
         hostname = "cribl-stream"
-        vlan     = "pipeline"
+        vlan     = "siem"
         tags     = ["terraform", "cribl", "stream", "container"]
       }
     }
@@ -557,8 +567,8 @@ run "cribl_stream_ids_picks_up_stream_tagged" {
   }
 
   assert {
-    condition     = local.cribl_stream_container_ids["cribl-stream"] == 182
-    error_message = "cribl_stream_container_ids should map 'cribl-stream' to vm_id 182"
+    condition     = local.cribl_stream_container_ids["cribl-stream"] == 425040
+    error_message = "cribl_stream_container_ids should map 'cribl-stream' to vm_id 425040"
   }
 }
 
@@ -652,10 +662,10 @@ run "container_reserved_ip_from_reserved_host" {
         tags          = ["terraform", "container", "monitoring", "docker"]
       }
       # Static guest: no reserved_ip (advertises its derived IP instead).
-      "haproxy" = {
-        vm_id    = 175
-        hostname = "haproxy"
-        vlan     = "pipeline"
+      "apt-cacher-ng" = {
+        vm_id    = 108
+        hostname = "apt-cacher-ng"
+        vlan     = "compute"
       }
     }
   }
@@ -668,13 +678,13 @@ run "container_reserved_ip_from_reserved_host" {
 
   # Static guest has no reservation.
   assert {
-    condition     = local.container_reserved_ip["haproxy"] == null
+    condition     = local.container_reserved_ip["apt-cacher-ng"] == null
     error_message = "static guest must have reserved_ip = null"
   }
 
   # Static guest also carries no DHCP MAC in the inventory export.
   assert {
-    condition     = output.ansible_inventory.containers["haproxy"].mac == null
+    condition     = output.ansible_inventory.containers["apt-cacher-ng"].mac == null
     error_message = "static guest inventory mac must be null"
   }
 


### PR DESCRIPTION
The observability pipeline tier (haproxy, cribl-edge-01/02, cribl-stream-01/02)
is being rebuilt from the decommissioned pipeline VLAN onto its proper trust
tier (siem, VLAN 40) with positional VMIDs. All firewall attachment logic is
tag-keyed, so the guests follow automatically once deployment.json changes;
the only rule-level references to the old VLAN are the three staged-disabled
zero-trust sources, which now accept from both VLANs for a zero-downtime
cutover. compact() keeps the joined source valid while either CIDR is absent
from the runtime map. The pipeline key is retired in a follow-up after soak.

Test mocks move to the target state: siem VLAN, DHCP-first with deterministic
MAC + reserved_host (the established positional-VMID pattern), candidate ids
421040/423040/425040 pending the private allocation-table confirmation. The
reserved-ip export run keeps its static-guest coverage via apt-cacher-ng.

Refs #579

> [!IMPORTANT]
> GATE B — human merge only (live firewall-rule change). Staged-disabled ZT rules only; the L1 apply is expected 0-destroy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)