### PR TITLE
feat(nautobot): wire Nautobot + shared Postgres guests; stamp inventory schema_version (#138, #134)

### DIFF
--- a/constants.tf
+++ b/constants.tf
@@ -72,6 +72,7 @@ locals {
       # constants, never literals.
       technitium_web    = 5380
       phpipam_web       = 80
+      nautobot_web      = 8080
       homeassistant_web = 8123
       openproject_web   = 80
       prometheus_web    = 9090

--- a/deployment.json.example
+++ b/deployment.json.example
@@ -186,6 +186,43 @@
       "pool_id": "infrastructure",
       "root_disk": { "size": 8 }
     },
+    "_ipam_dcim_comment": "Shared Postgres (data VLAN) + native Nautobot IPAM/DCIM (apps VLAN). Both DHCP/DNS-first with a reserved_host octet; VMIDs follow the tier-positional scheme (3=data, 6=apps). Native installs — no `features.nesting` (not Docker-in-LXC). Postgres carries a persistent /var/lib/postgresql data mount (survives rebuilds); Nautobot a /opt/nautobot mount and colocated Redis. Postgres has NO Traefik ingress (in-cluster 5432 only); Nautobot's web UI (8080) is fronted by Traefik. Illustrative placeholders only — the live values live in the gitignored deployment.json.",
+    "postgres": {
+      "vm_id": 303000,
+      "dhcp": true,
+      "reserved_host": 51,
+      "vlan": "data",
+      "hostname": "postgres",
+      "description": "Shared native Postgres — inventory/apps datastore (Nautobot now; Vikunja/EspoCRM later). Persistent data mount + pgdump backups.",
+      "cpu_cores": 2,
+      "memory_dedicated": 2048,
+      "tags": ["terraform", "container", "postgres", "database"],
+      "pool_id": "infrastructure",
+      "node_name": "proxmox-1",
+      "unprivileged": true,
+      "root_disk": { "size": 16 },
+      "mount_points": [
+        { "volume": "local-zfs", "size": "60G", "path": "/var/lib/postgresql" }
+      ]
+    },
+    "nautobot": {
+      "vm_id": 605000,
+      "dhcp": true,
+      "reserved_host": 52,
+      "vlan": "apps",
+      "hostname": "nautobot",
+      "description": "Native Nautobot IPAM/DCIM source of truth (venv + uwsgi + worker + scheduler; Redis colocated). Web UI on 8080, fronted by Traefik.",
+      "cpu_cores": 4,
+      "memory_dedicated": 4096,
+      "tags": ["terraform", "container", "nautobot"],
+      "pool_id": "infrastructure",
+      "node_name": "proxmox-1",
+      "unprivileged": true,
+      "root_disk": { "size": 24 },
+      "mount_points": [
+        { "volume": "local-zfs", "size": "40G", "path": "/opt/nautobot" }
+      ]
+    },
     "_ingress_ha_comment": "Ingress is HA: identical Traefik LXCs on DIFFERENT nodes carry the `ingress` tag; keepalived floats one VRRP virtual IP across them (ingress.tf derives ingress_vip/ingress_hosts from the `ingress` tag + network_cidrs). A VIP is synthesized only with at least two ingress nodes; add another by copying the block and bumping vm_id/node_name — no code change. DNS points every fronted service at the VIP, so a node loss migrates the VIP automatically.",
     "traefik": {
       "vm_id": 101,

--- a/ingress.tf
+++ b/ingress.tf
@@ -19,6 +19,7 @@ locals {
     prowlarr         = { backend = "download-vpn", port = local.pipeline_constants.media_ports.prowlarr_web }
     technitium       = { backend = "technitium-dns", port = local.pipeline_constants.service_ports.technitium_web }
     phpipam          = { backend = "phpipam", port = local.pipeline_constants.service_ports.phpipam_web }
+    nautobot         = { backend = "nautobot", port = local.pipeline_constants.service_ports.nautobot_web } # native IPAM/DCIM UI; Postgres has NO ingress row (in-cluster 5432 only)
     "object-storage" = { backend = "s3", port = local.pipeline_constants.service_ports.object_storage_console }
     # RustFS S3 API fronted by a valid-TLS hostname. Path-style S3 format.
     s3 = { backend = "s3", port = local.pipeline_constants.service_ports.object_storage_s3 }

--- a/inventory_publish.tf
+++ b/inventory_publish.tf
@@ -12,6 +12,10 @@ locals {
   # The inventory value, shared by output.ansible_inventory and the publish
   # resource below (a resource cannot reference an output, so this lives here).
   ansible_inventory = {
+    # Contract version of this published artifact. Consumers (and the
+    # homelab-contracts JSON schema that gates the publish) read this to confirm
+    # they understand the emitted shape. Bump only on a breaking key-set change.
+    schema_version = "2.0.0"
     # LXC Containers - using proxmox_pct_remote connection
     containers = {
       for k, v in(length(var.containers) > 0 ? module.containers[0].container_details : {}) : k => {

--- a/locals.tf
+++ b/locals.tf
@@ -229,4 +229,18 @@ locals {
     for k, v in var.containers : k => v.vm_id
     if contains(coalesce(try(v.tags, null), []), "hermes-agent")
   }
+
+  # Postgres LXC (postgres tag) — the shared native Postgres backing Nautobot
+  # (and later Vikunja/EspoCRM). modules/firewall opens 5432 to it from internal.
+  postgres_container_ids = {
+    for k, v in var.containers : k => v.vm_id
+    if contains(coalesce(try(v.tags, null), []), "postgres")
+  }
+
+  # Nautobot LXC (nautobot tag) — native IPAM/DCIM source of truth, web UI on
+  # nautobot_web (8080). modules/firewall opens 8080 to it from internal.
+  nautobot_container_ids = {
+    for k, v in var.containers : k => v.vm_id
+    if contains(coalesce(try(v.tags, null), []), "nautobot")
+  }
 }

--- a/main.tf
+++ b/main.tf
@@ -225,6 +225,10 @@ module "firewall" {
   # OpenBao secrets-management containers (openbao tag)
   openbao_container_ids = local.openbao_container_ids
 
+  # Postgres (postgres tag) + Nautobot (nautobot tag) containers — 5432 / 8080 from internal
+  postgres_container_ids = local.postgres_container_ids
+  nautobot_container_ids = local.nautobot_container_ids
+
   # Ingress (Traefik HA) containers (ingress tag) — define-disabled guest firewall
   # that pre-allows keepalived VRRP + 80/443 so a later enforcement flip is safe.
   ingress_container_ids = local.ingress_container_ids

--- a/modules/firewall/nautobot_rules.tf
+++ b/modules/firewall/nautobot_rules.tf
@@ -1,0 +1,85 @@
+# Nautobot LXC firewall — native IPAM/DCIM source of truth (web UI on
+# nautobot_web / 8080, Redis colocated). Its security group and *_services_rules
+# local live here, not in security_groups.tf / locals_rules.tf, to keep those
+# files under the shared _file-size workflow's 12 KB gate — same split as
+# honeypot_rules.tf.
+#
+# Live guest-layer rule: 8080 open from internal RFC1918, following the existing
+# default-deny per-service allow model. The web UI is reached through Traefik
+# (ingress.tf nautobot route); the tighter ingress-only source restriction is the
+# network-layer (tofu-unifi) inter-VLAN rule, which ships staged-disabled — the
+# guest firewall here is the live boundary. Egress is outbound-internal (device
+# onboarding + SSoT target internal Proxmox/iDRAC/UniFi) plus outbound-HTTPS for
+# PyPI during converge (native install of nautobot + ssot + device-onboarding
+# apps), same egress shape as the ai-orchestration Python apps.
+
+locals {
+  nautobot_services_rules = [
+    { proto = "tcp", dport = tostring(local.svc_ports.nautobot_web), source = local.internal_src, comment = "Nautobot web UI (TCP ${local.svc_ports.nautobot_web}) from internal" },
+  ]
+}
+
+resource "proxmox_virtual_environment_cluster_firewall_security_group" "nautobot_services" {
+  name    = "nautobot-svc"
+  comment = "Nautobot web UI (${local.svc_ports.nautobot_web}) from internal networks — IPAM/DCIM, Traefik-fronted"
+
+  dynamic "rule" {
+    for_each = local.nautobot_services_rules
+    content {
+      type    = "in"
+      action  = "ACCEPT"
+      proto   = rule.value.proto
+      dport   = rule.value.dport
+      source  = rule.value.source
+      comment = rule.value.comment
+    }
+  }
+}
+
+resource "proxmox_virtual_environment_firewall_options" "nautobot_container" {
+  for_each = var.nautobot_container_ids
+
+  node_name     = var.node_name
+  container_id  = each.value
+  enabled       = local.firewall_defaults.enabled
+  input_policy  = local.firewall_defaults.input_policy
+  output_policy = local.firewall_defaults.output_policy
+  log_level_in  = local.firewall_defaults.log_level_in
+  log_level_out = local.firewall_defaults.log_level_out
+
+  # DHCP-first guest (deployment.json dhcp=true) behind DROP in/out. Without the
+  # firewall's dhcp allow, its own DHCPDISCOVER/OFFER is dropped and it never
+  # leases its reserved apps-VLAN IP. Same treatment as the s3 container.
+  dhcp = true
+
+  depends_on = [proxmox_virtual_environment_cluster_firewall.main]
+}
+
+resource "proxmox_virtual_environment_firewall_rules" "nautobot_container" {
+  for_each = var.nautobot_container_ids
+
+  node_name    = var.node_name
+  container_id = each.value
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.internal_access.name
+    comment        = "Internal access (SSH, ICMP)"
+  }
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.nautobot_services.name
+    comment        = "Nautobot web UI (TCP/${local.svc_ports.nautobot_web})"
+  }
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.outbound_internal.name
+    comment        = "Outbound to internal only"
+  }
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.outbound_https.name
+    comment        = "Outbound HTTPS (PyPI package installs during converge)"
+  }
+
+  depends_on = [proxmox_virtual_environment_firewall_options.nautobot_container]
+}

--- a/modules/firewall/postgres_rules.tf
+++ b/modules/firewall/postgres_rules.tf
@@ -1,0 +1,77 @@
+# Postgres LXC firewall — the shared native Postgres backing Nautobot (and later
+# Vikunja/EspoCRM). Its security group and *_services_rules local live here, not
+# in security_groups.tf / locals_rules.tf, to keep those files under the shared
+# _file-size workflow's 12 KB gate — same split as honeypot_rules.tf.
+#
+# Live guest-layer rule: 5432 open from internal RFC1918, following the existing
+# default-deny per-service allow model (openbao/s3/vectordb). The tighter
+# apps-VLAN-only source restriction (Nautobot is today's only consumer) is the
+# network-layer (tofu-unifi) inter-VLAN rule, which ships staged-disabled — the
+# guest firewall here is the live boundary. A database never calls out, so egress
+# is outbound-internal only (same as openbao/s3, no outbound_https).
+
+locals {
+  postgres_services_rules = [
+    { proto = "tcp", dport = tostring(local.svc_ports.postgres_default), source = local.internal_src, comment = "Postgres (TCP ${local.svc_ports.postgres_default}) from internal" },
+  ]
+}
+
+resource "proxmox_virtual_environment_cluster_firewall_security_group" "postgres_services" {
+  name    = "postgres-svc"
+  comment = "Postgres (${local.svc_ports.postgres_default}) from internal networks — shared DB for Nautobot/Vikunja/EspoCRM"
+
+  dynamic "rule" {
+    for_each = local.postgres_services_rules
+    content {
+      type    = "in"
+      action  = "ACCEPT"
+      proto   = rule.value.proto
+      dport   = rule.value.dport
+      source  = rule.value.source
+      comment = rule.value.comment
+    }
+  }
+}
+
+resource "proxmox_virtual_environment_firewall_options" "postgres_container" {
+  for_each = var.postgres_container_ids
+
+  node_name     = var.node_name
+  container_id  = each.value
+  enabled       = local.firewall_defaults.enabled
+  input_policy  = local.firewall_defaults.input_policy
+  output_policy = local.firewall_defaults.output_policy
+  log_level_in  = local.firewall_defaults.log_level_in
+  log_level_out = local.firewall_defaults.log_level_out
+
+  # DHCP-first guest (deployment.json dhcp=true) behind DROP in/out. Without the
+  # firewall's dhcp allow, its own DHCPDISCOVER/OFFER is dropped and it never
+  # leases its reserved data-VLAN IP. Same treatment as the s3 container.
+  dhcp = true
+
+  depends_on = [proxmox_virtual_environment_cluster_firewall.main]
+}
+
+resource "proxmox_virtual_environment_firewall_rules" "postgres_container" {
+  for_each = var.postgres_container_ids
+
+  node_name    = var.node_name
+  container_id = each.value
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.internal_access.name
+    comment        = "Internal access (SSH, ICMP)"
+  }
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.postgres_services.name
+    comment        = "Postgres (TCP/${local.svc_ports.postgres_default})"
+  }
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.outbound_internal.name
+    comment        = "Outbound to internal only"
+  }
+
+  depends_on = [proxmox_virtual_environment_firewall_options.postgres_container]
+}

--- a/modules/firewall/tests/rule_generation.tftest.hcl
+++ b/modules/firewall/tests/rule_generation.tftest.hcl
@@ -32,6 +32,7 @@ variables {
       openbao_cluster        = 8201
       postgres_default       = 5432
       redis_default          = 6379
+      nautobot_web           = 8080
       ntp                    = 123
       idrac_kvm_r410         = 5410
       idrac_kvm_r710         = 5710
@@ -606,5 +607,50 @@ run "media_web_rules_track_constants" {
       contains(values(local.media_web_rules)[*].dport, tostring(var.pipeline_constants.media_ports.prowlarr_web)),
     ])
     error_message = "downloader-resident ports (qBittorrent/Prowlarr) must never appear on the LAN-only media guests"
+  }
+}
+
+# --- postgres + nautobot service rules (issue #138) ---
+
+run "postgres_rule_tracks_constant_and_internal_scope" {
+  command = plan
+
+  variables {
+    internal_networks = ["192.168.10.0/24", "192.168.20.0/24"]
+  }
+
+  # Exactly one live rule: TCP 5432 from the comma-joined internal networks.
+  assert {
+    condition     = length(local.postgres_services_rules) == 1
+    error_message = "postgres_services_rules must be exactly 1 (TCP 5432), got ${length(local.postgres_services_rules)}"
+  }
+
+  assert {
+    condition     = local.postgres_services_rules[0].proto == "tcp" && local.postgres_services_rules[0].dport == tostring(var.pipeline_constants.service_ports.postgres_default)
+    error_message = "postgres rule must be TCP tracking service_ports.postgres_default, got proto='${local.postgres_services_rules[0].proto}' dport='${local.postgres_services_rules[0].dport}'"
+  }
+
+  assert {
+    condition     = local.postgres_services_rules[0].source == "192.168.10.0/24,192.168.20.0/24"
+    error_message = "postgres rule source must be the comma-joined internal networks, got '${local.postgres_services_rules[0].source}'"
+  }
+}
+
+run "nautobot_rule_tracks_constant_and_internal_scope" {
+  command = plan
+
+  variables {
+    internal_networks = ["192.168.10.0/24", "192.168.20.0/24"]
+  }
+
+  # Exactly one live rule: TCP nautobot_web (8080) from the internal networks.
+  assert {
+    condition     = length(local.nautobot_services_rules) == 1
+    error_message = "nautobot_services_rules must be exactly 1 (TCP nautobot_web), got ${length(local.nautobot_services_rules)}"
+  }
+
+  assert {
+    condition     = local.nautobot_services_rules[0].proto == "tcp" && local.nautobot_services_rules[0].dport == tostring(var.pipeline_constants.service_ports.nautobot_web)
+    error_message = "nautobot rule must be TCP tracking service_ports.nautobot_web, got proto='${local.nautobot_services_rules[0].proto}' dport='${local.nautobot_services_rules[0].dport}'"
   }
 }

--- a/modules/firewall/variables.tf
+++ b/modules/firewall/variables.tf
@@ -69,6 +69,18 @@ variable "openbao_container_ids" {
   default     = {}
 }
 
+variable "postgres_container_ids" {
+  description = "Map of Postgres container names to their IDs (postgres tag). Shared native Postgres — inbound 5432 from internal; egress outbound-internal only."
+  type        = map(number)
+  default     = {}
+}
+
+variable "nautobot_container_ids" {
+  description = "Map of Nautobot container names to their IDs (nautobot tag). Native IPAM/DCIM — inbound nautobot_web (8080) from internal; egress outbound-internal + outbound-HTTPS (PyPI installs during converge)."
+  type        = map(number)
+  default     = {}
+}
+
 variable "ingress_container_ids" {
   description = "Map of ingress (Traefik HA) container names to their IDs (ingress tag). Firewall is DEFINE-DISABLED (see ingress_rules.tf): it pre-allows keepalived VRRP + 80/443 so enabling enforcement later never breaks the floating VIP."
   type        = map(number)

--- a/tests/ansible_inventory_contract.tftest.hcl
+++ b/tests/ansible_inventory_contract.tftest.hcl
@@ -75,7 +75,27 @@ variables {
   network_cidrs = { for name, id in var.vlan_ids : name => "192.168.${id}.0/24" }
 }
 
+# --- schema version (issue #134 producer contract) ---
+
+run "ansible_inventory_schema_version" {
+  command = plan
+
+  assert {
+    condition     = output.ansible_inventory.schema_version == "2.0.0"
+    error_message = "ansible_inventory must carry schema_version \"2.0.0\" so the homelab-contracts schema gate can confirm the emitted shape"
+  }
+}
+
 # --- constants structure tests ---
+
+run "ansible_inventory_nautobot_web_constant" {
+  command = plan
+
+  assert {
+    condition     = output.ansible_inventory.constants.service_ports.nautobot_web == 8080
+    error_message = "constants.service_ports.nautobot_web must be 8080 (Nautobot web UI)"
+  }
+}
 
 run "ansible_inventory_constants_exists" {
   command = plan
@@ -353,6 +373,51 @@ run "ansible_inventory_ingress_route_table" {
   assert {
     condition     = length([for r in output.ansible_inventory.ingress : r if r.name == "proxmox"]) == 0
     error_message = "ingress must omit the proxmox apex route when no node is commissioned"
+  }
+}
+
+# --- ingress: nautobot fronted, postgres never fronted (issue #138) ---
+#
+# Nautobot's web UI (8080) is a Traefik-fronted route; Postgres is reached only
+# in-cluster on 5432 and must NEVER appear in the ingress table.
+run "ansible_inventory_ingress_nautobot_not_postgres" {
+  command = plan
+
+  variables {
+    domain = "example.com"
+    containers = {
+      "nautobot" = {
+        vm_id         = 605000
+        hostname      = "nautobot"
+        vlan          = "apps"
+        dhcp          = true
+        reserved_host = 52
+        tags          = ["terraform", "container", "nautobot"]
+      }
+      "postgres" = {
+        vm_id         = 303000
+        hostname      = "postgres"
+        vlan          = "data"
+        dhcp          = true
+        reserved_host = 51
+        tags          = ["terraform", "container", "postgres", "database"]
+      }
+    }
+  }
+
+  # nautobot: DHCP-first backend fronted by FQDN on nautobot_web (8080).
+  assert {
+    condition = length([
+      for r in output.ansible_inventory.ingress :
+      r if r.name == "nautobot" && r.ip == "nautobot.example.com" && r.port == 8080
+    ]) == 1
+    error_message = "ingress must front nautobot at nautobot.example.com:8080 (FQDN backend + nautobot_web constant)"
+  }
+
+  # postgres has no ingress_services row -> it must never surface as a route.
+  assert {
+    condition     = length([for r in output.ansible_inventory.ingress : r if r.name == "postgres"]) == 0
+    error_message = "postgres must never appear in the ingress table (in-cluster 5432 only, no Traefik front)"
   }
 }
 

--- a/tests/firewall_filtering.tftest.hcl
+++ b/tests/firewall_filtering.tftest.hcl
@@ -491,3 +491,73 @@ run "non_honeypot_container_not_in_honeypot_ids" {
     error_message = "honeypot maps must be empty when no containers carry the 'honeypot' tag"
   }
 }
+
+# --- postgres_container_ids / nautobot_container_ids tests (issue #138) ---
+
+run "postgres_and_nautobot_tags_filter_correctly" {
+  command = plan
+
+  variables {
+    containers = {
+      "postgres" = {
+        vm_id         = 303000
+        hostname      = "postgres"
+        vlan          = "data"
+        dhcp          = true
+        reserved_host = 51
+        tags          = ["terraform", "container", "postgres", "database"]
+      }
+      "nautobot" = {
+        vm_id         = 605000
+        hostname      = "nautobot"
+        vlan          = "apps"
+        dhcp          = true
+        reserved_host = 52
+        tags          = ["terraform", "container", "nautobot"]
+      }
+    }
+  }
+
+  assert {
+    condition     = local.postgres_container_ids["postgres"] == 303000 && length(local.postgres_container_ids) == 1
+    error_message = "postgres-tagged container must be the sole member of postgres_container_ids"
+  }
+
+  assert {
+    condition     = local.nautobot_container_ids["nautobot"] == 605000 && length(local.nautobot_container_ids) == 1
+    error_message = "nautobot-tagged container must be the sole member of nautobot_container_ids"
+  }
+
+  # The two maps must not cross-claim, and neither belongs in the pipeline set.
+  assert {
+    condition     = !contains(keys(local.nautobot_container_ids), "postgres") && !contains(keys(local.postgres_container_ids), "nautobot")
+    error_message = "postgres_container_ids and nautobot_container_ids must not cross-claim guests"
+  }
+
+  assert {
+    condition     = !contains(keys(local.pipeline_container_ids), "postgres") && !contains(keys(local.pipeline_container_ids), "nautobot")
+    error_message = "neither postgres nor nautobot may land in pipeline_container_ids"
+  }
+}
+
+# A generic 'database'-tagged guest (e.g. mssql) must NOT be pulled into
+# postgres_container_ids — only the specific 'postgres' tag opens the 5432 rule.
+run "generic_database_tag_not_in_postgres_ids" {
+  command = plan
+
+  variables {
+    containers = {
+      "mssql" = {
+        vm_id    = 130
+        hostname = "mssql"
+        vlan     = "data"
+        tags     = ["terraform", "container", "database"]
+      }
+    }
+  }
+
+  assert {
+    condition     = length(local.postgres_container_ids) == 0
+    error_message = "a container tagged only 'database' (not 'postgres') must NOT be in postgres_container_ids"
+  }
+}

--- a/vault-secrets/main.tf
+++ b/vault-secrets/main.tf
@@ -53,3 +53,56 @@ data "vault_kv_secret_v2" "demo_read" {
 
   depends_on = [vault_kv_secret_v2.demo]
 }
+
+# --- Nautobot service credentials (generate-if-absent) --------------------------
+# The three secrets a native Nautobot needs. Each is generated random ONCE and
+# stored in state; re-apply reuses the stored value, so credentials never rotate
+# under the running service. ignore_changes pins the generator inputs so a later
+# edit to length/special can't silently rotate a live credential either — the
+# "keepers / ignore_changes" guard the plan calls for. Only the generated value
+# lands in OpenBao at secret/apps/nautobot; no real secret is ever committed.
+#
+# db_password is the shared Postgres credential Nautobot connects with — it lives
+# under apps/nautobot because Nautobot is the first (today, only) consumer of the
+# shared DB. It is promoted to a shared path only when a second consumer
+# (Vikunja/EspoCRM) actually needs it, per the source-tier secrets rule.
+resource "random_password" "nautobot_db_password" {
+  length  = 32
+  special = false # Postgres connection strings/URLs choke on some specials; alnum is safe
+
+  lifecycle {
+    ignore_changes = [length, special, override_special]
+  }
+}
+
+resource "random_password" "nautobot_secret_key" {
+  length  = 64
+  special = false # Django/Nautobot SECRET_KEY: alnum avoids env-file quoting hazards downstream
+
+  lifecycle {
+    ignore_changes = [length, special, override_special]
+  }
+}
+
+resource "random_password" "nautobot_superuser_password" {
+  length  = 24
+  special = false
+
+  lifecycle {
+    ignore_changes = [length, special, override_special]
+  }
+}
+
+# Seed OpenBao (KV v2 mount "secret", enabled by the openbao Ansible role). The
+# nautobot Ansible role reads secret/apps/nautobot for its DB, SECRET_KEY, and
+# initial superuser.
+resource "vault_kv_secret_v2" "nautobot" {
+  mount = "secret"
+  name  = "apps/nautobot"
+
+  data_json = jsonencode({
+    db_password        = random_password.nautobot_db_password.result
+    secret_key         = random_password.nautobot_secret_key.result
+    superuser_password = random_password.nautobot_superuser_password.result
+  })
+}


### PR DESCRIPTION
## What

Producer-side Terraform for **Phase P1 (#138)** — stand up a shared native
Postgres and a native Nautobot IPAM/DCIM guest — plus the **P0 (#134) producer
contract stamp**. This is the Terraform wiring only; the live guest creation and
Ansible converge happen later at the gated cutover, not in this PR.

## Changes

| Area | Change |
| --- | --- |
| `constants.tf` | `service_ports.nautobot_web = 8080` (`postgres_default` 5432 / `redis_default` 6379 already present) |
| `ingress.tf` | Nautobot web UI fronted at `nautobot.<domain>:8080`. **Postgres gets no ingress row** (in-cluster 5432 only) |
| `locals.tf` + `main.tf` | tag-filtered `postgres_container_ids` (`postgres` tag) + `nautobot_container_ids` (`nautobot` tag), wired into `module.firewall` |
| `modules/firewall/postgres_rules.tf` | live security group: 5432 from internal; DHCP-first container rules; egress outbound-internal only |
| `modules/firewall/nautobot_rules.tf` | live security group: 8080 from internal; DHCP-first container rules; egress internal + HTTPS (PyPI) |
| `vault-secrets/main.tf` | generate-if-absent random `db_password`/`secret_key`/`superuser_password` → `secret/apps/nautobot` (`ignore_changes` pins them so re-apply never rotates) |
| `inventory_publish.tf` | **#134**: top-level `schema_version = "2.0.0"` on the published `ansible_inventory` |
| `deployment.json.example` | illustrative `postgres` + `nautobot` container entries (see below) |
| tests | +2 firewall-module rule assertions, +2 root container-id filter assertions, +3 inventory-contract assertions |

### Firewall model note

The **guest-layer** rule is **live**, sourced from `internal_src`, matching the
existing default-deny per-service allow model (openbao / s3 / vectordb). The
tighter *container-scoped* source restriction ("5432 only from Nautobot", "8080
only from ingress") is the **network-layer (tofu-unifi) inter-VLAN rule, which
ships `enabled = false`** — that layer is WS-D's, staged-disabled per plan.

## Proposed `deployment.json` container entries (for the gated live edit)

These are the two entries WS-D's reservations and WS-E's cutover consume. They
are placeholders in `deployment.json.example`; the live edit into the gitignored
`deployment.json` happens later under flow-lock. **Verified no VMID /
`reserved_host` collision** against both `deployment.json.example` and the live
inventory shape (data VLAN had only `mssql`; apps VLAN legacy guests derive to
`.100`–`.251`; `.51`/`.52` clear).

```json
"postgres": {
  "vm_id": 303000,
  "dhcp": true,
  "reserved_host": 51,
  "vlan": "data",
  "hostname": "postgres",
  "description": "Shared native Postgres — inventory/apps datastore (Nautobot now; Vikunja/EspoCRM later). Persistent data mount + pgdump backups.",
  "cpu_cores": 2,
  "memory_dedicated": 2048,
  "tags": ["terraform", "container", "postgres", "database"],
  "pool_id": "infrastructure",
  "node_name": "proxmox-1",
  "unprivileged": true,
  "root_disk": { "size": 16 },
  "mount_points": [
    { "volume": "local-zfs", "size": "60G", "path": "/var/lib/postgresql" }
  ]
}
```

```json
"nautobot": {
  "vm_id": 605000,
  "dhcp": true,
  "reserved_host": 52,
  "vlan": "apps",
  "hostname": "nautobot",
  "description": "Native Nautobot IPAM/DCIM source of truth (venv + uwsgi + worker + scheduler; Redis colocated). Web UI on 8080, fronted by Traefik.",
  "cpu_cores": 4,
  "memory_dedicated": 4096,
  "tags": ["terraform", "container", "nautobot"],
  "pool_id": "infrastructure",
  "node_name": "proxmox-1",
  "unprivileged": true,
  "root_disk": { "size": 24 },
  "mount_points": [
    { "volume": "local-zfs", "size": "40G", "path": "/opt/nautobot" }
  ]
}
```

### Derived MAC / reserved-IP (for WS-D reservations)

`locals.tf` `container_mac` derives a deterministic MAC per DHCP-first guest as
`02:` + the first five octet-pairs of `md5(hostname)`; `reserved_ip` is
`cidrhost(network_cidrs[vlan], reserved_host)`:

| guest | vm_id | vlan | reserved_host | derived MAC | reserved_ip |
| --- | --- | --- | --- | --- | --- |
| postgres | 303000 | data (30) | 51 | `02:e8:a4:86:53:85` | `<data-subnet>.51` |
| nautobot | 605000 | apps (60) | 52 | `02:4a:6a:2f:24:43` | `<apps-subnet>.52` |

## Producer/schema (#134) — WS-A

Emitting top-level `schema_version = "2.0.0"` (string) alongside the real key
set: `containers, vms, docker_vms, splunk_vm, constants, ingress, ingress_vip,
ingress_hosts, host_services, nodes, node_storage, domain`. Asked WS-A to
confirm the schema names exactly `schema_version` (snake_case string) and that
this key set matches their reconciled schema; **awaiting confirmation** — value
matches the agreed `2.0.0`.

## Validation

- `tofu fmt` clean · root `tofu validate` Success · **root `tofu test` 113
  passed** · **firewall module `tofu test` 27 passed**.
- pre-commit: fmt / checkov / gitleaks / terraform-validate / tflint / tofu-test
  all pass.

## Risks / open questions

1. **Nautobot HTTPS egress** — I granted `outbound_https` for PyPI installs
   during converge (native `nautobot` + `nautobot-app-ssot` +
   `nautobot-app-device-onboarding`). If WS-B's role installs from an internal
   PyPI mirror instead, drop the rule for tighter least-privilege.
2. **Pre-existing (NOT this PR): `vault-secrets/` does not validate.** Its
   provider block pins `hashicorp/vault ~> 5.9`; the resolved provider (5.10.1
   via OpenTofu) rejects the `auth_login_approle` block and `outputs.tf`'s
   `.version` attribute. Confirmed identical failure on untouched `develop`. CI
   does not validate this module, so it went unnoticed. My additions
   (`random_password` + `vault_kv_secret_v2`) validate cleanly in isolation.
   Worth a separate fix issue — out of scope here.
3. Live `deployment.json` edit + `terragrunt apply` are the gated cutover
   (WS-E), deliberately not done here.

Refs #138, #134
