### PR TITLE
docs: retarget commit-validation override to OpenTofu + Terrakube

### DIFF
--- a/.claude/overrides/commit-validation.md
+++ b/.claude/overrides/commit-validation.md
@@ -1,50 +1,56 @@
-# Terraform/Terragrunt Validation Guidelines
+# OpenTofu Validation Guidelines
 
 ## Repository Context
 
-This is a Terraform/Terragrunt repository for Proxmox Virtual Environment infrastructure management.
+This is an OpenTofu repository for Proxmox Virtual Environment infrastructure
+management. Plans, applies, and state operations run remotely in a self-hosted
+Terrakube workspace (state in RustFS, locking in Terrakube); Terragrunt and the
+per-project S3/DynamoDB backend are retired. Local checks are static only and
+need no credentials.
 
 ## Validation Priorities
 
 ### High Priority Checks
 
-- **Terraform Syntax**: Ensure `terraform validate` passes
-- **Code Formatting**: Check if `terraform fmt` is needed
-- **Terragrunt Configuration**: Validate terragrunt.hcl if present
-- **Plan Generation**: Verify `terragrunt plan` works without errors
+- **Syntax**: Ensure `tofu validate` passes (`tofu init -backend=false` first).
+- **Code Formatting**: Check if `tofu fmt` is needed.
+- **Tests**: Verify `tofu test` passes.
+- **Plans/applies are remote**: Never gate a commit on a plan/apply — those run
+  in the Terrakube workspace under OIDC, not locally.
 
 ### Security Considerations
 
-- **No Hardcoded Secrets**: Scan for API tokens, passwords, or sensitive data
-- **Variable Usage**: Prefer variables over hardcoded values
-- **State File Safety**: Ensure no state files are being committed
+- **No Hardcoded Secrets**: Scan for API tokens, passwords, or sensitive data.
+  Provider credentials come from OpenBao via ephemeral resources, never state.
+- **Variable Usage**: Prefer variables over hardcoded values.
+- **State File Safety**: Ensure no state files are being committed.
 
 ### Infrastructure-Specific Concerns
 
-- **Resource Naming**: Follow consistent naming conventions
-- **Network Configurations**: Validate network settings make sense
-- **VM Specifications**: Ensure resource allocations are reasonable
-- **Dependencies**: Check for resource dependency issues
+- **Resource Naming**: Follow consistent naming conventions.
+- **Network Configurations**: Validate network settings make sense.
+- **VM Specifications**: Ensure resource allocations are reasonable.
+- **Dependencies**: Check for resource dependency issues.
 
 ## Suggested Validation Flow
 
-1. Run basic terraform validation commands
-2. Check for formatting issues and suggest fixes
-3. Scan for sensitive data exposure
-4. Verify infrastructure changes make logical sense
-5. Suggest testing approach for changes
+1. Run the static checks: `tofu init -backend=false`, `tofu validate`,
+   `tofu fmt -check`, `tofu test`.
+2. Check for formatting issues and suggest fixes.
+3. Scan for sensitive data exposure.
+4. Verify infrastructure changes make logical sense.
+5. Suggest a testing approach for changes.
 
 ## Common Issues to Watch For
 
-- Hardcoded IP addresses that should be variables
-- API endpoints that should reference variables
-- Resource conflicts or naming collisions
-- State backend configuration issues
-- Provider version compatibility
+- Hardcoded IP addresses that should be derived (`cidrhost(...)`) or variables.
+- API endpoints that should reference variables.
+- Resource conflicts or naming collisions.
+- Provider version compatibility.
 
 ## Flexibility Notes
 
-- Use discretion when validation tools aren't available
-- Adapt validation based on the scope of changes
-- Consider the impact level of modifications
-- Balance thoroughness with practicality
+- Use discretion when validation tools aren't available.
+- Adapt validation based on the scope of changes.
+- Consider the impact level of modifications.
+- Balance thoroughness with practicality.


### PR DESCRIPTION
## What

`.claude/overrides/commit-validation.md` still described this as a "Terraform/Terragrunt repository" and instructed agents to validate `terragrunt.hcl` and run `terragrunt plan`. The fleet migrated to OpenTofu applied through **Terrakube** (remote plans/applies, RustFS state, OpenBao ephemeral provider creds); Terragrunt and the per-project S3/DynamoDB backend are retired.

## Change

Retargeted the override to the current static-check flow — `tofu init -backend=false`, `tofu validate`, `tofu fmt`, `tofu test` — and made explicit that plans/applies run remotely in Terrakube and must never gate a commit (matches `AGENTS.md`). No behavior change to the infra itself; this is agent-facing validation guidance.

The other `aws-vault` / `terragrunt` mentions in this repo (TROUBLESHOOTING.md 30-day legacy note, INVENTORY_PUBLISHING.md "retired along with Terragrunt", copilot-instructions "retired static aws-vault base key") are intentionally retained — they correctly frame the old backend as legacy/retired.