### PR TITLE
ci: widen main-only CI triggers to include develop

### DIFF
--- a/.github/workflows/ci-doctor.md
+++ b/.github/workflows/ci-doctor.md
@@ -6,7 +6,7 @@ on:
   workflow_run:
     workflows: ["Terraform CI"]
     types: [completed]
-    branches: [main]
+    branches: [main, develop]
 if: ${{ github.event.workflow_run.conclusion == 'failure' || github.event.workflow_run.conclusion == 'cancelled' }}
 ---
 

--- a/.github/workflows/ci-fail-issue.yml
+++ b/.github/workflows/ci-fail-issue.yml
@@ -4,7 +4,7 @@ on:
   workflow_run:
     workflows: ["Terraform CI"]
     types: [completed]
-    branches: [main]
+    branches: [main, develop]
 
 permissions:
   actions: read

--- a/.github/workflows/osv-scan.yml
+++ b/.github/workflows/osv-scan.yml
@@ -11,7 +11,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
   push:
-    branches: [main]
+    branches: [main, develop]
   schedule:
     - cron: '17 11 * * 1'  # Weekly Monday 11:17 UTC (off-peak minute)
 

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - main
+      - develop
   pull_request:
     branches:
       - main
+      - develop
 
 permissions:
   contents: read


### PR DESCRIPTION
## What

Ahead of the git-flow-next pilot flip, widens hardcoded `main`-only triggers to also cover `develop`:

- `terraform.yml` ("Terraform CI") — both `push` and `pull_request` branch filters, `[main]` -> `[main, develop]`.
- `osv-scan.yml` — `push` branch filter, `[main]` -> `[main, develop]` (security gate, not release/deploy).
- `ci-fail-issue.yml` — `workflow_run` branch filter (consumes "Terraform CI" completions), `[main]` -> `[main, develop]`.
- `ci-doctor.md` (gh-aw agentic CI triage source) — same `workflow_run` branch filter widened. See lock-file note below.

## Why

`develop` becomes a long-lived branch with direct pushes allowed once the pilot flips. The required CI check, the security scan, and the auto-issue/auto-doctor failure-triage flows all need to run there too, not just on `main`.

## Scope notes

- `release-please.yml` stays `main`-only by design — release cadence is tied to the released state, not `develop`.
- `ci-fix.yml` has no branch filter at all on its `workflow_run` trigger, so it already covers `develop` without changes.
- `ai-merge-gate.yml`, `ai-pr-care.yml`, `ci-gate.yml` have no `branches` restriction on their `pull_request` triggers, so PR-time checks already run against develop-targeted PRs unchanged.
- `release-please-config.json` / `.release-please-manifest.json` / `release-please.yml` verified present and following the org-standard pattern — no gap.
- Other gh-aw `.md`/`.lock.yml` pairs (`daily-malicious-code-scan`, `link-checker`, `sub-issue-closer`, `repo-health-audit`) are schedule/workflow_dispatch only — no changes needed.

## Known gap — `ci-doctor.lock.yml` not regenerated

Same caveat as the sibling `ai-assistant-instructions` PR: the only `gh aw` CLI available locally is a "dev" build newer than this repo's pinned version. Compiling with it silently upgrades the entire toolchain (schema version, action SHAs, container images) as a side effect of what should be a one-line trigger change — out of scope here. **Follow-up needed:** regenerate `ci-doctor.lock.yml` with the pinned toolchain so only the `branches` list changes.

## Open PRs targeting main (not retargeted here, per instructions — retarget happens at flip time)

- #612 `chore(deps): lock file maintenance` (renovate)
- #610 `chore(deps): update actions/checkout action to v7` (renovate)

Both will auto-retarget after the default-branch change per Renovate's own behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Assisted-by: Claude:claude-sonnet-5
Claude-Session: https://claude.ai/code/session_01D9EGoFt6YZvquAVYFZURtQ