### PR TITLE
fix(vault): set skip_child_token on vault providers

### DIFF
--- a/aws-infra/main.tf
+++ b/aws-infra/main.tf
@@ -24,7 +24,9 @@ terraform {
 # Terrakube exchanges its per-run workload identity for VAULT_TOKEN. OpenBao's
 # AWS secrets engine then mints a short-lived STS session. The ephemeral block
 # guarantees that the credentials are not persisted in a plan or state.
-provider "vault" {}
+provider "vault" {
+  skip_child_token = true
+}
 
 ephemeral "vault_aws_access_credentials" "route53" {
   mount  = var.openbao_aws_mount

--- a/main.tf
+++ b/main.tf
@@ -29,7 +29,9 @@ terraform {
 # Terrakube supplies a short-lived OpenBao token through its native workload
 # identity integration. No AppRole secret or long-lived token is stored in the
 # workspace.
-provider "vault" {}
+provider "vault" {
+  skip_child_token = true
+}
 
 ephemeral "vault_kv_secret_v2" "object_storage" {
   mount = var.openbao_kv_mount

--- a/servarr-config/main.tf
+++ b/servarr-config/main.tf
@@ -4,7 +4,9 @@
 # and is handled separately (see README); TRaSH custom-formats/quality come from
 # Configarr.
 
-provider "vault" {}
+provider "vault" {
+  skip_child_token = true
+}
 
 # Terrakube supplies a short-lived OpenBao token from its workload identity.
 # The media credentials exist only for this run and never enter plan or state.


### PR DESCRIPTION
Applies the universal `skip_child_token = true` fix (proven on tofu-github #54) to all three OpenTofu roots so Terrakube dynamic OpenBao credentials work without a child-token mint.

Files: `main.tf`, `aws-infra/main.tf`, `servarr-config/main.tf` — bare `provider "vault" {}` → multiline form with `skip_child_token = true` (fmt-canonical).

Local: `tofu fmt -check` clean, all three roots `tofu validate` Success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FzxS5Ji7fKYSNfnr7HSn1U