### PR TITLE
chore(renovate): thin wrapper; migrate fileMatch to managerFilePatterns

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,13 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended",
     "local>dryvist/.github"
   ],
   "customManagers": [
     {
       "customType": "regex",
-      "fileMatch": ["variables-storage\\.tf$"],
+      "managerFilePatterns": ["/variables-storage\\.tf$/"],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s+default\\s*=\\s*\"(?<currentValue>[^\"]+)\""
       ],


### PR DESCRIPTION
chore(renovate): thin wrapper; migrate fileMatch to managerFilePatterns

Drop the redundant config:recommended (default.json already provides it) and migrate the deprecated customManager `fileMatch` to `managerFilePatterns`. Keeps the Proxmox ISO custom datasource/manager and its 30-day minimumReleaseAge rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CB5heppQHhv8xE1XWeeFVA