### PR TITLE
revert: restore shellcheck directives

### DIFF
--- a/packer/scripts/install-splunk.sh
+++ b/packer/scripts/install-splunk.sh
@@ -15,6 +15,7 @@ sudo apt-get install -y wget
 TMPDIR=${TMPDIR:-/tmp}
 cd "$TMPDIR"
 
+# shellcheck disable=SC2154
 wget -O "splunk-${SPLUNK_VERSION}-${SPLUNK_BUILD}-linux-${SPLUNK_ARCHITECTURE}.deb" \
   "https://download.splunk.com/products/splunk/releases/${SPLUNK_VERSION}/linux/splunk-${SPLUNK_VERSION}-${SPLUNK_BUILD}-linux-${SPLUNK_ARCHITECTURE}.deb"
 
@@ -25,6 +26,7 @@ echo "${SPLUNK_DOWNLOAD_SHA512}  splunk-${SPLUNK_VERSION}-${SPLUNK_BUILD}-linux-
 sudo dpkg -i "splunk-${SPLUNK_VERSION}-${SPLUNK_BUILD}-linux-${SPLUNK_ARCHITECTURE}.deb"
 
 # Enable Splunk at boot
+# shellcheck disable=SC2154
 sudo "${SPLUNK_HOME}/bin/splunk" enable boot-start \
   -user "${SPLUNK_USER}" \
   --accept-license \

--- a/packer/scripts/validate-ownership.sh
+++ b/packer/scripts/validate-ownership.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 echo 'Validating Splunk file ownership...'
 
 # Count files not owned by splunk:splunk
+# shellcheck disable=SC2154
 NON_SPLUNK_FILES=$(sudo find "${SPLUNK_HOME}" \
   \( ! -user "${SPLUNK_USER}" -o ! -group "${SPLUNK_GROUP}" \) \
   2>/dev/null | wc -l)


### PR DESCRIPTION
Restores the `# shellcheck disable=SC2154` directives in `packer/scripts/install-splunk.sh` and `packer/scripts/validate-ownership.sh`.

These directives were stripped in #632 under the mistaken belief that shellcheck was a spell-checker. It is a valuable shell linter, and the ban has been reversed. This reverts the removal so the directives are back in place.

Reverts commit 0246fe5 (PR #632).