### PR TITLE
docs(readme): add apply/redeploy flow to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,21 @@ read Proxmox, SSH, Route53, and RustFS credentials with native ephemeral
 resources; no credential is stored in repository configuration or Terrakube
 workspace variables.
 
+## Installation
+
+This repo is consumed by CI and Terrakube, not installed. For local static
+checks, the Nix dev shell provides `tofu` via direnv:
+
+```bash
+direnv allow
+```
+
+## Usage
+
+Static checks run locally without credentials; credentialed plans and
+applies run remotely — see [How to apply / redeploy](#how-to-apply--redeploy)
+below.
+
 ## Configuration
 
 | Source | Contents |
@@ -39,6 +54,21 @@ tofu -chdir=modules/proxmox-stack test
 
 Credentialed plans, applies, imports, and state operations run only in the
 private `tofu-proxmox` Terrakube workspace.
+
+## How to apply / redeploy
+
+Authenticate once per machine, then plan and apply like any other `tofu`
+command — the run executes remotely on a Terrakube executor, so no local
+Proxmox, AWS, or GitHub credential is ever needed:
+
+```bash
+tofu login terrakube-api.<domain>   # one-time per machine
+tofu init
+tofu apply
+```
+
+Full runbook (access model, credential lifecycle, token scoping):
+[docs.jacobpevans.com/infrastructure/applying-via-terrakube](https://docs.jacobpevans.com/infrastructure/applying-via-terrakube).
 
 ## Documentation
 


### PR DESCRIPTION
## Summary

- Adds a short "How to apply / redeploy" section: one-time `tofu login <terrakube-api-host>` per machine, then plain `tofu init && tofu apply` executing remotely on a Terrakube executor — no local Proxmox/AWS/GitHub credential needed. Links to the full runbook on docs.jacobpevans.com (dryvist/docs#163).
- Adds the `Installation` and `Usage` sections required by this repo's `.readme-validator.yaml` (previously missing, unrelated pre-existing gap surfaced by the README validation hook while editing).

Drafted from `iac-platform/docs/bootstrap.md` and `tofu/terrakube/providers.tf`; final command-accuracy verification pending the live Terrakube dynamic-credentials converge (canary re-run).

Only placeholder values used (`<domain>`, `terrakube-api.<domain>`) — no real FQDN, org login, or token appears in the diff.

## Test plan

- [x] `tofu fmt -check -recursive` — no output, passes.
- [x] Local README validator (`.readme-validator.yaml` required sections) passes.
- [ ] CI (`tofu validate`, `tofu test`, docs checks) — pending.

Assisted-by: Claude:claude-sonnet-5
Claude-Session: https://claude.ai/code/session_01FzxS5Ji7fKYSNfnr7HSn1U