### PR TITLE
fix(vm): clamp startup order at 0 for 6-digit VMIDs

### DIFF
--- a/modules/proxmox-vm/main.tf
+++ b/modules/proxmox-vm/main.tf
@@ -26,10 +26,13 @@ resource "proxmox_virtual_environment_vm" "vms" {
   # Startup configuration
   on_boot = try(each.value.on_boot, true)
 
-  # Startup order: 256 - vm_id (higher IDs start first)
+  # Startup order: 256 - vm_id (higher IDs start first). Clamped at 0 so
+  # 6-digit positional VMIDs (DNS-first/DHCP guests, see docs vmid-network-tiers)
+  # don't produce a negative order — those guests get order 0 (unordered), which
+  # is correct for non-critical DHCP workloads. Legacy <256 IDs are unaffected.
   # Delay: global startup_delay between each start
   startup {
-    order    = 256 - each.value.vm_id
+    order    = max(0, 256 - each.value.vm_id)
     up_delay = var.startup_delay
   }
 


### PR DESCRIPTION
## Why

`modules/proxmox-vm/main.tf` derives startup order as `256 - vm_id`, which
assumes VMIDs below 256. A 6-digit positional VMID produces a deeply negative
order — `iac-platform` (110130) yields **-109874**, which is not a valid
Proxmox startup order.

The container module **already guards this exact case**:

```hcl
# modules/proxmox-container/main.tf
# ... Clamped at 0 so 6-digit positional VMIDs ... don't produce a negative
# order — those guests get order 0 (unordered) ...
order = max(0, 256 - each.value.vm_id)
```

That clamp landed with the same derivation (#78); the VM module was missed.

## What

Apply the identical clamp to the VM module. Large VMIDs get order 0
(unordered), correct for non-critical DHCP guests. Legacy sub-256 IDs are
unaffected — `docker-host` (250) keeps order 6.

## How it was found

A pending plan wanted to push `startup.order = -1 -> -109874` onto the
iac-platform VM. This blocks that.

## Verification

`tofu fmt -check` clean; `tofu validate` passes. Post-merge, the plan should
show no `startup` change for `iac-platform` (256 - 110130 clamps to 0, and 0
is what an unordered guest already effectively has) — confirmed against the
plan before applying.