### PR TITLE
feat(deployment): add apps-tier primary Postgres LXC (postgres-apps)

### DIFF
--- a/deployment.json.example
+++ b/deployment.json.example
@@ -223,6 +223,24 @@
         { "volume": "local-zfs", "size": "60G", "path": "/var/lib/postgresql" }
       ]
     },
+    "postgres-apps": {
+      "vm_id": 602000,
+      "dhcp": true,
+      "reserved_host": 56,
+      "vlan": "apps",
+      "hostname": "postgres-apps",
+      "description": "Apps-tier primary Postgres — native Postgres backing Nautobot/Vikunja/Zammad, on the applications VLAN alongside its dependents. Streaming-replication primary; persistent data mount + pgdump backups.",
+      "cpu_cores": 2,
+      "memory_dedicated": 2048,
+      "tags": ["terraform", "container", "postgres"],
+      "pool_id": "infrastructure",
+      "node_name": "proxmox-2",
+      "unprivileged": true,
+      "root_disk": { "size": 16 },
+      "mount_points": [
+        { "volume": "local-zfs", "size": "60G", "path": "/var/lib/postgresql" }
+      ]
+    },
     "nautobot": {
       "vm_id": 605000,
       "dhcp": true,


### PR DESCRIPTION
## What

Adds a new native Postgres LXC, `postgres-apps`, to the committed deployment
example as the applications tier's primary datastore. It is colocated on the
applications VLAN with the apps that depend on it (Nautobot, Vikunja, Zammad)
so their database traffic no longer crosses tiers.

## Guest definition

| Field | Value | Why |
| --- | --- | --- |
| VMID | `602000` | tier 6 (applications) · sub-tier 0 · criticality 2 · OS 0 (LXC) · instance 0 · env 0 (prod) |
| Hostname | `postgres-apps` | Distinct singleton name; MAC/DNS/reservation derive from it |
| VLAN | `apps` | Same tier as its dependents |
| Node | `proxmox-2` | Off the node hosting its dependents and the existing data-tier Postgres |
| Reserved host | `56` | Next free octet on the apps VLAN (52–55 in use) |
| Sizing | 2 cpu / 2048 MB · 16 GB root · 60 GB data at `/var/lib/postgresql` | Mirrors the proven data-tier Postgres |
| Tag | `postgres` | Drives guest firewall 5432-from-internal and `postgres_group` inventory enrolment |

Criticality `2` is lower (more critical) than the apps' `5`, so a numeric sort
restores it before the services that depend on it.

## Why this is the whole change

Guest wiring is fully data-driven: the firewall (`postgres_container_ids`),
inventory group membership, and IP/MAC/DNS derivation all key off the `postgres`
tag and the container map. No module code changes are needed to add the guest.

## Not covered here (follow-ups)

- The private RustFS `deployment.json` must gain the same entry before an apply;
  this example is the committed reference for that shape.
- The downstream `postgres` Ansible role has no primary/standby split today, so
  a second `postgres`-tagged host would provision all three app databases on
  both instances. A `postgres_role: primary|standby` variable plus streaming
  replication tasks are required before this becomes the live primary — tracked
  separately.

## Scheme note for review

The public VMID scheme documents sub-tiers `0/1/2` only. This guest uses
sub-tier `0` (matching the existing data-tier Postgres) rather than an
undocumented sub-tier. If the private allocation table defines a dedicated
"data / backing services" sub-tier, the VMID should be revised to match it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TduAFRb5WCmy1crcz8jSrQ
