### PR TITLE
fix(vault-secrets): skip child token for least-privilege AppRole

### DIFF
--- a/vault-secrets/main.tf
+++ b/vault-secrets/main.tf
@@ -21,6 +21,9 @@ terraform {
 # address / role_id / secret_id come from Doppler env vars (see terragrunt.hcl).
 provider "vault" {
   address = var.vault_addr
+  # The Terraform AppRole is least-privilege for this module and cannot mint
+  # child tokens; use the login token directly.
+  skip_child_token = true
 
   auth_login {
     path = "auth/approle/login"


### PR DESCRIPTION
## What

Set `skip_child_token = true` on the `vault` provider in the `vault-secrets` module.

## Why

The `terraform-apply` AppRole is least-privilege and its policy denies `auth/token/create`. The Vault provider's default behaviour is to mint a short-lived child token from the login token; with `create` denied that call fails and the module cannot authenticate. `skip_child_token` makes the provider use the AppRole login token directly.

Verified empirically: `sys/capabilities-self` for the terraform AppRole returns `deny` on `auth/token/create`.

Refs #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)