### PR TITLE
feat(firewall): allow OpenBao HTTPS egress

### DIFF
--- a/modules/firewall/openbao_rules.tf
+++ b/modules/firewall/openbao_rules.tf
@@ -40,6 +40,11 @@ resource "proxmox_virtual_environment_firewall_rules" "openbao_container" {
     comment        = "Outbound to internal only"
   }
 
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.outbound_https.name
+    comment        = "Outbound HTTPS for secrets engines"
+  }
+
   # --- zero-trust (staged disabled): narrows the "from internal" ACCEPT
   # above to the specific source VLANs the service-flow matrix permits.
   # ponytail: disabled-only for now — enable per-rule once observed against

--- a/modules/firewall/security_groups.tf
+++ b/modules/firewall/security_groups.tf
@@ -167,7 +167,7 @@ resource "proxmox_virtual_environment_cluster_firewall_security_group" "outbound
 
 resource "proxmox_virtual_environment_cluster_firewall_security_group" "outbound_https" {
   name    = "outbound-https"
-  comment = "Allow outbound HTTPS (TCP 443) to any destination — Cribl license telemetry (see locals.outbound_https_rules)"
+  comment = "Allow outbound HTTPS (TCP 443) to any destination for explicitly attached workloads (see locals.outbound_https_rules)"
 
   dynamic "rule" {
     for_each = local.outbound_https_rules

--- a/modules/firewall/tests/rule_generation.tftest.hcl
+++ b/modules/firewall/tests/rule_generation.tftest.hcl
@@ -534,8 +534,8 @@ run "outbound_https_is_tcp_443_only" {
     internal_networks = ["192.168.0.0/16"]
   }
 
-  # License-telemetry egress stays the single TCP/443 rule — any growth here
-  # widens internet egress for cribl containers and needs explicit review.
+  # Explicitly attached workload egress stays the single TCP/443 rule — any
+  # growth here widens internet egress and needs explicit review.
   assert {
     condition     = length(local.outbound_https_rules) == 1
     error_message = "outbound_https_rules must contain exactly one rule, got ${length(local.outbound_https_rules)}"
@@ -544,6 +544,22 @@ run "outbound_https_is_tcp_443_only" {
   assert {
     condition     = local.outbound_https_rules[0].proto == "tcp" && local.outbound_https_rules[0].dport == "443"
     error_message = "outbound_https_rules[0] must be TCP 443, got proto='${local.outbound_https_rules[0].proto}' dport='${local.outbound_https_rules[0].dport}'"
+  }
+}
+
+run "openbao_receives_outbound_https" {
+  command = plan
+
+  variables {
+    openbao_container_ids = { openbao = 130 }
+  }
+
+  assert {
+    condition = contains(
+      [for rule in proxmox_virtual_environment_firewall_rules.openbao_container["openbao"].rule : rule.security_group],
+      proxmox_virtual_environment_cluster_firewall_security_group.outbound_https.name,
+    )
+    error_message = "OpenBao containers must attach the outbound-https security group"
   }
 }
 


### PR DESCRIPTION
## Summary
- attach the existing outbound HTTPS security group to OpenBao voters
- retain the existing internal-only egress group
- prove TCP/443 egress is present in firewall module tests

## Validation
- tofu fmt -check -recursive
- tofu validate
- tofu test: 29 passed
- changed-file pre-commit suite

Refs: dryvist/ansible-proxmox-apps (companion service-engine PR)
Refs: dryvist/docs (companion architecture PR)

Refs: dryvist/ansible-proxmox-apps#882
Refs: dryvist/docs#155