### PR TITLE
feat(constants): ai_log_routing map — per-source index/sourcetype truth

### DIFF
--- a/constants-ai-log.tf
+++ b/constants-ai-log.tf
@@ -22,4 +22,32 @@ locals {
     homelab_llm    = 10323 # homelab llama_cpp + llm_router   -> index=llm
     openbao_audit  = 10331 # OpenBao file audit device        -> index=openbao_audit (new)
   }
+
+  # Splunk landing zone per source, keyed to the SAME names as ai_log_ports so
+  # the two maps cannot drift apart (ai_log_routing derives its port from
+  # ai_log_ports; a name mismatch is a plan-time error). This is the single
+  # routing truth the downstream repos consume via ansible_inventory.constants:
+  # HAProxy renders one frontend per entry, Cribl Stream one tcpjson/syslog
+  # input per entry, and the ai_stamp pipeline stamps index/sourcetype from it.
+  # ai_log_ports itself stays map(number) — the firewall module types it, and
+  # it is already applied — so the routing metadata lives in this additive map.
+  ai_log_index_map = {
+    claude_code    = { index = "claude", sourcetype = "claude:code" }
+    codex_cli      = { index = "codex", sourcetype = "codex:cli" }
+    agy_cli        = { index = "gemini", sourcetype = "antigravity:cli" }
+    copilot_cli    = { index = "openai", sourcetype = "copilot:cli" }
+    vscode         = { index = "vscode", sourcetype = "vscode:telemetry" }
+    macstudio_llm  = { index = "llm", sourcetype = "llamaswap" }
+    macstudio_gate = { index = "llm", sourcetype = "caddy:access" }
+    homelab_llm    = { index = "llm", sourcetype = "llamaswap" }
+    openbao_audit  = { index = "openbao_audit", sourcetype = "openbao:audit" }
+  }
+
+  ai_log_routing = {
+    for name, port in local.ai_log_ports : name => {
+      port       = port
+      index      = local.ai_log_index_map[name].index
+      sourcetype = local.ai_log_index_map[name].sourcetype
+    }
+  }
 }

--- a/constants.tf
+++ b/constants.tf
@@ -167,6 +167,9 @@ locals {
     # family (defined in constants-ai-log.tf to keep this file under the shared
     # _file-size 12 KB gate; locals merge across files in the module).
     ai_log_ports = local.ai_log_ports
+    # name -> { port, index, sourcetype } routing truth for those receivers
+    # (ports derived from ai_log_ports, so the maps cannot drift).
+    ai_log_routing = local.ai_log_routing
     # IaC automation platform (Terrakube + Semaphore UI) on the iac-platform VM
     # (docker compose, mgmt VLAN, pve3). Host ports published by the compose
     # stack; ingress.tf fronts each behind its own <name>.<domain> route. The

--- a/tests/locals.tftest.hcl
+++ b/tests/locals.tftest.hcl
@@ -689,3 +689,46 @@ run "container_reserved_ip_from_reserved_host" {
     error_message = "dhcp guest inventory mac must be the 02:-prefixed deterministic MAC"
   }
 }
+
+# --- ai_log_routing tests (routing truth derives from ai_log_ports) ---
+
+run "ai_log_routing_ports_track_ai_log_ports" {
+  command = plan
+
+  # Same key set, and every routing port equals its ai_log_ports twin — the
+  # routing map is derived, so a drifted port is impossible by construction;
+  # this asserts the derivation itself stays wired.
+  assert {
+    condition     = keys(local.ai_log_routing) == keys(local.ai_log_ports)
+    error_message = "ai_log_routing must have exactly the ai_log_ports key set"
+  }
+
+  assert {
+    condition     = alltrue([for name, r in local.ai_log_routing : r.port == local.ai_log_ports[name]])
+    error_message = "every ai_log_routing port must equal its ai_log_ports twin"
+  }
+
+  assert {
+    condition     = alltrue([for name, r in local.ai_log_routing : length(r.index) > 0 && length(r.sourcetype) > 0])
+    error_message = "every ai_log_routing entry needs a non-empty index and sourcetype"
+  }
+}
+
+run "ai_log_routing_exported_in_pipeline_constants" {
+  command = plan
+
+  assert {
+    condition     = local.pipeline_constants.ai_log_routing == local.ai_log_routing
+    error_message = "pipeline_constants must surface ai_log_routing for the ansible_inventory consumers"
+  }
+
+  assert {
+    condition     = local.pipeline_constants.ai_log_routing.claude_code.index == "claude"
+    error_message = "claude_code must route to index=claude"
+  }
+
+  assert {
+    condition     = local.pipeline_constants.ai_log_routing.openbao_audit.sourcetype == "openbao:audit"
+    error_message = "openbao_audit must carry sourcetype openbao:audit"
+  }
+}


### PR DESCRIPTION
Publishes the name -> { port, index, sourcetype } routing map for the AI
log-ingest receivers as a new pipeline_constants key. The downstream repos
consume it via ansible_inventory.constants: HAProxy renders one frontend per
entry, Cribl Stream one input per entry, and the stamping pipeline assigns
index/sourcetype from it — replacing the inline comments in ai_log_ports as
the machine-readable source of truth.

The map is additive and derives its ports from ai_log_ports (a name mismatch
is a plan-time error), so the applied firewall module — which types
ai_log_ports as map(number) — is untouched and the change plans as an
inventory-object update only.

Refs #579

> [!IMPORTANT]
> Additive constant; post-merge plan should be an inventory-object update only (L12a).

🤖 Generated with [Claude Code](https://claude.com/claude-code)