### PR TITLE
docs: rename terraform-proxmox self-references to tofu-proxmox

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,4 +1,4 @@
-# GitHub Copilot Instructions — terraform-proxmox
+# GitHub Copilot Instructions — tofu-proxmox
 
 ## Repository Purpose
 

--- a/aws-infra/modules/route53-records/README.md
+++ b/aws-infra/modules/route53-records/README.md
@@ -77,7 +77,7 @@ This module is part of the `aws-infra/` root module, which is completely
 separated from the Proxmox infrastructure:
 
 ```text
-terraform-proxmox/
+tofu-proxmox/
 ├── aws-infra/                    # AWS resources (this module's parent)
 │   ├── main.tf                   # AWS provider and module calls
 │   ├── native root configuration            # Separate state management

--- a/docs/MANAGING_REAL_VALUES.md
+++ b/docs/MANAGING_REAL_VALUES.md
@@ -106,7 +106,7 @@ tofu apply -var-file=terraform.tfvars.prod
 
 ```bash
 # Repository structure with worktrees
-~/git/terraform-proxmox/
+~/git/tofu-proxmox/
 ├── .git/                    # Shared git directory (bare repo)
 ├── .env/terraform.tfvars    # Shared environment config (gitignored)
 ├── main/                    # Main branch worktree
@@ -114,7 +114,7 @@ tofu apply -var-file=terraform.tfvars.prod
 └── bugfix/bug-fix/          # Fix branch worktree
 
 # Each worktree references the shared .env/terraform.tfvars via symlink
-~/git/terraform-proxmox/feature/feature-name/.env -> ../../.env
+~/git/tofu-proxmox/feature/feature-name/.env -> ../../.env
 ```
 
 **Configuration precedence** (highest to lowest):
@@ -135,14 +135,14 @@ tofu apply -var-file=terraform.tfvars.prod
 
 ```bash
 # Create .env directory at repo root (if not exists)
-mkdir -p ~/git/terraform-proxmox/.env
+mkdir -p ~/git/tofu-proxmox/.env
 
 # Copy your real values to .env/terraform.tfvars
 cp terraform.tfvars.example .env/terraform.tfvars
 # Edit .env/terraform.tfvars with your real values
 
 # Create symlink in each worktree
-cd ~/git/terraform-proxmox/feat/your-branch
+cd ~/git/tofu-proxmox/feat/your-branch
 ln -s ../../.env .env
 
 # OpenTofu now automatically loads .env/terraform.tfvars

--- a/docs/NETWORK_DIAGNOSIS.md
+++ b/docs/NETWORK_DIAGNOSIS.md
@@ -61,7 +61,7 @@ security-log indexes.
 
 | Work | Repo |
 | --- | --- |
-| netmon LXC definitions, `netmon_metrics` index doc, ports | terraform-proxmox (this) |
+| netmon LXC definitions, `netmon_metrics` index doc, ports | tofu-proxmox (this) |
 | Telegraf + exporter + SmokePing container config | ansible-proxmox-apps |
 | `netmon_metrics` Splunk index creation | ansible-splunk |
 | Per-uplink source-IP policy routes | tofu-unifi (gated apply) |

--- a/modules/rack-server-cluster/README.md
+++ b/modules/rack-server-cluster/README.md
@@ -61,7 +61,7 @@ to verify the declared inventory matches the live cluster.
 
 ## Why nothing is hard-coded
 
-`terraform-proxmox` is the org's source of truth for cluster identity, but
+`tofu-proxmox` is the org's source of truth for cluster identity, but
 this repo is public. Real values (IPs, MACs, service tags, hostnames) must
 be supplied via private RustFS or environment, never committed. The
 `private deployment object.example` at the repo root shows the placeholder shape


### PR DESCRIPTION
docs-only prose rename of the repo's own former name; operational values (bucket/key/URL) and code files left untouched.