### PR TITLE
chore: commit .terraformignore for Terrakube config uploads

### DIFF
--- a/.terraformignore
+++ b/.terraformignore
@@ -1,0 +1,10 @@
+.direnv/
+.entire/
+.docs
+.git/
+.terraform/
+.terragrunt-cache/
+aws-infra/.terragrunt-cache/
+servarr-config/.terragrunt-cache/
+vault-secrets/
+*.log


### PR DESCRIPTION
Terrakube CLI-driven runs upload the working directory; without a .terraformignore the tarball carries `.terraform/` (whose store symlinks break remote init with 'provider plugins are not consistent with the lock file'), terragrunt-era caches, and local detritus. Proven necessary during today's state-migration window (runs 71–76).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XHojUdkdBityvW3nA5yJkj