### PR TITLE
feat(firewall): DROP/DROP guest companions for the LAN-only media tier

### DIFF
--- a/locals-media.tf
+++ b/locals-media.tf
@@ -1,0 +1,15 @@
+# Media-tier tag-filter locals, split from locals.tf to keep that file under
+# the shared _file-size 12 KB error threshold; locals merge across files.
+locals {
+  # LAN-only media guests (media tag), EXCLUDING the VPN-locked downloader
+  # (vpn tag). The downloader's fail-closed in-guest killswitch is its enforced
+  # network boundary — stacking a hypervisor DROP policy underneath the tunnel
+  # would add a second, independently-managed failure mode without adding
+  # coverage (the killswitch already denies every flow the guest firewall
+  # would). See docs/ARCHITECTURE.md (media pool firewall boundary).
+  media_container_ids = {
+    for k, v in var.containers : k => v.vm_id
+    if contains(coalesce(try(v.tags, null), []), "media")
+    && !contains(coalesce(try(v.tags, null), []), "vpn")
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -238,6 +238,10 @@ module "firewall" {
   # Network-quality monitoring LXC: tagged "monitoring" (SmokePing + speedtest-exporter)
   monitoring_container_ids = local.monitoring_container_ids
 
+  # LAN-only media LXCs: media tag minus the VPN-locked downloader (its in-guest
+  # killswitch is the boundary; see locals-media.tf)
+  media_container_ids = local.media_container_ids
+
   # Hermes Agent LXC: tagged "hermes-agent" (autonomous agent, broad HTTPS egress)
   hermes_agent_container_ids = local.hermes_agent_container_ids
 

--- a/modules/firewall/media_rules.tf
+++ b/modules/firewall/media_rules.tf
@@ -1,0 +1,81 @@
+# Media tier guest firewall. The LAN-only media guests (PVRs, streaming,
+# request UI, insights dashboard) get the standard DROP/DROP companion:
+# internal access, their own web port from internal, and internal + HTTPS
+# egress (cross-app wiring lives on internal networks; metadata providers and
+# container-image pulls need outbound TLS).
+#
+# The VPN-locked downloader is deliberately ABSENT: its fail-closed in-guest
+# killswitch is the enforced boundary (root locals-media.tf excludes it from
+# var.media_container_ids by tag).
+#
+# Inbound web ports are attached as per-guest inline rules keyed by container
+# name — NOT one shared security group — so no guest exposes a sibling's port.
+# A media guest with no entry in the map gets no inbound web allowance at all
+# (safe default for a future addition). Ports are DRY from pipeline_constants.
+locals {
+  media_ports = var.pipeline_constants.media_ports
+
+  media_web_rules = {
+    sonarr  = { dport = tostring(local.media_ports.sonarr_web), comment = "Sonarr web/API (TCP ${local.media_ports.sonarr_web}) from internal" }
+    radarr  = { dport = tostring(local.media_ports.radarr_web), comment = "Radarr web/API (TCP ${local.media_ports.radarr_web}) from internal" }
+    plex    = { dport = tostring(local.media_ports.plex_web), comment = "Plex web/streaming (TCP ${local.media_ports.plex_web}) from internal" }
+    seerr   = { dport = tostring(local.media_ports.seerr_web), comment = "Seerr request UI/API (TCP ${local.media_ports.seerr_web}) from internal" }
+    sortarr = { dport = tostring(local.media_ports.sortarr_web), comment = "Sortarr insights UI (TCP ${local.media_ports.sortarr_web}) from internal" }
+  }
+}
+
+resource "proxmox_virtual_environment_firewall_options" "media_container" {
+  for_each = var.media_container_ids
+
+  node_name     = var.node_name
+  container_id  = each.value
+  enabled       = local.firewall_defaults.enabled
+  input_policy  = local.firewall_defaults.input_policy
+  output_policy = local.firewall_defaults.output_policy
+  log_level_in  = local.firewall_defaults.log_level_in
+  log_level_out = local.firewall_defaults.log_level_out
+
+  # DHCP-first guests behind DROP policies need their own DHCPDISCOVER/OFFER
+  # allowed or they never lease their reserved media-VLAN address.
+  dhcp = true
+
+  depends_on = [proxmox_virtual_environment_cluster_firewall.main]
+}
+
+resource "proxmox_virtual_environment_firewall_rules" "media_container" {
+  for_each = var.media_container_ids
+
+  node_name    = var.node_name
+  container_id = each.value
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.internal_access.name
+    comment        = "Internal access (SSH, ICMP)"
+  }
+
+  # Per-guest web/API port from internal networks (Traefik ingress, LAN
+  # clients, and the request UI's cross-app API calls are all internal).
+  dynamic "rule" {
+    for_each = contains(keys(local.media_web_rules), each.key) ? [local.media_web_rules[each.key]] : []
+    content {
+      type    = "in"
+      action  = "ACCEPT"
+      proto   = "tcp"
+      dport   = rule.value.dport
+      source  = local.internal_src
+      comment = rule.value.comment
+    }
+  }
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.outbound_internal.name
+    comment        = "Outbound to internal (cross-app wiring, DNS, apt proxy)"
+  }
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.outbound_https.name
+    comment        = "Outbound HTTPS (metadata providers, image pulls)"
+  }
+
+  depends_on = [proxmox_virtual_environment_firewall_options.media_container]
+}

--- a/modules/firewall/tests/rule_generation.tftest.hcl
+++ b/modules/firewall/tests/rule_generation.tftest.hcl
@@ -101,6 +101,16 @@ variables {
       homelab_llm    = 10323
       openbao_audit  = 10331
     }
+    # Media stack web UIs (referenced by media_rules.tf per-guest inbound rules)
+    media_ports = {
+      qbittorrent_web = 8080
+      prowlarr_web    = 9696
+      sonarr_web      = 8989
+      radarr_web      = 7878
+      plex_web        = 32400
+      seerr_web       = 5055
+      sortarr_web     = 8787
+    }
     honeypot_ports = {
       apprise_api = 8000
       ftp         = 21
@@ -614,5 +624,35 @@ run "node_exporter_rule_inert_without_siem_cidr" {
   assert {
     condition     = local.node_exporter_rules[0].source == ""
     error_message = "node_exporter rule must be inert (empty source) when the siem CIDR is absent"
+  }
+}
+
+# --- media per-guest web rules ---
+
+run "media_web_rules_track_constants" {
+  command = plan
+
+  assert {
+    condition     = toset(keys(local.media_web_rules)) == toset(["plex", "radarr", "seerr", "sonarr", "sortarr"])
+    error_message = "media_web_rules must cover exactly the five LAN-only media guests (never the VPN-locked downloader)"
+  }
+
+  assert {
+    condition = alltrue([
+      local.media_web_rules.sonarr.dport == tostring(var.pipeline_constants.media_ports.sonarr_web),
+      local.media_web_rules.radarr.dport == tostring(var.pipeline_constants.media_ports.radarr_web),
+      local.media_web_rules.plex.dport == tostring(var.pipeline_constants.media_ports.plex_web),
+      local.media_web_rules.seerr.dport == tostring(var.pipeline_constants.media_ports.seerr_web),
+      local.media_web_rules.sortarr.dport == tostring(var.pipeline_constants.media_ports.sortarr_web),
+    ])
+    error_message = "media per-guest web dports drifted from pipeline_constants.media_ports"
+  }
+
+  assert {
+    condition = !anytrue([
+      contains(values(local.media_web_rules)[*].dport, tostring(var.pipeline_constants.media_ports.qbittorrent_web)),
+      contains(values(local.media_web_rules)[*].dport, tostring(var.pipeline_constants.media_ports.prowlarr_web)),
+    ])
+    error_message = "downloader-resident ports (qBittorrent/Prowlarr) must never appear on the LAN-only media guests"
   }
 }

--- a/modules/firewall/variables.tf
+++ b/modules/firewall/variables.tf
@@ -99,6 +99,12 @@ variable "hermes_agent_container_ids" {
   default     = {}
 }
 
+variable "media_container_ids" {
+  description = "Map of LAN-only media LXC names to IDs (tag-driven: media tag minus the VPN-locked downloader). DROP/DROP companion: per-guest web port from internal + outbound internal/HTTPS (metadata providers, image pulls)."
+  type        = map(number)
+  default     = {}
+}
+
 variable "ai_orchestration_container_ids" {
   description = "Map of AI orchestration LXC names to IDs (tag-driven: n8n, Dify, LangFlow, LangGraph, agent-exec). Inbound UI ports from internal + outbound internal/HTTPS (model endpoints, external APIs)."
   type        = map(number)
@@ -179,6 +185,7 @@ variable "pipeline_constants" {
     vector_db_ports    = map(number)
     honeypot_ports     = map(number)
     ai_log_ports       = map(number)
+    media_ports        = map(number)
   })
 }
 


### PR DESCRIPTION
## What

The five LAN-only media guests were the last tier with **no Proxmox guest firewall at all** (every other tier has a default-deny companion). This adds the standard DROP/DROP options + rules, keyed off the existing `media` tag:

- **Per-guest inbound web port as an inline rule keyed by container name** — not one shared security group — so no guest exposes a sibling's port, and a future media guest without a map entry gets no inbound web allowance (safe default). Ports are DRY from `pipeline_constants.media_ports` (now part of the module's typed contract).
- **Shared egress groups reused**: `internal_access` (SSH/ICMP), `outbound_internal` (cross-app wiring, DNS, apt proxy), `outbound_https` (metadata providers, container-image pulls). `dhcp = true` (DHCP-first guests behind DROP).
- **The VPN-locked media downloader is deliberately excluded** (tag filter in `locals-media.tf`): its fail-closed in-guest killswitch is the enforced boundary; stacking a hypervisor DROP policy underneath the tunnel adds a second, independently-managed failure mode without adding coverage. A docs PR follows to make `docs/ARCHITECTURE.md`'s firewall-boundary line say exactly this.
- New files rather than appends: `locals.tf` and `security_groups.tf` both sit within ~300 B of the 12 KB size gate (same split precedent as `locals-honeypot.tf`).

## Verification

- `tofu validate` clean; root `tofu test` **109/109**; module `tofu test` **28/28** including the new `media_web_rules_track_constants` run (five-guest coverage, constants-tracking dports, downloader-port exclusion).
- Live tag pre-check done: all six media guests already carry the `media` tag (downloader also carries `vpn`), so this keys off existing data — no inventory change needed.

## Apply plan (production safety — streaming service is actively used)

- Expected plan: **adds only** (10 new resources: options + rules × 5 CTs), 0 destroy.
- Proxmox's guest firewall accepts established/related flows implicitly, so active streaming sessions survive enablement; the enforcement window for NEW connections is the seconds between options and rules creation.
- Pre-apply: check the streaming server for active sessions; per-resource production-impact review before applying.

## Rollback

- Reverting this PR produces a **destroy plan** (removes the options/rules resources) — needs explicit sign-off.
- Emergency no-apply mitigation: `pvesh set /nodes/<node>/lxc/<vmid>/firewall/options --enable 0` per affected CT (drift, reconciled by the eventual revert-apply).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HXiX2uJBEn6HNa2brL6iKd