### PR TITLE
refactor(storage): rename object-storage container key + tf identifiers to s3

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -173,8 +173,8 @@ for infrastructure (private, in the on-prem `s3` store; see
 Summary by pool:
 
 - **`infrastructure`** — `ansible`, `pve-scripts-local`, `technitium-dns`,
-  `pi-hole`, `phpipam`, `apt-cacher-ng`, `object-storage` (RustFS, hostname
-  `s3`), `mailpit`, `ntfy`, `homeassistant`, `mssql`, `nginx-proxy-manager`,
+  `pi-hole`, `phpipam`, `apt-cacher-ng`, `s3` (RustFS object store),
+  `mailpit`, `ntfy`, `homeassistant`, `mssql`, `nginx-proxy-manager`,
   `prometheus`, `traefik` (HTTPS/TLS ingress)
 - **`logging`** — `haproxy`, `cribl-edge-01/02`, `cribl-stream-01/02`,
   `splunk-mgmt` (SH + DS + LM + MC + CM)

--- a/ingress.tf
+++ b/ingress.tf
@@ -19,9 +19,9 @@ locals {
     prowlarr         = { backend = "download-vpn", port = local.pipeline_constants.media_ports.prowlarr_web }
     technitium       = { backend = "technitium-dns", port = local.pipeline_constants.service_ports.technitium_web }
     phpipam          = { backend = "phpipam", port = local.pipeline_constants.service_ports.phpipam_web }
-    "object-storage" = { backend = "object-storage", port = local.pipeline_constants.service_ports.object_storage_console }
+    "object-storage" = { backend = "s3", port = local.pipeline_constants.service_ports.object_storage_console }
     # RustFS S3 API fronted by a valid-TLS hostname. Path-style S3 format.
-    s3 = { backend = "object-storage", port = local.pipeline_constants.service_ports.object_storage_s3 }
+    s3 = { backend = "s3", port = local.pipeline_constants.service_ports.object_storage_s3 }
     # openbao is fronted as a load-balanced pool (openbao_backends below).
     mailpit           = { backend = "mailpit", port = local.pipeline_constants.notification_ports.mailpit_web }
     ntfy              = { backend = "ntfy", port = local.pipeline_constants.notification_ports.ntfy_http }

--- a/locals.tf
+++ b/locals.tf
@@ -162,7 +162,7 @@ locals {
   }
 
   # Object storage containers (object-storage tag) — RustFS.
-  object_storage_container_ids = {
+  s3_container_ids = {
     for k, v in var.containers : k => v.vm_id
     if contains(coalesce(try(v.tags, null), []), "object-storage")
   }

--- a/main.tf
+++ b/main.tf
@@ -220,7 +220,7 @@ module "firewall" {
   cribl_edge_container_ids = local.cribl_edge_container_ids
 
   # Object storage (object-storage tag) — RustFS.
-  object_storage_container_ids = local.object_storage_container_ids
+  s3_container_ids = local.s3_container_ids
 
   # OpenBao secrets-management containers (openbao tag)
   openbao_container_ids = local.openbao_container_ids

--- a/modules/firewall/ai_orchestration_rules.tf
+++ b/modules/firewall/ai_orchestration_rules.tf
@@ -1,7 +1,7 @@
 # AI orchestration tier firewall resources. The orchestration UIs (n8n, Dify,
 # LangFlow, LangGraph) and the agent-exec runtime live on the ai VLAN; Langfuse
 # lives on the siem VLAN. All are DHCP-first guests behind DROP in/out policies, so each gets
-# `dhcp = true` (same reason as object_storage_rules.tf). The Cribl Edge OTLP
+# `dhcp = true` (same reason as s3_rules.tf). The Cribl Edge OTLP
 # ingest rule (from the ai VLAN) is attached to the pipeline containers in
 # container_rules.tf; this file owns the app-side guests.
 #

--- a/modules/firewall/container_rules.tf
+++ b/modules/firewall/container_rules.tf
@@ -1,7 +1,7 @@
 # Splunk container firewall resources live in modules/firewall/splunk_container_rules.tf
 # Pipeline container firewall resources live in modules/firewall/pipeline_container_rules.tf
 # (both extracted so container_rules.tf stays under the shared _file-size
-# workflow's 12 KB error threshold — same reason object_storage_rules.tf was split out).
+# workflow's 12 KB error threshold — same reason s3_rules.tf was split out).
 
 # Cribl Stream containers (receives from Edge, routes to Splunk HEC)
 
@@ -229,4 +229,4 @@ resource "proxmox_virtual_environment_firewall_rules" "rag_container" {
   depends_on = [proxmox_virtual_environment_firewall_options.rag_container]
 }
 
-# Object storage container firewall resources: modules/firewall/object_storage_rules.tf
+# Object storage container firewall resources: modules/firewall/s3_rules.tf

--- a/modules/firewall/hermes_agent_rules.tf
+++ b/modules/firewall/hermes_agent_rules.tf
@@ -1,7 +1,7 @@
 # =============================================================================
 # Hermes Agent container firewall configuration
 # =============================================================================
-# Extracted into its own file (like monitoring_rules.tf / object_storage_rules.tf)
+# Extracted into its own file (like monitoring_rules.tf / s3_rules.tf)
 # so container_rules.tf stays under the shared _file-size workflow's 12 KB error
 # threshold.
 #

--- a/modules/firewall/idrac_rules.tf
+++ b/modules/firewall/idrac_rules.tf
@@ -1,7 +1,7 @@
 # =============================================================================
 # iDRAC KVM container firewall configuration
 # =============================================================================
-# Extracted into its own file (like object_storage_rules.tf) so container_rules.tf
+# Extracted into its own file (like s3_rules.tf) so container_rules.tf
 # stays under the shared _file-size workflow's 12 KB error threshold.
 # The idrac-kvm host is a Docker-in-LXC (vm_id 251, tag "idrac"); it exposes the
 # HTML5 noVNC viewers on host ports 5410 (R410) / 5710 (R710) via the

--- a/modules/firewall/locals_rules.tf
+++ b/modules/firewall/locals_rules.tf
@@ -101,7 +101,7 @@ locals {
     { proto = "tcp", dport = tostring(local.svc_ports.cribl_prometheus_rw), source = local.internal_src, comment = "Prometheus remote_write receiver from internal" },
   ]
 
-  object_storage_services_rules = [
+  s3_services_rules = [
     { proto = "tcp", dport = tostring(local.svc_ports.object_storage_s3), source = local.internal_src, comment = "Object storage (RustFS) S3 API from internal" },
     { proto = "tcp", dport = tostring(local.svc_ports.object_storage_console), source = local.internal_src, comment = "Object storage (RustFS) Console from internal" },
   ]

--- a/modules/firewall/s3_rules.tf
+++ b/modules/firewall/s3_rules.tf
@@ -3,8 +3,8 @@
 # 12 KB error threshold (same pattern as idrac_rules.tf). S3 API on 9000,
 # Console on 9001 — both internal-only via the object-storage-svc group.
 
-resource "proxmox_virtual_environment_firewall_options" "object_storage_container" {
-  for_each = var.object_storage_container_ids
+resource "proxmox_virtual_environment_firewall_options" "s3_container" {
+  for_each = var.s3_container_ids
 
   node_name     = var.node_name
   container_id  = each.value
@@ -23,8 +23,8 @@ resource "proxmox_virtual_environment_firewall_options" "object_storage_containe
   depends_on = [proxmox_virtual_environment_cluster_firewall.main]
 }
 
-resource "proxmox_virtual_environment_firewall_rules" "object_storage_container" {
-  for_each = var.object_storage_container_ids
+resource "proxmox_virtual_environment_firewall_rules" "s3_container" {
+  for_each = var.s3_container_ids
 
   node_name    = var.node_name
   container_id = each.value
@@ -35,7 +35,7 @@ resource "proxmox_virtual_environment_firewall_rules" "object_storage_container"
   }
 
   rule {
-    security_group = proxmox_virtual_environment_cluster_firewall_security_group.object_storage_services.name
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.s3_services.name
     comment        = "Object storage services (TCP/${local.svc_ports.object_storage_s3} S3 API, TCP/${local.svc_ports.object_storage_console} Console)"
   }
 
@@ -44,5 +44,5 @@ resource "proxmox_virtual_environment_firewall_rules" "object_storage_container"
     comment        = "Outbound to internal only"
   }
 
-  depends_on = [proxmox_virtual_environment_firewall_options.object_storage_container]
+  depends_on = [proxmox_virtual_environment_firewall_options.s3_container]
 }

--- a/modules/firewall/security_groups.tf
+++ b/modules/firewall/security_groups.tf
@@ -250,12 +250,12 @@ resource "proxmox_virtual_environment_cluster_firewall_security_group" "apt_cach
   }
 }
 
-resource "proxmox_virtual_environment_cluster_firewall_security_group" "object_storage_services" {
+resource "proxmox_virtual_environment_cluster_firewall_security_group" "s3_services" {
   name    = "object-storage-svc"
   comment = "Object storage (RustFS): S3 API (${local.svc_ports.object_storage_s3}) and Console (${local.svc_ports.object_storage_console}) from internal networks"
 
   dynamic "rule" {
-    for_each = local.object_storage_services_rules
+    for_each = local.s3_services_rules
     content {
       type    = "in"
       action  = "ACCEPT"

--- a/modules/firewall/tests/rule_generation.tftest.hcl
+++ b/modules/firewall/tests/rule_generation.tftest.hcl
@@ -25,7 +25,7 @@ variables {
       cribl_s2s           = 10300
       cribl_prometheus_rw = 9201
       apt_cacher_ng       = 3142
-      # Object storage (RustFS) — referenced by object_storage_services_rules
+      # Object storage (RustFS) — referenced by s3_services_rules
       object_storage_s3      = 9000
       object_storage_console = 9001
       openbao_api            = 8200
@@ -268,13 +268,13 @@ run "object_storage_rules_track_constants_port" {
   }
 
   assert {
-    condition     = local.object_storage_services_rules[0].dport == tostring(var.pipeline_constants.service_ports.object_storage_s3)
-    error_message = "object_storage_services_rules[0].dport must be tostring(pipeline_constants.service_ports.object_storage_s3), got '${local.object_storage_services_rules[0].dport}'"
+    condition     = local.s3_services_rules[0].dport == tostring(var.pipeline_constants.service_ports.object_storage_s3)
+    error_message = "s3_services_rules[0].dport must be tostring(pipeline_constants.service_ports.object_storage_s3), got '${local.s3_services_rules[0].dport}'"
   }
 
   assert {
-    condition     = local.object_storage_services_rules[1].dport == tostring(var.pipeline_constants.service_ports.object_storage_console)
-    error_message = "object_storage_services_rules[1].dport must be tostring(pipeline_constants.service_ports.object_storage_console), got '${local.object_storage_services_rules[1].dport}'"
+    condition     = local.s3_services_rules[1].dport == tostring(var.pipeline_constants.service_ports.object_storage_console)
+    error_message = "s3_services_rules[1].dport must be tostring(pipeline_constants.service_ports.object_storage_console), got '${local.s3_services_rules[1].dport}'"
   }
 }
 

--- a/modules/firewall/variables.tf
+++ b/modules/firewall/variables.tf
@@ -57,7 +57,7 @@ variable "cribl_edge_container_ids" {
   default     = {}
 }
 
-variable "object_storage_container_ids" {
+variable "s3_container_ids" {
   description = "Map of object storage (RustFS) container names to their IDs"
   type        = map(number)
   default     = {}

--- a/tests/firewall_filtering.tftest.hcl
+++ b/tests/firewall_filtering.tftest.hcl
@@ -288,14 +288,14 @@ run "cribl_edge_not_in_cribl_stream_ids" {
   }
 }
 
-# --- object_storage_container_ids tests ---
+# --- s3_container_ids tests ---
 
-run "object_storage_tagged_container_in_object_storage_ids" {
+run "object_storage_tagged_container_in_s3_ids" {
   command = plan
 
   variables {
     containers = {
-      "object-storage" = {
+      "s3" = {
         vm_id         = 990004
         hostname      = "object-storage"
         vlan          = "siem"
@@ -307,22 +307,22 @@ run "object_storage_tagged_container_in_object_storage_ids" {
   }
 
   assert {
-    condition     = contains(keys(local.object_storage_container_ids), "object-storage")
-    error_message = "Container with 'object-storage' tag must be in object_storage_container_ids"
+    condition     = contains(keys(local.s3_container_ids), "s3")
+    error_message = "Container with 'object-storage' tag must be in s3_container_ids"
   }
 
   assert {
-    condition     = local.object_storage_container_ids["object-storage"] == 990004
-    error_message = "object_storage_container_ids['object-storage'] should be vm_id 990004"
+    condition     = local.s3_container_ids["s3"] == 990004
+    error_message = "s3_container_ids['s3'] should be vm_id 990004"
   }
 
   assert {
-    condition     = !contains(keys(local.pipeline_container_ids), "object-storage")
+    condition     = !contains(keys(local.pipeline_container_ids), "s3")
     error_message = "Container with 'object-storage' tag must NOT be in pipeline_container_ids"
   }
 
   assert {
-    condition     = !contains(keys(local.notification_container_ids), "object-storage")
+    condition     = !contains(keys(local.notification_container_ids), "s3")
     error_message = "Container with 'object-storage' tag must NOT be in notification_container_ids"
   }
 }


### PR DESCRIPTION
## What

Address-only rename of the object storage (RustFS) container map key and its
internal Terraform identifiers from `object-storage` / `object_storage_*` to
`s3`. This is a pure refactor — no resource creation, deletion, or behavioral
change. Net LOC delta ~0 (35 insertions / 35 deletions).

### Renamed (code-only)

- Root local `object_storage_container_ids` → `s3_container_ids` (`locals.tf`),
  its passthrough in `main.tf`, and the module variable `object_storage_container_ids`
  → `s3_container_ids` (`modules/firewall/variables.tf`).
- `git mv modules/firewall/object_storage_rules.tf → s3_rules.tf`, with resources
  `..._firewall_options.object_storage_container` / `..._firewall_rules.object_storage_container`
  → `.s3_container`.
- Module local `object_storage_services_rules` → `s3_services_rules`
  (`locals_rules.tf`) and SG resource `object_storage_services` → `s3_services`
  (`security_groups.tf`).
- `ingress.tf` route `backend` values → `"s3"` (to match the new container key).
- Tests updated to the new addresses; stale `object_storage_rules.tf` file-split
  citations in sibling rule files updated to `s3_rules.tf`.

## Paired operator step (NOT in this PR)

This code rename is paired with an operator-run `terragrunt state mv` plus the
`deployment.json` container-key change (private, handled out-of-band), so the
existing live resources re-attach to the new addresses instead of being
destroyed and recreated. The moves:

1. `module.firewall...cluster_firewall_security_group.object_storage_services` → `.s3_services`
2. `module.firewall...firewall_options.object_storage_container[<key>]` → `.s3_container[<key>]`
3. `module.firewall...firewall_rules.object_storage_container[<key>]` → `.s3_container[<key>]`
4. root container instance key `["object-storage"]` → `["s3"]` (driven by the `deployment.json` key rename; the firewall `for_each` instances re-key with it)

## Deliberately frozen (downstream contracts — unchanged)

- Live security-group name string `object-storage-svc` (renaming it would destroy
  a live cluster SG).
- The `object-storage` container **tag** (tag-based Ansible grouping downstream).
- Pipeline-constant keys `object_storage_s3` / `object_storage_console`.
- Ingress **route keys** (`"object-storage"` console route, `s3` API route) — only
  their `backend` values change.
- `docs/SECRETS_HIERARCHY.md` `secret/platform/object-storage/` OpenBao KV path — a
  live secrets-mount name, not the container key; a code-only rename does not move it.

## Verification

- `grep object_storage_container_ids|object_storage_services|object_storage_container`
  over `*.tf` / `*.tftest.hcl` → **zero hits**.
- `tofu fmt -check`, `tofu validate` green in root and `modules/firewall`.
- `tofu test`: root **108 passed / 0 failed**, `modules/firewall` **25 passed / 0 failed**.
- `pre-commit run --all-files` → all hooks pass.
