### PR TITLE
feat(hermes): job-submission API port, firewall rule, and Traefik ingress

### DIFF
--- a/constants.tf
+++ b/constants.tf
@@ -66,6 +66,11 @@ locals {
       # Traefik-fronted as https://hermes.<sub>/webhooks/<name>; gives the one
       # non-A2A agent an event-driven trigger channel on the agent plane.
       hermes_webhook = 8644
+      # hermes_api — the Hermes agent's inbound job-submission API (`hermes
+      # gateway` api_server platform: POST /v1/runs, /api/jobs cron CRUD,
+      # bearer-authenticated). Traefik-fronted as https://hermes-api.<sub>;
+      # the sanctioned non-exec path to submit work to the agent.
+      hermes_api = 8642
       # AI orchestration stack web UIs (Traefik-fronted) — n8n, Dify, LangFlow,
       # LangGraph, and Langfuse (LLM trace/cost/eval). ingress.tf references these.
       n8n_web      = 5678

--- a/ingress.tf
+++ b/ingress.tf
@@ -52,7 +52,11 @@ locals {
     # Hermes agent inbound webhook front door: https://hermes.<domain>/webhooks/<name>
     # -> hermes-agent container : hermes_webhook (HMAC-signed, event-driven trigger
     # for the one non-A2A agent). Guest firewall opens the port from internal.
-    hermes          = { backend = "hermes-agent", port = local.pipeline_constants.service_ports.hermes_webhook }
+    hermes = { backend = "hermes-agent", port = local.pipeline_constants.service_ports.hermes_webhook }
+    # Hermes agent inbound job-submission API: https://hermes-api.<domain>/v1/runs
+    # -> hermes-agent container : hermes_api (`hermes gateway` api_server platform,
+    # bearer-authenticated). The sanctioned non-exec job path; internal-only firewall.
+    "hermes-api"    = { backend = "hermes-agent", port = local.pipeline_constants.service_ports.hermes_api }
     smokeping       = { backend = "smokeping", port = local.pipeline_constants.service_ports.smokeping_web }
     "haproxy-stats" = { backend = "haproxy", port = local.pipeline_constants.service_ports.haproxy_stats }
   }

--- a/modules/firewall/hermes_agent_rules.tf
+++ b/modules/firewall/hermes_agent_rules.tf
@@ -15,6 +15,9 @@
 #                        for arbitrary tool-calling).
 #   - hermes_webhook   : inbound webhook receiver (Traefik-fronted hermes.<domain>),
 #                        from internal only — event-driven agent trigger.
+#   - hermes_api       : inbound job-submission API (Traefik-fronted
+#                        hermes-api.<domain>), from internal only — bearer-authed
+#                        `api_server` platform (POST /v1/runs, /api/jobs).
 #
 # Hardening follow-up (not this PR): route egress through an audited Squid
 # forward-proxy and replace outbound_internal with a microsegmented allowlist so
@@ -27,12 +30,13 @@
 locals {
   hermes_webhook_services_rules = [
     { proto = "tcp", dport = tostring(local.svc_ports.hermes_webhook), source = local.internal_src, comment = "Hermes webhook receiver (TCP ${local.svc_ports.hermes_webhook}) from internal" },
+    { proto = "tcp", dport = tostring(local.svc_ports.hermes_api), source = local.internal_src, comment = "Hermes job-submission API (TCP ${local.svc_ports.hermes_api}) from internal" },
   ]
 }
 
 resource "proxmox_virtual_environment_cluster_firewall_security_group" "hermes_webhook_services" {
   name    = "hermes-webhook-svc"
-  comment = "Hermes agent inbound webhook receiver (${local.svc_ports.hermes_webhook}) from internal networks — event-driven agent trigger, Traefik-fronted"
+  comment = "Hermes agent inbound receivers (webhook ${local.svc_ports.hermes_webhook}, job API ${local.svc_ports.hermes_api}) from internal networks — Traefik-fronted"
 
   dynamic "rule" {
     for_each = local.hermes_webhook_services_rules

--- a/modules/firewall/tests/rule_generation.tftest.hcl
+++ b/modules/firewall/tests/rule_generation.tftest.hcl
@@ -52,8 +52,9 @@ variables {
       agentgateway_proxy   = 8080
       agentgateway_admin   = 15000
       agentgateway_metrics = 15020
-      # Hermes inbound webhook receiver (referenced by hermes_webhook_services_rules)
+      # Hermes inbound webhook receiver + job API (referenced by hermes_webhook_services_rules)
       hermes_webhook = 8644
+      hermes_api     = 8642
       # AI orchestration + observability (referenced by ai_orchestration rules)
       n8n_web           = 5678
       dify_web          = 80


### PR DESCRIPTION
Adds the `hermes_api` service-port constant, an internal-only firewall ACCEPT on the hermes-agent guest, and a Traefik ingress row (`hermes-api.<sub>`) fronting the Hermes gateway's bearer-authenticated `api_server` platform — the sanctioned non-exec path to submit jobs to the agent (`POST /v1/runs`, `/api/jobs` cron CRUD). One concern: the network/ingress surface only; the role change that consumes `service_ports.hermes_api` is the companion ansible-proxmox-apps PR.

Verification: `terragrunt validate` passes; `tofu fmt` clean. Apply after merge publishes the inventory so the role change can converge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VuJXrGxy5PS1HwpUKBu8LY