### PR TITLE
feat: add develop-environment input for deployment.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,7 +128,10 @@ scripts/timing-results.txt
 # Live deployment config — contains real node names, VM inventory, and ZFS pool names.
 # Private desired-state input — lives in the on-prem `s3` store, fetched by terragrunt
 # (see agentsmd/rules/infra/deployment-json-source-of-truth.md). Repo keeps only the example.
+# The develop-environment input is a second private object, same rules. Repo keeps only its
+# example (deployment.develop.json.example).
 deployment.json
+deployment.develop.json
 
 # ---------------------------------------------------------------------
 # dryvist org-default: secrets, credentials & AI-assistant local state

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,15 @@ locals.tf derivations    (computed)             — management_network, splunk_n
 - `deployment.json` — resource definitions (containers, VMs, pools, sizing).
   Private, not committed; fetched from the on-prem `s3` store at plan/apply. See
   [`deployment-json-source-of-truth`](agentsmd/rules/infra/deployment-json-source-of-truth.md).
+- **Two environments (git-flow).** Prod is `deployment.json` (`environment:
+  homelab`); develop is a second private object `deployment.develop.json`
+  (`environment: develop`), selected by explicitly exporting
+  `S3_INVENTORY_KEY=deployment.develop.json`. The `environment` field derives a
+  develop-scoped tfstate key, input-mirror path, and published-inventory key, so
+  develop applies REAL guests on the `nonprod` VLAN independently of prod without
+  touching prod state. **Prod paths are pinned unchanged** — see the rule doc
+  above for the derived-key table and invariants. Repo keeps
+  `deployment.develop.json.example`.
 - `terraform.sops.json` — five env-specific values: `network_prefix`,
   `domain`, `vm_ssh_public_key_path`, `vm_ssh_private_key_path`,
   `proxmox_ssh_username`. Decrypted automatically by Terragrunt.

--- a/agentsmd/rules/infra/deployment-json-source-of-truth.md
+++ b/agentsmd/rules/infra/deployment-json-source-of-truth.md
@@ -38,6 +38,28 @@ only. The repo keeps only `deployment.json.example`. Read/edit recipe:
   triggers destroy + recreate. Verify against `terragrunt state list` first.
   (Authoring details: see the contract page above.)
 
+**Two environments (git-flow):** there are two independent inputs — the prod
+object (`deployment.json`, `environment: homelab`) and the develop object
+(`deployment.develop.json`, `environment: develop`). Select which one a run uses
+by **explicitly** exporting `S3_INVENTORY_KEY` (`deployment.json` is the default;
+`deployment.develop.json` for develop) — there is no git-branch inference. The
+`environment` field inside the fetched object then drives three derived keys:
+
+| Key | `homelab` (prod, UNCHANGED) | `develop` |
+| --- | --- | --- |
+| tfstate | `terraform-proxmox/terraform.tfstate` | `terraform-proxmox/develop/terraform.tfstate` |
+| input mirror | `terraform-proxmox/input/deployment.json` | `terraform-proxmox/input/develop/deployment.json` |
+| published inventory | `terraform-proxmox/inventory/ansible_inventory.json` | `terraform-proxmox/inventory/develop/ansible_inventory.json` |
+
+Invariants: **prod paths never change** (the `homelab` branch pins today's exact
+literals — drift makes a prod apply init an empty state and plan a full destroy);
+**never point the develop input at prod state**; separate tfstate keys mean
+separate locks, but both envs share one physical cluster, so the global flow
+lease still serializes applies across them. Keep the develop object **minimal**
+(only guests under test) on the `nonprod` VLAN with the env digit `1` in the last
+VMID position. An unknown `environment` fails loud (allowlist `["homelab","develop"]`).
+The repo keeps only `deployment.develop.json.example`.
+
 **Repo-specific layer split (not on the public page — installation-specific):**
 
 - SOPS (`terraform.sops.json`) holds installation-specific values (not

--- a/deployment.develop.json.example
+++ b/deployment.develop.json.example
@@ -1,0 +1,44 @@
+{
+  "_comment": "EXAMPLE FILE for the DEVELOP environment — copy to deployment.develop.json for live use (gitignored, same rules as deployment.json). This is a SEPARATE private desired-state input: select it by exporting S3_INVENTORY_KEY=deployment.develop.json before terragrunt. Its `environment: develop` makes terragrunt derive a develop-scoped tfstate key, input-mirror path, and published-inventory key, so it applies REAL guests independently of production without ever touching prod state. KEEP IT MINIMAL — only the guests under test, not a clone of the fleet (a second live env shares one physical cluster). Guests live on the `nonprod` VLAN and carry the env digit `1` in the last VMID position ([Tier][Sub][Crit][OS][Inst][Env]; prod uses env 0). See docs/SOPS_SETUP.md and the deployment-state contract.",
+
+  "proxmox_node": "proxmox-1",
+  "environment": "develop",
+
+  "nodes": {
+    "proxmox-1": { "role": "node-1", "hardware": "amd-desktop" }
+  },
+
+  "pools": {
+    "nonprod": { "comment": "Develop-environment workloads (isolated from production)" }
+  },
+
+  "datastores": {},
+  "node_storage": {},
+  "host_services": {},
+
+  "_containers_comment": "Representative develop guests on the nonprod VLAN. VMIDs end in `1` (env=develop) to stay distinct from their prod siblings on the shared cluster. Add only what you are actively testing.",
+  "containers": {
+    "dev-app": {
+      "vm_id": 900001,
+      "vlan": "nonprod",
+      "hostname": "dev-app",
+      "description": "Example develop app container — replace with the guest under test",
+      "cpu_cores": 1,
+      "memory_dedicated": 512,
+      "tags": ["terraform", "container", "develop"],
+      "pool_id": "nonprod",
+      "root_disk": { "size": 8 }
+    },
+    "dev-db": {
+      "vm_id": 900011,
+      "vlan": "nonprod",
+      "hostname": "dev-db",
+      "description": "Example develop datastore container — replace or delete",
+      "cpu_cores": 1,
+      "memory_dedicated": 1024,
+      "tags": ["terraform", "container", "develop"],
+      "pool_id": "nonprod",
+      "root_disk": { "size": 16 }
+    }
+  }
+}

--- a/deployment.schema.json
+++ b/deployment.schema.json
@@ -58,7 +58,8 @@
     },
     "environment": {
       "type": "string",
-      "minLength": 1
+      "description": "Selects which environment this input drives. Terragrunt derives the tfstate key, the AWS input-mirror path, and the published-inventory key from it; `homelab` pins to production's exact current literals, `develop` nests under its own prefixes. An unknown value fails loud before any plan.",
+      "enum": ["homelab", "develop"]
     }
   },
   "definitions": {

--- a/deployment.schema.json
+++ b/deployment.schema.json
@@ -7,7 +7,8 @@
     "containers",
     "nodes",
     "pools",
-    "proxmox_node"
+    "proxmox_node",
+    "environment"
   ],
   "additionalProperties": true,
   "properties": {

--- a/inventory_publish.tf
+++ b/inventory_publish.tf
@@ -113,8 +113,13 @@ data "aws_caller_identity" "current" {}
 # only when this resource is in scope — a `-target` apply that excludes it does
 # not republish a partial inventory.
 resource "aws_s3_object" "ansible_inventory" {
-  bucket       = "terraform-proxmox-state-useast2-${data.aws_caller_identity.current.account_id}"
-  key          = "terraform-proxmox/inventory/ansible_inventory.json"
+  bucket = "terraform-proxmox-state-useast2-${data.aws_caller_identity.current.account_id}"
+  # Env-scoped so a develop apply never overwrites the prod inventory that Ansible reads.
+  # Production ("homelab") keeps the exact current literal; every other env nests under its
+  # own prefix — symmetric with the state key in terragrunt.hcl (which passes `environment`
+  # in as var.environment). The terragrunt env allowlist already fails loud before Terraform
+  # sees a bad value, so no separate guard is needed here.
+  key          = var.environment == "homelab" ? "terraform-proxmox/inventory/ansible_inventory.json" : "terraform-proxmox/inventory/${var.environment}/ansible_inventory.json"
   content      = jsonencode(local.ansible_inventory)
   content_type = "application/json"
 

--- a/scripts/mirror-deployment-json.sh
+++ b/scripts/mirror-deployment-json.sh
@@ -29,7 +29,14 @@ fi
 SRC_BUCKET="${S3_INVENTORY_BUCKET:-iac-inventory}"
 SRC_KEY="${S3_INVENTORY_KEY:-deployment.json}"
 SRC_REGION="${S3_INVENTORY_REGION:-us-east-1}"
-MIRROR_KEY="terraform-proxmox/input/deployment.json"
+# Mirror path tracks the selected input, matching terragrunt.hcl's fetch fallback: ONLY the
+# develop object nests under input/develop/; every other key (prod default or a staging
+# candidate) keeps the current prod literal.
+if [[ "$SRC_KEY" == "deployment.develop.json" ]]; then
+  MIRROR_KEY="terraform-proxmox/input/develop/deployment.json"
+else
+  MIRROR_KEY="terraform-proxmox/input/deployment.json"
+fi
 
 for var in S3_ENDPOINT S3_ACCESS_KEY S3_SECRET_KEY; do
   if [[ -z "${!var:-}" ]]; then

--- a/scripts/sync-inventory.sh
+++ b/scripts/sync-inventory.sh
@@ -17,6 +17,20 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 cd "$REPO_ROOT"
 
+# Environment scoping: a develop apply must never overwrite the prod artifacts that the
+# Ansible consumers read. Derive the env from the selected input (S3_INVENTORY_KEY), the
+# same signal as the mirror path — ONLY the develop object nests its data-repo mirror under
+# a develop/ prefix and its own sync branch, and skips warming the prod offline-fallback
+# cache entirely; every other key (prod default or a staging candidate) keeps the literals.
+SRC_KEY="${S3_INVENTORY_KEY:-deployment.json}"
+if [[ "$SRC_KEY" == "deployment.develop.json" ]]; then
+  ENV_DEST_PREFIX="develop/"
+  SYNC_BRANCH_SUFFIX="-develop"
+else
+  ENV_DEST_PREFIX=""
+  SYNC_BRANCH_SUFFIX=""
+fi
+
 GIT_HOME="${GIT_HOME:?GIT_HOME must be set}"
 # The contract schema. Defaults to the interim schema; Phase 2 points this at the
 # homelab-schemas repo via TOFU_INVENTORY_SCHEMA.
@@ -47,9 +61,9 @@ nix run nixpkgs#check-jsonschema -- --schemafile "$SCHEMA" "$tmp"
 #     the commit lands on a sync branch in a throwaway worktree (the clone's
 #     checked-out branch is never touched) and a PR is opened with gh, which
 #     infers everything it needs from the clone's origin.
-dest="tofu/terraform-proxmox/ansible_inventory.json"
+dest="tofu/terraform-proxmox/${ENV_DEST_PREFIX}ansible_inventory.json"
 if [[ -n "$DATA_REPO_DIR" ]]; then
-  sync_branch="chore/inventory-sync"
+  sync_branch="chore/inventory-sync${SYNC_BRANCH_SUFFIX}"
   sync_wt="$(mktemp -d)"
   git -C "$DATA_REPO_DIR" fetch -q origin
   git -C "$DATA_REPO_DIR" worktree add -q --force -B "$sync_branch" "$sync_wt" origin/main
@@ -74,7 +88,12 @@ fi
 
 # Cache-warming: the gitignored copy each consumer's resolver uses as its
 # offline fallback (resolution priority 3, after TOFU_INVENTORY_PATH and the
-# S3 artifact).
+# S3 artifact). This is the PROD fallback — a develop apply must not overwrite it, so
+# skip warming entirely for any non-prod environment (develop consumers pin explicitly).
+if [[ -n "$ENV_DEST_PREFIX" ]]; then
+  echo "sync-inventory: develop env — skipped prod offline-cache warming" >&2
+  exit 0
+fi
 for repo in ansible-proxmox ansible-proxmox-apps ansible-splunk; do
   for root in "${GIT_HOME_PUBLIC:-}" "$GIT_HOME"; do
     if [[ -n "$root" && -d "$root/$repo/main/inventory" ]]; then

--- a/terragrunt.hcl
+++ b/terragrunt.hcl
@@ -29,7 +29,13 @@ locals {
   #            fail (or return empty) does the command exit non-zero and run_cmd
   #            raise — never a silent {} that would plan a full destroy.
   s3_mirror_bucket = "terraform-proxmox-state-useast2-${get_aws_account_id()}"
-  s3_mirror_key    = "terraform-proxmox/input/deployment.json"
+  # The AWS mirror path tracks the EXPLICITLY-selected input (S3_INVENTORY_KEY), not the
+  # object's `environment` field: the fallback runs mid-fetch, before the object (and its
+  # environment) can be read, so deriving from the decoded env would be a dependency cycle.
+  # ONLY the develop object nests under input/develop/; every other key (prod default, or a
+  # staging candidate) keeps the current prod literal so its mirror never moves.
+  # ponytail: two-env branch; generalize to a stem-map when a third input appears.
+  s3_mirror_key = local.s3_inventory_key == "deployment.develop.json" ? "terraform-proxmox/input/develop/deployment.json" : "terraform-proxmox/input/deployment.json"
   deployment_json = (
     get_env("DEPLOYMENT_JSON_PATH", "") != ""
     ? file(get_env("DEPLOYMENT_JSON_PATH"))
@@ -58,6 +64,33 @@ locals {
     )
   )
   deployment_config = jsondecode(trimspace(local.deployment_json))
+
+  # Environment selector: the fetched input declares its own identity in `environment`,
+  # and the state key derives from THAT field (the authority that travels with the data),
+  # so staging a prod candidate under a temp key still targets prod state.
+  deployment_env_raw = local.deployment_config.environment
+
+  # Safety cross-check (the load-bearing invariant): the explicitly-selected input
+  # (S3_INVENTORY_KEY) and the object's declared `environment` MUST agree, or a mislabeled
+  # object could point develop guests at PRODUCTION state. `deployment.develop.json` must
+  # carry `environment: develop`; any other key (prod default or a staging candidate) must
+  # carry `environment: homelab`. This one-key map — keyed by the filename's EXPECTED env,
+  # indexed by the object's ACTUAL env — raises (no try(), same fail-loud contract as the
+  # fetch) on ANY mismatch, which also enforces the {homelab,develop} allowlist.
+  input_expected_env = local.s3_inventory_key == "deployment.develop.json" ? "develop" : "homelab"
+  deployment_env = {
+    (local.input_expected_env) = local.deployment_env_raw
+  }[local.deployment_env_raw]
+
+  # Production ("homelab") pins the state key to today's EXACT literal so a prod plan never
+  # migrates state; develop nests under its own prefix (separate key => separate S3/DynamoDB
+  # lock, so envs never collide). The published inventory key derives symmetrically from
+  # var.environment in inventory_publish.tf.
+  # ponytail: two-env map; add the env + its state prefix here when a third one appears.
+  s3_state_key = {
+    homelab = "terraform-proxmox/terraform.tfstate"
+    develop = "terraform-proxmox/develop/terraform.tfstate"
+  }[local.deployment_env]
 
   # Layer 2: Network topology + SSH paths (committed, SOPS-encrypted — edit with `sops terraform.sops.json`).
   # Values: domain, vm_ssh_public_key_path, vm_ssh_private_key_path, proxmox_ssh_username.
@@ -218,7 +251,7 @@ remote_state {
   }
   config = {
     bucket         = "terraform-proxmox-state-useast2-${get_aws_account_id()}"
-    key            = "terraform-proxmox/terraform.tfstate"
+    key            = local.s3_state_key
     region         = "us-east-2"
     encrypt        = true
     use_lockfile   = true


### PR DESCRIPTION
## Why

git-flow-next makes `develop` the default integration branch, but this repo had a **single** `deployment.json` input and a **single** fixed tfstate key — so a `develop` branch had nowhere to plan or apply infrastructure changes without contending with `main`/production over one state.

## What

A second, independently-appliable environment, selected **explicitly** via `S3_INVENTORY_KEY` (no git-branch inference). The fetched object's `environment` field derives three keys:

| Key | `homelab` (prod, UNCHANGED) | `develop` |
| --- | --- | --- |
| tfstate | `terraform-proxmox/terraform.tfstate` | `terraform-proxmox/develop/terraform.tfstate` |
| input mirror | `terraform-proxmox/input/deployment.json` | `terraform-proxmox/input/develop/deployment.json` |
| published inventory | `terraform-proxmox/inventory/ansible_inventory.json` | `terraform-proxmox/inventory/develop/ansible_inventory.json` |

Production paths are pinned to today's exact literals, so adding develop changes nothing a production plan touches (no state migration). A **fail-loud cross-check** requires the selected input filename and the object's declared `environment` to agree, so a mislabeled object can never route develop guests at production state. Scripts and the published-inventory key are scoped symmetrically so a develop apply never clobbers the prod artifacts Ansible reads. Separate state keys give separate locks; the global flow lease still serializes applies across both envs on the one cluster.

Also: `deployment.develop.json.example` (minimal, `nonprod` VLAN, env-digit VMIDs), a schema enum, and the two-environment model in `AGENTS.md` + the internal rule.

## Verification

- `tofu fmt`, `tofu validate`, `tofu test` (116/116) pass; both example files validate against the schema.
- Functional check via `terragrunt render` (offline, no cluster): prod input → `terraform-proxmox/terraform.tfstate` (**unchanged**); develop input → `.../develop/terraform.tfstate`; a develop-selected but homelab-labelled object **fails loud** ("Invalid index" at the cross-check).

### Manual pre-cutover gate (needs live creds — not run in CI)

Before the first real apply: with the **default** env, run `terragrunt init` + `plan` and confirm **0 changes** and **no state-migration prompt** (rendered `backend.tf` key must be `terraform-proxmox/terraform.tfstate`). Authoring the live `deployment.develop.json` object and confirming OIDC/IAM covers `terraform-proxmox/develop/*` are follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)