### PR TITLE
feat(hermes): inbound webhook port, firewall SG, and Traefik ingress

### DIFF
--- a/constants.tf
+++ b/constants.tf
@@ -61,6 +61,11 @@ locals {
       agentgateway_proxy   = 8080
       agentgateway_admin   = 15000
       agentgateway_metrics = 15020
+      # hermes_webhook — the Hermes agent's inbound webhook receiver
+      # (`hermes gateway` platform, routes /webhooks/<name>, HMAC-signed).
+      # Traefik-fronted as https://hermes.<sub>/webhooks/<name>; gives the one
+      # non-A2A agent an event-driven trigger channel on the agent plane.
+      hermes_webhook = 8644
       # AI orchestration stack web UIs (Traefik-fronted) — n8n, Dify, LangFlow,
       # LangGraph, and Langfuse (LLM trace/cost/eval). ingress.tf references these.
       n8n_web      = 5678

--- a/ingress.tf
+++ b/ingress.tf
@@ -49,7 +49,11 @@ locals {
     # the API host also lets browser Studio point its ?baseUrl at it.
     langgraph        = { backend = "langgraph", port = local.pipeline_constants.service_ports.langgraph_api }
     "langgraph-chat" = { backend = "langgraph", port = local.pipeline_constants.service_ports.agent_chat_ui_web }
-    smokeping        = { backend = "smokeping", port = local.pipeline_constants.service_ports.smokeping_web }
-    "haproxy-stats"  = { backend = "haproxy", port = local.pipeline_constants.service_ports.haproxy_stats }
+    # Hermes agent inbound webhook front door: https://hermes.<domain>/webhooks/<name>
+    # -> hermes-agent container : hermes_webhook (HMAC-signed, event-driven trigger
+    # for the one non-A2A agent). Guest firewall opens the port from internal.
+    hermes          = { backend = "hermes-agent", port = local.pipeline_constants.service_ports.hermes_webhook }
+    smokeping       = { backend = "smokeping", port = local.pipeline_constants.service_ports.smokeping_web }
+    "haproxy-stats" = { backend = "haproxy", port = local.pipeline_constants.service_ports.haproxy_stats }
   }
 }

--- a/modules/firewall/hermes_agent_rules.tf
+++ b/modules/firewall/hermes_agent_rules.tf
@@ -13,10 +13,39 @@
 #   - outbound_https   : TCP 443 to anywhere, for the agent's web/search/browser
 #                        tools (Agy review: a 443/53/123-only egress is too tight
 #                        for arbitrary tool-calling).
+#   - hermes_webhook   : inbound webhook receiver (Traefik-fronted hermes.<domain>),
+#                        from internal only — event-driven agent trigger.
 #
 # Hardening follow-up (not this PR): route egress through an audited Squid
 # forward-proxy and replace outbound_internal with a microsegmented allowlist so
 # the agent cannot reach arbitrary internal hosts. Tracked in the deployment plan.
+
+# Inbound webhook ACCEPT for the `hermes gateway` webhook receiver
+# (/webhooks/<name>, HMAC-signed) so other agents/systems can trigger the agent.
+# Scoped to internal so only in-cluster callers reach it; port DRY from
+# pipeline_constants (svc_ports = var.pipeline_constants.service_ports).
+locals {
+  hermes_webhook_services_rules = [
+    { proto = "tcp", dport = tostring(local.svc_ports.hermes_webhook), source = local.internal_src, comment = "Hermes webhook receiver (TCP ${local.svc_ports.hermes_webhook}) from internal" },
+  ]
+}
+
+resource "proxmox_virtual_environment_cluster_firewall_security_group" "hermes_webhook_services" {
+  name    = "hermes-webhook-svc"
+  comment = "Hermes agent inbound webhook receiver (${local.svc_ports.hermes_webhook}) from internal networks — event-driven agent trigger, Traefik-fronted"
+
+  dynamic "rule" {
+    for_each = local.hermes_webhook_services_rules
+    content {
+      type    = "in"
+      action  = "ACCEPT"
+      proto   = rule.value.proto
+      dport   = rule.value.dport
+      source  = rule.value.source
+      comment = rule.value.comment
+    }
+  }
+}
 
 resource "proxmox_virtual_environment_firewall_options" "hermes_agent_container" {
   for_each = var.hermes_agent_container_ids
@@ -58,6 +87,11 @@ resource "proxmox_virtual_environment_firewall_rules" "hermes_agent_container" {
   rule {
     security_group = proxmox_virtual_environment_cluster_firewall_security_group.outbound_https.name
     comment        = "Outbound HTTPS (TCP 443) for agent web/search/browser tools"
+  }
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.hermes_webhook_services.name
+    comment        = "Inbound webhook receiver (Traefik-fronted) from internal"
   }
 
   depends_on = [proxmox_virtual_environment_firewall_options.hermes_agent_container]

--- a/modules/firewall/tests/rule_generation.tftest.hcl
+++ b/modules/firewall/tests/rule_generation.tftest.hcl
@@ -52,6 +52,8 @@ variables {
       agentgateway_proxy   = 8080
       agentgateway_admin   = 15000
       agentgateway_metrics = 15020
+      # Hermes inbound webhook receiver (referenced by hermes_webhook_services_rules)
+      hermes_webhook = 8644
       # AI orchestration + observability (referenced by ai_orchestration rules)
       n8n_web           = 5678
       dify_web          = 80


### PR DESCRIPTION
## What

Give the Hermes agent an event-driven trigger channel. It doesn't speak A2A,
so its `hermes gateway` webhook receiver (routes `/webhooks/<name>`, HMAC-signed)
is fronted at the Traefik ingress front door.

- **constants.tf**: add `hermes_webhook` port to `pipeline_constants.service_ports`.
- **modules/firewall/hermes_agent_rules.tf**: inbound-ACCEPT security group for
  the webhook receiver, sourced from internal networks only, referenced from the
  agent container's firewall rules.
- **ingress.tf**: `hermes` alias → hermes-agent container : `hermes_webhook`, so
  `https://hermes.<domain>/webhooks/<name>` reaches the receiver.

Port is DRY from `pipeline_constants`; the default-deny guest firewall opens the
receiver to internal callers only.

## Validation

- `tofu fmt -check` clean; `tofu validate` passes.
- Applied: **1 added, 3 changed, 0 destroyed** (already live).
- Inventory republished with the new `hermes_webhook` constant + `hermes` ingress
  entry; the downstream `hermes_agent` role consumes it (companion apps PR).

Part of the A2A-fabric workstream (LangGraph A2A route already merged; this is
the non-A2A agent's inbound trigger).

🤖 Generated with [Claude Code](https://claude.com/claude-code)