### PR TITLE
chore(main): promote develop to main (release)

### DIFF
--- a/.claude/overrides/commit-validation.md
+++ b/.claude/overrides/commit-validation.md
@@ -1,50 +1,56 @@
-# Terraform/Terragrunt Validation Guidelines
+# OpenTofu Validation Guidelines
 
 ## Repository Context
 
-This is a Terraform/Terragrunt repository for Proxmox Virtual Environment infrastructure management.
+This is an OpenTofu repository for Proxmox Virtual Environment infrastructure
+management. Plans, applies, and state operations run remotely in a self-hosted
+Terrakube workspace (state in RustFS, locking in Terrakube); Terragrunt and the
+per-project S3/DynamoDB backend are retired. Local checks are static only and
+need no credentials.
 
 ## Validation Priorities
 
 ### High Priority Checks
 
-- **Terraform Syntax**: Ensure `terraform validate` passes
-- **Code Formatting**: Check if `terraform fmt` is needed
-- **Terragrunt Configuration**: Validate terragrunt.hcl if present
-- **Plan Generation**: Verify `terragrunt plan` works without errors
+- **Syntax**: Ensure `tofu validate` passes (`tofu init -backend=false` first).
+- **Code Formatting**: Check if `tofu fmt` is needed.
+- **Tests**: Verify `tofu test` passes.
+- **Plans/applies are remote**: Never gate a commit on a plan/apply — those run
+  in the Terrakube workspace under OIDC, not locally.
 
 ### Security Considerations
 
-- **No Hardcoded Secrets**: Scan for API tokens, passwords, or sensitive data
-- **Variable Usage**: Prefer variables over hardcoded values
-- **State File Safety**: Ensure no state files are being committed
+- **No Hardcoded Secrets**: Scan for API tokens, passwords, or sensitive data.
+  Provider credentials come from OpenBao via ephemeral resources, never state.
+- **Variable Usage**: Prefer variables over hardcoded values.
+- **State File Safety**: Ensure no state files are being committed.
 
 ### Infrastructure-Specific Concerns
 
-- **Resource Naming**: Follow consistent naming conventions
-- **Network Configurations**: Validate network settings make sense
-- **VM Specifications**: Ensure resource allocations are reasonable
-- **Dependencies**: Check for resource dependency issues
+- **Resource Naming**: Follow consistent naming conventions.
+- **Network Configurations**: Validate network settings make sense.
+- **VM Specifications**: Ensure resource allocations are reasonable.
+- **Dependencies**: Check for resource dependency issues.
 
 ## Suggested Validation Flow
 
-1. Run basic terraform validation commands
-2. Check for formatting issues and suggest fixes
-3. Scan for sensitive data exposure
-4. Verify infrastructure changes make logical sense
-5. Suggest testing approach for changes
+1. Run the static checks: `tofu init -backend=false`, `tofu validate`,
+   `tofu fmt -check`, `tofu test`.
+2. Check for formatting issues and suggest fixes.
+3. Scan for sensitive data exposure.
+4. Verify infrastructure changes make logical sense.
+5. Suggest a testing approach for changes.
 
 ## Common Issues to Watch For
 
-- Hardcoded IP addresses that should be variables
-- API endpoints that should reference variables
-- Resource conflicts or naming collisions
-- State backend configuration issues
-- Provider version compatibility
+- Hardcoded IP addresses that should be derived (`cidrhost(...)`) or variables.
+- API endpoints that should reference variables.
+- Resource conflicts or naming collisions.
+- Provider version compatibility.
 
 ## Flexibility Notes
 
-- Use discretion when validation tools aren't available
-- Adapt validation based on the scope of changes
-- Consider the impact level of modifications
-- Balance thoroughness with practicality
+- Use discretion when validation tools aren't available.
+- Adapt validation based on the scope of changes.
+- Consider the impact level of modifications.
+- Balance thoroughness with practicality.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,21 @@ read Proxmox, SSH, Route53, and RustFS credentials with native ephemeral
 resources; no credential is stored in repository configuration or Terrakube
 workspace variables.
 
+## Installation
+
+This repo is consumed by CI and Terrakube, not installed. For local static
+checks, the Nix dev shell provides `tofu` via direnv:
+
+```bash
+direnv allow
+```
+
+## Usage
+
+Static checks run locally without credentials; credentialed plans and
+applies run remotely — see [How to apply / redeploy](#how-to-apply--redeploy)
+below.
+
 ## Configuration
 
 | Source | Contents |
@@ -39,6 +54,21 @@ tofu -chdir=modules/proxmox-stack test
 
 Credentialed plans, applies, imports, and state operations run only in the
 private `tofu-proxmox` Terrakube workspace.
+
+## How to apply / redeploy
+
+Authenticate once per machine, then plan and apply like any other `tofu`
+command — the run executes remotely on a Terrakube executor, so no local
+Proxmox, AWS, or GitHub credential is ever needed:
+
+```bash
+tofu login terrakube-api.<domain>   # one-time per machine
+tofu init
+tofu apply
+```
+
+Full runbook (access model, credential lifecycle, token scoping):
+[docs.jacobpevans.com/infrastructure/applying-via-terrakube](https://docs.jacobpevans.com/infrastructure/applying-via-terrakube).
 
 ## Documentation
 

--- a/aws-infra/main.tf
+++ b/aws-infra/main.tf
@@ -24,7 +24,9 @@ terraform {
 # Terrakube exchanges its per-run workload identity for VAULT_TOKEN. OpenBao's
 # AWS secrets engine then mints a short-lived STS session. The ephemeral block
 # guarantees that the credentials are not persisted in a plan or state.
-provider "vault" {}
+provider "vault" {
+  skip_child_token = true
+}
 
 ephemeral "vault_aws_access_credentials" "route53" {
   mount  = var.openbao_aws_mount

--- a/main.tf
+++ b/main.tf
@@ -29,7 +29,9 @@ terraform {
 # Terrakube supplies a short-lived OpenBao token through its native workload
 # identity integration. No AppRole secret or long-lived token is stored in the
 # workspace.
-provider "vault" {}
+provider "vault" {
+  skip_child_token = true
+}
 
 ephemeral "vault_kv_secret_v2" "object_storage" {
   mount = var.openbao_kv_mount

--- a/servarr-config/main.tf
+++ b/servarr-config/main.tf
@@ -4,7 +4,9 @@
 # and is handled separately (see README); TRaSH custom-formats/quality come from
 # Configarr.
 
-provider "vault" {}
+provider "vault" {
+  skip_child_token = true
+}
 
 # Terrakube supplies a short-lived OpenBao token from its workload identity.
 # The media credentials exist only for this run and never enter plan or state.


### PR DESCRIPTION
Promote develop to main. Merge-commit per git-flow (never squash into main); release-please tags on merge.

Contents:
- fix(vault): set skip_child_token to true on vault providers (#651)
- docs: apply/redeploy flow + Installation/Usage README sections (#648)
- docs: retarget commit-validation override to OpenTofu + Terrakube (#650)

Code-only promotion; state/apply is separate. Static CI (fmt/validate/test) green on develop.