### PR TITLE
docs(copilot): sync copilot-instructions with the Terrakube/OpenBao model

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -3,8 +3,9 @@
 ## Repository Purpose
 
 Infrastructure as code for provisioning VMs and containers on Proxmox VE using
-OpenTofu + Terragrunt. Downstream repos (ansible-proxmox-apps, ansible-splunk) consume
-the outputs.
+OpenTofu. Terrakube owns execution, state, and workspace locking. Downstream
+repos (ansible-proxmox, ansible-proxmox-apps, ansible-splunk) consume the
+published Ansible inventory.
 
 ## CRITICAL: OpenTofu, Not Terraform
 
@@ -13,35 +14,39 @@ The binary is `tofu`. All HCL is OpenTofu-compatible.
 
 ## Running Commands
 
-All commands must be wrapped with aws-vault and Doppler:
+Static checks run locally without credentials:
 
 ```bash
-aws-vault exec tf-proxmox -- doppler run -- terragrunt <COMMAND>
+tofu init -backend=false
+tofu validate
+tofu test
 ```
 
-For plan/apply:
-
-```bash
-aws-vault exec tf-proxmox -- doppler run -- terragrunt plan
-aws-vault exec tf-proxmox -- doppler run -- terragrunt apply
-```
+Plans, applies, imports, and state operations run only in the private
+Terrakube workspace — never locally. There is no local credential wrapper to
+run: Terrakube exchanges its workload identity for a short-lived OpenBao
+token, and providers read Proxmox, SSH, Route53, and RustFS credentials
+through native ephemeral resources.
 
 ## Technology Stack
 
 - **OpenTofu** (not Terraform) — IaC engine
-- **Terragrunt** — wrapper for DRY config and remote state
-- **Doppler** — secrets management (runtime env vars)
-- **aws-vault** — AWS credentials
-- **SOPS/age** — encrypted secrets in repo (`terraform.sops.json`)
+- **Terrakube** — remote execution, state, workspace locking, and run audit
+- **OpenBao** — native workload identity and ephemeral provider credentials
+  (including AWS STS for Route53, via OpenBao's AWS secrets engine —
+  replacing the retired static aws-vault base key)
+- **RustFS** — private desired-state (`deployment.json`) and published
+  Ansible inventory objects
 
 ## HCL Conventions
 
 - Module inputs in `variables.tf`, outputs in `outputs.tf`, providers in `providers.tf`
-- Use `deployment.json` for environment-specific non-secret config — private, not
-  committed, fetched from the on-prem `s3` store (see
+- Use `deployment.json` for environment-specific non-secret config — private,
+  not committed, fetched from homelab RustFS at plan/apply (see
   `agentsmd/rules/infra/deployment-json-source-of-truth.md`)
-- Use `terraform.sops.json` for encrypted secrets (edit with `sops terraform.sops.json`)
-- Terragrunt config in `terragrunt.hcl` at each module root
+- Credentials live in OpenBao KV, delivered through native ephemeral
+  resources — never copied into Terrakube workspace variables or
+  `deployment.json`
 
 ## CI
 


### PR DESCRIPTION
## Summary

`.github/copilot-instructions.md` was missed in the earlier Terrakube/OpenBao migration sweep (AGENTS.md, README.md, and `docs/ARCHITECTURE.md` / `docs/SECRETS_ROADMAP.md` already describe the current model). It still told Copilot to run `aws-vault exec tf-proxmox -- doppler run -- terragrunt <COMMAND>` and referenced `terragrunt.hcl` / `terraform.sops.json` — none of which exist in this repo anymore (verified: zero files matching `sops` or `terragrunt.hcl` in the tree).

- Replaced the Terragrunt + aws-vault + SOPS command flow with the current static-checks-only local flow (`tofu init -backend=false && tofu validate && tofu test`); credentialed operations run only in the private Terrakube workspace.
- Updated the technology stack list to Terrakube + OpenBao (including a note that AWS STS for Route53 goes through OpenBao's AWS secrets engine, replacing the retired static aws-vault base key — per `docs/ARCHITECTURE.md`).
- Updated the HCL conventions section: `deployment.json` now comes from RustFS, not an "on-prem s3 store"; removed the dead `terraform.sops.json` / `terragrunt.hcl` references.

## Verification

- `pre-commit run --files .github/copilot-instructions.md` — passes (trailing whitespace, EOF, large-file, hardcoded-secret checks).