### PR TITLE
fix(firewall): attach ai-log-ingest accepts to the Cribl Stream backends

### DIFF
--- a/modules/firewall/ai_log_ingest_rules.tf
+++ b/modules/firewall/ai_log_ingest_rules.tf
@@ -2,11 +2,13 @@
 #
 # One dedicated Cribl TCP-JSON receiver per AI-log source family (MacBook AI
 # tools, Mac Studio LLM stack, homelab LLM fabric, OpenBao audit). All are
-# HAProxy-fronted TCP frontends the sources dial; HAProxy load-balances to the
-# Cribl Stream pair over the existing cribl_s2s (10300) backend (already opened
-# by cribl_stream_services_rules). This group only opens the per-source
-# frontends on the pipeline (HAProxy) containers — see the attachment in
-# pipeline_container_rules.tf.
+# HAProxy-fronted TCP frontends the sources dial; HAProxy load-balances each
+# frontend PORT-TO-PORT onto the Cribl Stream pair's matching in_ai_* listener
+# (backend ai_backend_<port>, NOT the shared 10300 S2S backend — Stream keys
+# index/sourcetype stamping off the port). The group is therefore attached
+# twice: the HAProxy containers get the frontends (pipeline_container_rules.tf)
+# and the Stream containers get the same accepts for their backend listeners
+# (container_rules.tf).
 #
 # Rule data lives here (not in locals.tf) so that file stays under the shared
 # _file-size 12 KB error threshold. local.svc_ports / local.internal_src are

--- a/modules/firewall/container_rules.tf
+++ b/modules/firewall/container_rules.tf
@@ -45,6 +45,16 @@ resource "proxmox_virtual_environment_firewall_rules" "cribl_stream_container" {
     comment        = "NetFlow/IPFIX ingestion (UDP 2055)"
   }
 
+  # HAProxy balances every ai_log_routing frontend PORT-TO-PORT onto this
+  # pair (backend ai_backend_<port> -> stream:<port>), so the per-source
+  # in_ai_* listeners need the same accepts the HAProxy frontends carry.
+  # Without this every AI family except the 10300 S2S path is dropped here
+  # while HAProxy's tcp-check marks the backend down and resets senders.
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.ai_log_ingest.name
+    comment        = "AI/LLM log-ingest backends (HAProxy -> per-port in_ai_* listeners)"
+  }
+
   rule {
     security_group = proxmox_virtual_environment_cluster_firewall_security_group.outbound_internal.name
     comment        = "Outbound to internal only (reaches Splunk HEC 8088)"


### PR DESCRIPTION
**Root cause of every dark AI-family index** (claude/codex/gemini/openai/vscode, the LLM gate + homelab llamaswap legs, llm_metrics via the :10321 scrape path, openbao_audit):

HAProxy balances every `ai_log_routing` frontend **port-to-port** onto the Cribl Stream pair (`backend ai_backend_<port>` → `stream:<port>`), but the `ai-log-ingest` security group was only attached to the **HAProxy** containers — its design comment assumed all frontends would ride the shared 10300 S2S backend. With default-DROP on the Stream guests, every per-port `in_ai_*` listener except 10300 is unreachable:

- Stream provably listens on all the AI ports (verified read-only on the pair).
- The cluster `ai-log-ingest` group exists with ACCEPTs for all ports — it just isn't attached to the Stream containers (verified via the PVE API rule list).
- HAProxy's `tcp-check` marks each backend down and resets senders — the Mac Edge logs `Other party ended the socket connection` against 10311/10312 while 10300 connects fine.

Fix: attach the same security group to `proxmox_virtual_environment_firewall_rules.cribl_stream_container` and correct the stale comment in `ai_log_ingest_rules.tf`. No new ports, no new sources — the identical accepts the HAProxy frontends already carry.

Module tests: 28 passed. `tofu validate` clean.

**GATE B — live-firewall change: do not self-merge.** After merge + apply, the buffered Edge persistent queues on both Macs should flush and the AI indexes light up with no further action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014TS3gHC9B5sR5WxvLt9gRE