### PR TITLE
feat(infra): deploy Zammad in HA configuration and define multi-instance naming scheme

### DIFF
--- a/deployment.json.example
+++ b/deployment.json.example
@@ -259,18 +259,36 @@
         { "volume": "local-zfs", "size": "10G", "path": "/var/lib/vikunja" }
       ]
     },
-    "zammad": {
+    "zammad-20": {
       "vm_id": 605020,
       "dhcp": true,
       "reserved_host": 54,
       "vlan": "apps",
-      "hostname": "zammad",
+      "hostname": "zammad-20",
       "description": "Zammad ITSM/ticketing + knowledge base — the incident-management system of record. Native DEB (Rails web/worker/websocket + colocated Elasticsearch for full-text incident search + colocated Redis); nginx/API on zammad_web (8080) fronted by Traefik; state in the shared Postgres; persistent /opt/zammad holds app state + attachments. The ES index is derived/rebuildable and stays on the ephemeral rootfs (rake zammad:searchindex:rebuild).",
       "cpu_cores": 4,
       "memory_dedicated": 8192,
       "tags": ["terraform", "container", "zammad"],
       "pool_id": "infrastructure",
-      "node_name": "proxmox-1",
+      "node_name": "proxmox-2",
+      "unprivileged": true,
+      "root_disk": { "size": 24 },
+      "mount_points": [
+        { "volume": "local-zfs", "size": "40G", "path": "/opt/zammad" }
+      ]
+    },
+    "zammad-30": {
+      "vm_id": 605030,
+      "dhcp": true,
+      "reserved_host": 55,
+      "vlan": "apps",
+      "hostname": "zammad-30",
+      "description": "Zammad ITSM/ticketing + knowledge base (HA Instance 2).",
+      "cpu_cores": 4,
+      "memory_dedicated": 8192,
+      "tags": ["terraform", "container", "zammad"],
+      "pool_id": "infrastructure",
+      "node_name": "proxmox-3",
       "unprivileged": true,
       "root_disk": { "size": 24 },
       "mount_points": [

--- a/docs/INCIDENT_MANAGEMENT.md
+++ b/docs/INCIDENT_MANAGEMENT.md
@@ -1,0 +1,11 @@
+# Incident Management
+
+This repository handles incident management configuration and orchestration. Zammad is our ITSM solution used by AI agents and operators alike.
+
+## Architecture
+- Active-Active High Availability across Proxmox nodes
+- Managed by OpenTofu + Terrakube
+- Proxied via Traefik Ingress with Sticky Sessions
+
+## Integration
+AI agents authenticate securely via OpenBao and interact with the Zammad API for incident resolution, tracking, and orchestration.

--- a/docs/INCIDENT_MANAGEMENT.md
+++ b/docs/INCIDENT_MANAGEMENT.md
@@ -3,9 +3,11 @@
 This repository handles incident management configuration and orchestration. Zammad is our ITSM solution used by AI agents and operators alike.
 
 ## Architecture
+
 - Active-Active High Availability across Proxmox nodes
 - Managed by OpenTofu + Terrakube
 - Proxied via Traefik Ingress with Sticky Sessions
 
 ## Integration
+
 AI agents authenticate securely via OpenBao and interact with the Zammad API for incident resolution, tracking, and orchestration.

--- a/docs/INFRASTRUCTURE_NUMBERING.md
+++ b/docs/INFRASTRUCTURE_NUMBERING.md
@@ -13,9 +13,12 @@ maintenance windows allow — they are **not** the target.
 
 ---
 
-## The VMID positional scheme (current)
+## Hostname & Multi-Instance Naming Law
 
-A VMID is six digits, each position carrying meaning (read coarsest → finest):
+**FUTURE LAW**: For all new multi-instance containers or VMs, the hostname suffix MUST be two digits where the **first digit is the Proxmox node ID**.
+For example, instead of `zammad-1` and `zammad-2`, use `zammad-20` (Node 2, instance 0) and `zammad-30` (Node 3, instance 0).
+
+## The VMID positional scheme (current)
 
 ```text
 [Tier][Sub-tier][Crit][OS][Instance][Env]

--- a/modules/proxmox-stack/ingress.tf
+++ b/modules/proxmox-stack/ingress.tf
@@ -21,7 +21,6 @@ locals {
     phpipam          = { backend = "phpipam", port = local.pipeline_constants.service_ports.phpipam_web }
     nautobot         = { backend = "nautobot", port = local.pipeline_constants.service_ports.nautobot_web } # native IPAM/DCIM UI; Postgres has NO ingress row (in-cluster 5432 only)
     vikunja          = { backend = "vikunja", port = local.pipeline_constants.service_ports.vikunja_web }
-    zammad           = { backend = "zammad", port = local.pipeline_constants.service_ports.zammad_web } # native ITSM/ticketing + KB UI; nginx on 8080
     "object-storage" = { backend = "s3", port = local.pipeline_constants.service_ports.object_storage_console }
     # RustFS S3 API fronted by a valid-TLS hostname. Path-style S3 format.
     s3 = { backend = "s3", port = local.pipeline_constants.service_ports.object_storage_s3 }

--- a/modules/proxmox-stack/locals-ingress-backends.tf
+++ b/modules/proxmox-stack/locals-ingress-backends.tf
@@ -36,6 +36,16 @@ locals {
     if contains(keys(var.containers), k)
   ]
 
+  # Zammad HA backend pool. Every LXC tagged "zammad" is load-balanced
+  # behind a single zammad.<domain> route with sticky sessions.
+  zammad_backend_keys = sort([
+    for k, v in var.containers : k
+    if contains(coalesce(try(v.tags, null), []), "zammad")
+  ])
+  zammad_backends = [
+    for k in local.zammad_backend_keys : local.container_address[k]
+  ]
+
   # Assembled routes: one {name, ip, port} per fronted service whose backend
   # container is actually defined (others are skipped, so a partial deployment
   # never emits a dangling route). The backend address comes from
@@ -134,6 +144,17 @@ locals {
         port              = local.pipeline_constants.service_ports.llm_router_api
         health_check      = true
         health_check_path = "/health/liveliness"
+      }
+    ] : [],
+    # Zammad HA: one zammad.<domain> route load-balancing the application nodes.
+    # sticky keeps a browser UI session pinned to one node.
+    length(local.zammad_backends) > 0 ? [
+      {
+        name         = "zammad"
+        backends     = local.zammad_backends
+        port         = local.pipeline_constants.service_ports.zammad_web
+        sticky       = true
+        health_check = true
       }
     ] : [],
     # IaC automation platform (Terrakube + Semaphore UI) on the iac-platform VM


### PR DESCRIPTION
## Summary
This PR configures Proxmox infrastructure and dynamic ingress backends to deploy Zammad as the central ITSM incident-management system of record for AI agents. It establishes the active-active High Availability (HA) topology and enforces the new multi-instance naming scheme.

## Changes
- **Infrastructure Layout**: Defined `zammad-20` on `proxmox-2` and `zammad-30` on `proxmox-3` in `deployment.json.example` to ensure Zammad is run on different nodes (excluding `proxmox-1`).
- **Naming Scheme**: Created `docs/INCIDENT_MANAGEMENT.md` and updated `docs/INFRASTRUCTURE_NUMBERING.md` defining the new law: multi-instance hostnames must use a suffix containing the Proxmox Node ID followed by the instance ID (e.g. `zammad-20`, `zammad-30`).
- **Load Balancing / Ingress**: Removed static `zammad` backend from `ingress.tf` and replaced it with a dynamic, tag-based backend pool filter in `locals-ingress-backends.tf` with sticky sessions enabled to support HA proxying.

## Test Plan
- Ran `tofu fmt` and `tofu validate` locally (configuration is valid).
- Verified pre-commit checks pass (locally and on CI).
- CI check suite completed successfully on GitHub.