### PR TITLE
chore: remove shellcheck disable directives from packer scripts

### DIFF
--- a/packer/scripts/install-splunk.sh
+++ b/packer/scripts/install-splunk.sh
@@ -15,7 +15,6 @@ sudo apt-get install -y wget
 TMPDIR=${TMPDIR:-/tmp}
 cd "$TMPDIR"
 
-# shellcheck disable=SC2154
 wget -O "splunk-${SPLUNK_VERSION}-${SPLUNK_BUILD}-linux-${SPLUNK_ARCHITECTURE}.deb" \
   "https://download.splunk.com/products/splunk/releases/${SPLUNK_VERSION}/linux/splunk-${SPLUNK_VERSION}-${SPLUNK_BUILD}-linux-${SPLUNK_ARCHITECTURE}.deb"
 
@@ -26,7 +25,6 @@ echo "${SPLUNK_DOWNLOAD_SHA512}  splunk-${SPLUNK_VERSION}-${SPLUNK_BUILD}-linux-
 sudo dpkg -i "splunk-${SPLUNK_VERSION}-${SPLUNK_BUILD}-linux-${SPLUNK_ARCHITECTURE}.deb"
 
 # Enable Splunk at boot
-# shellcheck disable=SC2154
 sudo "${SPLUNK_HOME}/bin/splunk" enable boot-start \
   -user "${SPLUNK_USER}" \
   --accept-license \

--- a/packer/scripts/validate-ownership.sh
+++ b/packer/scripts/validate-ownership.sh
@@ -7,7 +7,6 @@ set -euo pipefail
 echo 'Validating Splunk file ownership...'
 
 # Count files not owned by splunk:splunk
-# shellcheck disable=SC2154
 NON_SPLUNK_FILES=$(sudo find "${SPLUNK_HOME}" \
   \( ! -user "${SPLUNK_USER}" -o ! -group "${SPLUNK_GROUP}" \) \
   2>/dev/null | wc -l)


### PR DESCRIPTION
Per maintainer decision, shellcheck is no longer used anywhere.

Drop the now-inert `# shellcheck disable=SC2154` comments from the Splunk
packer provisioning scripts (`install-splunk.sh`, `validate-ownership.sh`).
No shellcheck runner exists in this repo, so these were dead suppression
comments only.

Generated gh-aw `*.lock.yml` workflow files still contain `SC1003` directives;
those are compiler output and are not hand-edited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)