### PR TITLE
feat(network): media tier to VLAN 70 — complete the VMID/VLAN tier alignment

### DIFF
--- a/docs/INFRASTRUCTURE_NUMBERING.md
+++ b/docs/INFRASTRUCTURE_NUMBERING.md
@@ -30,8 +30,7 @@ A VMID is six digits, each position carrying meaning (read coarsest → finest):
 
 A plain numeric sort groups guests by tier → sub-tier → criticality, for free. Example:
 Plex (`702000`) = tier 7 (media) · sub 0 (user-facing) · crit 2 · OS 0 (LXC) · instance 0 ·
-env 0 (prod), and lives on VLAN 70 — identity and network are one number. (As-built
-exception: the media tier still runs on VLAN 55 — see the accepted deviation below.)
+env 0 (prod), and lives on VLAN 70 — identity and network are one number.
 
 ### Trust tiers → VLANs (tier × 10)
 
@@ -50,13 +49,6 @@ exception: the media tier still runs on VLAN 55 — see the accepted deviation b
 Special-purpose VLANs sit **outside** the tier numbering: `1` Default, `5` Management,
 `53` DNS (named for port 53).
 
-**Accepted deviation — media tier (tier 7):** the media guests carry tier-7 VMIDs
-(`7xxxxx`) but run on the pre-tier `media_svc` VLAN **55**, not 70. The VMIDs already
-encode the target end-state; the VLAN renumber is a supervised maintenance event
-(cross-system: network controller VLAN, DHCP reservations, DNS, firewall sources —
-every media guest changes address mid-transition) tracked in issue #526, and is
-deliberately not folded into routine changes. Until it lands, tier 7 is the one
-tier where "identity and network are one number" does not hold.
 
 ---
 

--- a/docs/INFRASTRUCTURE_NUMBERING.md
+++ b/docs/INFRASTRUCTURE_NUMBERING.md
@@ -49,7 +49,6 @@ env 0 (prod), and lives on VLAN 70 — identity and network are one number.
 Special-purpose VLANs sit **outside** the tier numbering: `1` Default, `5` Management,
 `53` DNS (named for port 53).
 
-
 ---
 
 ## Addressing: DHCP / DNS-first, with a static exception

--- a/tests/ansible_inventory_contract.tftest.hcl
+++ b/tests/ansible_inventory_contract.tftest.hcl
@@ -314,22 +314,22 @@ run "ansible_inventory_ingress_route_table" {
     domain = "example.com"
   }
 
-  # plex: backend "plex" (192.168.55.210) on media_ports.plex_web (32400).
+  # plex: backend "plex" (192.168.70.210) on media_ports.plex_web (32400).
   assert {
     condition = length([
       for r in output.ansible_inventory.ingress :
-      r if r.name == "plex" && r.ip == "192.168.55.210" && r.port == 32400
+      r if r.name == "plex" && r.ip == "192.168.70.210" && r.port == 32400
     ]) == 1
-    error_message = "ingress must front plex at 192.168.55.210:32400 (derived IP + constant port)"
+    error_message = "ingress must front plex at 192.168.70.210:32400 (derived IP + constant port)"
   }
 
-  # seerr: backend "seerr" (192.168.55.211) on media_ports.seerr_web (5055).
+  # seerr: backend "seerr" (192.168.70.211) on media_ports.seerr_web (5055).
   assert {
     condition = length([
       for r in output.ansible_inventory.ingress :
-      r if r.name == "seerr" && r.ip == "192.168.55.211" && r.port == 5055
+      r if r.name == "seerr" && r.ip == "192.168.70.211" && r.port == 5055
     ]) == 1
-    error_message = "ingress must front seerr at 192.168.55.211:5055"
+    error_message = "ingress must front seerr at 192.168.70.211:5055"
   }
 
   # Services whose backend container is absent are skipped (sonarr not deployed).

--- a/tests/locals.tftest.hcl
+++ b/tests/locals.tftest.hcl
@@ -653,7 +653,7 @@ run "container_reserved_ip_from_reserved_host" {
 
   variables {
     containers = {
-      # DHCP-first media-VLAN guest: reserved_host 210 -> 192.168.55.210, decoupled
+      # DHCP-first media-VLAN guest: reserved_host 210 -> 192.168.70.210, decoupled
       # from the 6-digit positional vm_id (which the /24 cidrhost math can't express).
       "netq-probe-media" = {
         vm_id         = 990003
@@ -672,10 +672,10 @@ run "container_reserved_ip_from_reserved_host" {
     }
   }
 
-  # media_svc id 55 -> 192.168.55.0/24; reserved_host 210 -> 192.168.55.210.
+  # media_svc id 70 -> 192.168.70.0/24; reserved_host 210 -> 192.168.70.210.
   assert {
-    condition     = local.container_reserved_ip["netq-probe-media"] == "192.168.55.210"
-    error_message = "dhcp guest reserved_host 210 on media_svc must yield 192.168.55.210, got ${local.container_reserved_ip["netq-probe-media"]}"
+    condition     = local.container_reserved_ip["netq-probe-media"] == "192.168.70.210"
+    error_message = "dhcp guest reserved_host 210 on media_svc must yield 192.168.70.210, got ${local.container_reserved_ip["netq-probe-media"]}"
   }
 
   # Static guest has no reservation.
@@ -692,8 +692,8 @@ run "container_reserved_ip_from_reserved_host" {
 
   # DHCP guest surfaces both mac and reserved_ip in the inventory export.
   assert {
-    condition     = output.ansible_inventory.containers["netq-probe-media"].reserved_ip == "192.168.55.210"
-    error_message = "dhcp guest inventory reserved_ip must be 192.168.55.210, got ${output.ansible_inventory.containers["netq-probe-media"].reserved_ip}"
+    condition     = output.ansible_inventory.containers["netq-probe-media"].reserved_ip == "192.168.70.210"
+    error_message = "dhcp guest inventory reserved_ip must be 192.168.70.210, got ${output.ansible_inventory.containers["netq-probe-media"].reserved_ip}"
   }
 
   assert {

--- a/variables-network.tf
+++ b/variables-network.tf
@@ -47,7 +47,7 @@ variable "vlan_ids" {
     data      = 30
     ai        = 50
     apps      = 60
-    media_svc = 55
+    media_svc = 70
     homeauto  = 80
     nonprod   = 90
   }


### PR DESCRIPTION
Executes the supervised renumber (#526) during the 2026-07-07 maintenance window, after dryvist/tofu-unifi#76 moved the network + reservations.

- `media_svc` vlan id 55 → **70** (guest NICs re-tag; addresses re-derive from the updated CIDR value; every rule/inventory consumer is key-derived).
- Test fixtures re-derive to synthetic 192.168.70.x (`tofu test` 109/109).
- INFRASTRUCTURE_NUMBERING's accepted-deviation note removed — the deviation no longer exists.

Cutover safety: zero active streaming sessions verified immediately before each apply; per-change production-impact review run over the full 52-change plan (0 add / 52 change / **0 destroy** — SG source strings + NIC tags + inventory republish).

Closes #526

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HXiX2uJBEn6HNa2brL6iKd