### PR TITLE
feat(vikunja): wire vikunja LXC firewall, ingress, and service port

### DIFF
--- a/constants.tf
+++ b/constants.tf
@@ -73,6 +73,7 @@ locals {
       technitium_web    = 5380
       phpipam_web       = 80
       nautobot_web      = 8080
+      vikunja_web       = 3456
       homeassistant_web = 8123
       openproject_web   = 80
       prometheus_web    = 9090

--- a/deployment.json.example
+++ b/deployment.json.example
@@ -223,6 +223,24 @@
         { "volume": "local-zfs", "size": "40G", "path": "/opt/nautobot" }
       ]
     },
+    "vikunja": {
+      "vm_id": 605010,
+      "dhcp": true,
+      "reserved_host": 53,
+      "vlan": "apps",
+      "hostname": "vikunja",
+      "description": "Vikunja task management — native Go binary, web/API on 3456 fronted by Traefik; state in the shared Postgres; persistent /var/lib/vikunja for file attachments.",
+      "cpu_cores": 2,
+      "memory_dedicated": 1024,
+      "tags": ["terraform", "container", "vikunja"],
+      "pool_id": "infrastructure",
+      "node_name": "proxmox-1",
+      "unprivileged": true,
+      "root_disk": { "size": 8 },
+      "mount_points": [
+        { "volume": "local-zfs", "size": "10G", "path": "/var/lib/vikunja" }
+      ]
+    },
     "_ingress_ha_comment": "Ingress is HA: identical Traefik LXCs on DIFFERENT nodes carry the `ingress` tag; keepalived floats one VRRP virtual IP across them (ingress.tf derives ingress_vip/ingress_hosts from the `ingress` tag + network_cidrs). A VIP is synthesized only with at least two ingress nodes; add another by copying the block and bumping vm_id/node_name — no code change. DNS points every fronted service at the VIP, so a node loss migrates the VIP automatically.",
     "traefik": {
       "vm_id": 101,

--- a/ingress.tf
+++ b/ingress.tf
@@ -20,6 +20,7 @@ locals {
     technitium       = { backend = "technitium-dns", port = local.pipeline_constants.service_ports.technitium_web }
     phpipam          = { backend = "phpipam", port = local.pipeline_constants.service_ports.phpipam_web }
     nautobot         = { backend = "nautobot", port = local.pipeline_constants.service_ports.nautobot_web } # native IPAM/DCIM UI; Postgres has NO ingress row (in-cluster 5432 only)
+    vikunja          = { backend = "vikunja", port = local.pipeline_constants.service_ports.vikunja_web }
     "object-storage" = { backend = "s3", port = local.pipeline_constants.service_ports.object_storage_console }
     # RustFS S3 API fronted by a valid-TLS hostname. Path-style S3 format.
     s3 = { backend = "s3", port = local.pipeline_constants.service_ports.object_storage_s3 }

--- a/locals-vikunja.tf
+++ b/locals-vikunja.tf
@@ -1,0 +1,14 @@
+# Vikunja tag-filter local — extracted from locals.tf so that file stays under
+# the shared _file-size workflow's 12 KB limit (locals merge across files in a
+# module, so this is a pure relocation with no behavior change). Consumed by the
+# firewall module call in main.tf.
+
+locals {
+  # Vikunja LXC (vikunja tag) — native task-management app, web/API on
+  # vikunja_web (3456), state in the shared Postgres. modules/firewall opens
+  # 3456 to it from internal.
+  vikunja_container_ids = {
+    for k, v in var.containers : k => v.vm_id
+    if contains(coalesce(try(v.tags, null), []), "vikunja")
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -225,9 +225,10 @@ module "firewall" {
   # OpenBao secrets-management containers (openbao tag)
   openbao_container_ids = local.openbao_container_ids
 
-  # Postgres (postgres tag) + Nautobot (nautobot tag) containers — 5432 / 8080 from internal
+  # Postgres + Nautobot + Vikunja containers — 5432 / 8080 / 3456 from internal
   postgres_container_ids = local.postgres_container_ids
   nautobot_container_ids = local.nautobot_container_ids
+  vikunja_container_ids  = local.vikunja_container_ids
 
   # Ingress (Traefik HA) containers (ingress tag) — define-disabled guest firewall
   # that pre-allows keepalived VRRP + 80/443 so a later enforcement flip is safe.

--- a/modules/firewall/tests/rule_generation.tftest.hcl
+++ b/modules/firewall/tests/rule_generation.tftest.hcl
@@ -33,6 +33,7 @@ variables {
       postgres_default       = 5432
       redis_default          = 6379
       nautobot_web           = 8080
+      vikunja_web            = 3456
       ntp                    = 123
       idrac_kvm_r410         = 5410
       idrac_kvm_r710         = 5710
@@ -652,5 +653,31 @@ run "nautobot_rule_tracks_constant_and_internal_scope" {
   assert {
     condition     = local.nautobot_services_rules[0].proto == "tcp" && local.nautobot_services_rules[0].dport == tostring(var.pipeline_constants.service_ports.nautobot_web)
     error_message = "nautobot rule must be TCP tracking service_ports.nautobot_web, got proto='${local.nautobot_services_rules[0].proto}' dport='${local.nautobot_services_rules[0].dport}'"
+  }
+}
+
+# --- vikunja service rules (issue #141) ---
+
+run "vikunja_rule_tracks_constant_and_internal_scope" {
+  command = plan
+
+  variables {
+    internal_networks = ["192.168.10.0/24", "192.168.20.0/24"]
+  }
+
+  # Exactly one live rule: TCP vikunja_web (3456) from the internal networks.
+  assert {
+    condition     = length(local.vikunja_services_rules) == 1
+    error_message = "vikunja_services_rules must be exactly 1 (TCP vikunja_web), got ${length(local.vikunja_services_rules)}"
+  }
+
+  assert {
+    condition     = local.vikunja_services_rules[0].proto == "tcp" && local.vikunja_services_rules[0].dport == tostring(var.pipeline_constants.service_ports.vikunja_web)
+    error_message = "vikunja rule must be TCP tracking service_ports.vikunja_web, got proto='${local.vikunja_services_rules[0].proto}' dport='${local.vikunja_services_rules[0].dport}'"
+  }
+
+  assert {
+    condition     = local.vikunja_services_rules[0].source == "192.168.10.0/24,192.168.20.0/24"
+    error_message = "vikunja rule source must be the comma-joined internal networks, got '${local.vikunja_services_rules[0].source}'"
   }
 }

--- a/modules/firewall/variables.tf
+++ b/modules/firewall/variables.tf
@@ -81,6 +81,12 @@ variable "nautobot_container_ids" {
   default     = {}
 }
 
+variable "vikunja_container_ids" {
+  description = "Map of Vikunja container names to their IDs (vikunja tag). Native task-management app — inbound vikunja_web (3456) from internal; egress outbound-internal only (no package-manager egress, binary is controller-staged)."
+  type        = map(number)
+  default     = {}
+}
+
 variable "ingress_container_ids" {
   description = "Map of ingress (Traefik HA) container names to their IDs (ingress tag). Firewall is DEFINE-DISABLED (see ingress_rules.tf): it pre-allows keepalived VRRP + 80/443 so enabling enforcement later never breaks the floating VIP."
   type        = map(number)

--- a/modules/firewall/vikunja_rules.tf
+++ b/modules/firewall/vikunja_rules.tf
@@ -1,0 +1,79 @@
+# Vikunja LXC firewall — native single-binary task-management app, web/API on
+# vikunja_web (3456), state in the shared Postgres. Its security group and
+# *_services_rules local live here, not in locals_rules.tf / security_groups.tf,
+# to keep those files under the shared _file-size workflow's 12 KB gate — same
+# split as nautobot_rules.tf / postgres_rules.tf.
+#
+# Live guest-layer rule: 3456 open from internal RFC1918, following the existing
+# default-deny per-service allow model. The web UI is reached through Traefik
+# (ingress.tf vikunja route); the tighter ingress-only source restriction is the
+# network-layer (tofu-unifi) inter-VLAN rule, which ships staged-disabled — the
+# guest firewall here is the live boundary. The binary is controller-staged (no
+# package-manager egress) and its only dependencies are Postgres + DNS + apt, so
+# egress is outbound-internal only — no outbound_https.
+
+locals {
+  vikunja_services_rules = [
+    { proto = "tcp", dport = tostring(local.svc_ports.vikunja_web), source = local.internal_src, comment = "Vikunja web/API from internal" },
+  ]
+}
+
+resource "proxmox_virtual_environment_cluster_firewall_security_group" "vikunja_services" {
+  name    = "vikunja-svc"
+  comment = "Vikunja web/API (${local.svc_ports.vikunja_web}) from internal networks — Traefik-fronted"
+
+  dynamic "rule" {
+    for_each = local.vikunja_services_rules
+    content {
+      type    = "in"
+      action  = "ACCEPT"
+      proto   = rule.value.proto
+      dport   = rule.value.dport
+      source  = rule.value.source
+      comment = rule.value.comment
+    }
+  }
+}
+
+resource "proxmox_virtual_environment_firewall_options" "vikunja_container" {
+  for_each = var.vikunja_container_ids
+
+  node_name     = var.node_name
+  container_id  = each.value
+  enabled       = local.firewall_defaults.enabled
+  input_policy  = local.firewall_defaults.input_policy
+  output_policy = local.firewall_defaults.output_policy
+  log_level_in  = local.firewall_defaults.log_level_in
+  log_level_out = local.firewall_defaults.log_level_out
+
+  # DHCP-first guest (deployment.json dhcp=true) behind DROP in/out. Without the
+  # firewall's dhcp allow, its own DHCPDISCOVER/OFFER is dropped and it never
+  # leases its reserved apps-VLAN IP. Same treatment as the s3 container.
+  dhcp = true
+
+  depends_on = [proxmox_virtual_environment_cluster_firewall.main]
+}
+
+resource "proxmox_virtual_environment_firewall_rules" "vikunja_container" {
+  for_each = var.vikunja_container_ids
+
+  node_name    = var.node_name
+  container_id = each.value
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.internal_access.name
+    comment        = "Internal access (SSH, ICMP)"
+  }
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.vikunja_services.name
+    comment        = "Vikunja web/API (TCP/${local.svc_ports.vikunja_web})"
+  }
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.outbound_internal.name
+    comment        = "Outbound to internal only"
+  }
+
+  depends_on = [proxmox_virtual_environment_firewall_options.vikunja_container]
+}

--- a/tests/ansible_inventory_contract.tftest.hcl
+++ b/tests/ansible_inventory_contract.tftest.hcl
@@ -97,6 +97,15 @@ run "ansible_inventory_nautobot_web_constant" {
   }
 }
 
+run "ansible_inventory_vikunja_web_constant" {
+  command = plan
+
+  assert {
+    condition     = output.ansible_inventory.constants.service_ports.vikunja_web == 3456
+    error_message = "constants.service_ports.vikunja_web must be 3456 (Vikunja web/API)"
+  }
+}
+
 run "ansible_inventory_constants_exists" {
   command = plan
 
@@ -418,6 +427,34 @@ run "ansible_inventory_ingress_nautobot_not_postgres" {
   assert {
     condition     = length([for r in output.ansible_inventory.ingress : r if r.name == "postgres"]) == 0
     error_message = "postgres must never appear in the ingress table (in-cluster 5432 only, no Traefik front)"
+  }
+}
+
+# --- ingress: vikunja fronted (issue #141) ---
+run "ansible_inventory_ingress_vikunja_fronted" {
+  command = plan
+
+  variables {
+    domain = "example.com"
+    containers = {
+      "vikunja" = {
+        vm_id         = 605010
+        hostname      = "vikunja"
+        vlan          = "apps"
+        dhcp          = true
+        reserved_host = 53
+        tags          = ["terraform", "container", "vikunja"]
+      }
+    }
+  }
+
+  # vikunja: DHCP-first backend fronted by FQDN on vikunja_web (3456).
+  assert {
+    condition = length([
+      for r in output.ansible_inventory.ingress :
+      r if r.name == "vikunja" && r.ip == "vikunja.example.com" && r.port == 3456
+    ]) == 1
+    error_message = "ingress must front vikunja at vikunja.example.com:3456 (FQDN backend + vikunja_web constant)"
   }
 }
 

--- a/tests/firewall_filtering.tftest.hcl
+++ b/tests/firewall_filtering.tftest.hcl
@@ -540,6 +540,35 @@ run "postgres_and_nautobot_tags_filter_correctly" {
   }
 }
 
+# --- vikunja_container_ids test (issue #141) ---
+
+run "vikunja_tag_filters_correctly" {
+  command = plan
+
+  variables {
+    containers = {
+      "vikunja" = {
+        vm_id         = 605010
+        hostname      = "vikunja"
+        vlan          = "apps"
+        dhcp          = true
+        reserved_host = 53
+        tags          = ["terraform", "container", "vikunja"]
+      }
+    }
+  }
+
+  assert {
+    condition     = local.vikunja_container_ids["vikunja"] == 605010 && length(local.vikunja_container_ids) == 1
+    error_message = "vikunja-tagged container must be the sole member of vikunja_container_ids"
+  }
+
+  assert {
+    condition     = !contains(keys(local.pipeline_container_ids), "vikunja")
+    error_message = "vikunja must not land in pipeline_container_ids"
+  }
+}
+
 # A generic 'database'-tagged guest (e.g. mssql) must NOT be pulled into
 # postgres_container_ids — only the specific 'postgres' tag opens the 5432 rule.
 run "generic_database_tag_not_in_postgres_ids" {


### PR DESCRIPTION
## Summary

Wires the guest-layer firewall, Traefik ingress route, and service-port
constant for a new Vikunja LXC (native single-binary task-management app,
web/API on port 3456), mirroring the existing openbao/nautobot/postgres
patterns:

- `constants.tf`: `vikunja_web = 3456` in `pipeline_constants.service_ports`.
- `modules/firewall/vikunja_rules.tf` (new): self-contained security group +
  `vikunja_services_rules` local + per-container firewall options/rules for
  `var.vikunja_container_ids` — internal-only inbound to 3456, outbound-internal
  egress only (no outbound-HTTPS; the binary is controller-staged, and its only
  dependencies are Postgres/DNS/apt). Follows the current self-contained-file
  convention (same split as `nautobot_rules.tf` / `postgres_rules.tf`), rather
  than the older locals.tf/security_groups.tf split `openbao_rules.tf` uses.
- `locals-vikunja.tf` (new): `vikunja_container_ids` tag-filter local,
  extracted to its own file (not added to `locals.tf`) to stay under the repo's
  12 KB file-size CI gate — `locals.tf`, `main.tf`, `ingress.tf`, and
  `constants.tf` were all already within ~250 bytes of the 12288-byte limit.
- `main.tf` / `ingress.tf`: wire the new local into the `firewall` module call
  and add a `vikunja` Traefik ingress route.
- `deployment.json.example`: illustrative `vikunja` LXC entry (DHCP-first,
  apps VLAN, persistent `/var/lib/vikunja` mount for attachments) alongside
  the existing postgres/nautobot examples.
- Test coverage extended in `modules/firewall/tests/rule_generation.tftest.hcl`,
  `tests/firewall_filtering.tftest.hcl`, and `tests/ansible_inventory_contract.tftest.hcl`
  (service-rule shape, tag-filter isolation, ingress fronting, constants
  contract), mirroring the existing nautobot coverage.

## Verification

Run from the worktree via the Nix dev shell (`tofu` on PATH):

- `tofu fmt -recursive -diff` — no changes.
- `tofu init -backend=false && tofu validate` — Success, configuration valid.
- `tofu test` (root) — 116 passed, 0 failed (includes 3 new vikunja runs).
- `tofu test` (`modules/firewall`) — 28 passed, 0 failed (includes the new
  `vikunja_rule_tracks_constant_and_internal_scope` run).
- `pre-commit run --files <changed files>` — all hooks pass (fmt, Checkov,
  secret scan, `terraform validate`, `tflint`, `tofu test` with mock
  providers).

## Notes

Textually adjacent to #618 (postgres/nautobot wiring follow-up); no semantic
dependency — whichever merges second rebases cleanly. (The bulk of the
postgres/nautobot wiring itself is already merged into `develop` via #617, so
this PR mirrors that already-landed pattern directly.)

Refs dryvist/docs-starlight#141

🤖 Generated with [Claude Code](https://claude.com/claude-code)