### PR TITLE
feat: add Hindsight agent-memory service (constants, ingress pool, firewall)

### DIFF
--- a/modules/firewall/hindsight_rules.tf
+++ b/modules/firewall/hindsight_rules.tf
@@ -1,0 +1,83 @@
+# Hindsight agent-memory LXC firewall — two stateless API replicas (hindsight
+# tag, ai VLAN) behind a Traefik load-balanced pool. Its security group and
+# *_services_rules local live here, not in security_groups.tf /
+# locals_rules.tf, to keep those files under the shared _file-size workflow's
+# 12 KB gate — same split as postgres_rules.tf.
+#
+# Live guest-layer rules: the REST API + built-in MCP endpoint (8888) and the
+# Control Plane UI (9999) open from internal RFC1918, following the existing
+# default-deny per-service allow model. Egress: outbound-internal (Postgres,
+# LiteLLM router) plus outbound HTTPS (Docker install/images, embedding-model
+# download) — same shape as the vectordb (Qdrant) Docker-in-LXC guests.
+
+locals {
+  memory_ports = var.pipeline_constants.memory_ports
+
+  hindsight_services_rules = [
+    { proto = "tcp", dport = tostring(local.memory_ports.hindsight_api), source = local.internal_src, comment = "Hindsight API + MCP from internal" },
+    { proto = "tcp", dport = tostring(local.memory_ports.hindsight_cp), source = local.internal_src, comment = "Hindsight Control Plane UI from internal" },
+  ]
+}
+
+resource "proxmox_virtual_environment_cluster_firewall_security_group" "hindsight_services" {
+  name    = "memory-svc"
+  comment = "Hindsight agent memory (${local.memory_ports.hindsight_api} API/MCP, ${local.memory_ports.hindsight_cp} CP UI) from internal networks"
+
+  dynamic "rule" {
+    for_each = local.hindsight_services_rules
+    content {
+      type    = "in"
+      action  = "ACCEPT"
+      proto   = rule.value.proto
+      dport   = rule.value.dport
+      source  = rule.value.source
+      comment = rule.value.comment
+    }
+  }
+}
+
+resource "proxmox_virtual_environment_firewall_options" "hindsight_container" {
+  for_each = var.hindsight_container_ids
+
+  node_name     = var.node_name
+  container_id  = each.value
+  enabled       = local.firewall_defaults.enabled
+  input_policy  = local.firewall_defaults.input_policy
+  output_policy = local.firewall_defaults.output_policy
+  log_level_in  = local.firewall_defaults.log_level_in
+  log_level_out = local.firewall_defaults.log_level_out
+
+  # DHCP-first guest behind DROP policies (same reason as llm_fabric_rules.tf).
+  dhcp = true
+
+  depends_on = [proxmox_virtual_environment_cluster_firewall.main]
+}
+
+resource "proxmox_virtual_environment_firewall_rules" "hindsight_container" {
+  for_each = var.hindsight_container_ids
+
+  node_name    = var.node_name
+  container_id = each.value
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.internal_access.name
+    comment        = "Internal access (SSH, ICMP)"
+  }
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.hindsight_services.name
+    comment        = "Hindsight (API/MCP, CP UI)"
+  }
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.outbound_internal.name
+    comment        = "Outbound to internal only"
+  }
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.outbound_https.name
+    comment        = "Outbound HTTPS (Docker install/images, embedding model)"
+  }
+
+  depends_on = [proxmox_virtual_environment_firewall_options.hindsight_container]
+}

--- a/modules/firewall/outputs.tf
+++ b/modules/firewall/outputs.tf
@@ -23,6 +23,11 @@ output "vectordb_container_firewall_enabled" {
   value       = { for k, v in proxmox_virtual_environment_firewall_options.vectordb_container : k => v.enabled }
 }
 
+output "hindsight_container_firewall_enabled" {
+  description = "Map of Hindsight agent-memory container IDs with firewall enabled"
+  value       = { for k, v in proxmox_virtual_environment_firewall_options.hindsight_container : k => v.enabled }
+}
+
 output "rag_container_firewall_enabled" {
   description = "Map of RAG engine container IDs with firewall enabled (LlamaIndex)"
   value       = { for k, v in proxmox_virtual_environment_firewall_options.rag_container : k => v.enabled }

--- a/modules/firewall/tests/rule_generation.tftest.hcl
+++ b/modules/firewall/tests/rule_generation.tftest.hcl
@@ -96,6 +96,10 @@ variables {
       qdrant_http = 6333
       qdrant_grpc = 6334
     }
+    memory_ports = {
+      hindsight_api = 8888
+      hindsight_cp  = 9999
+    }
     ai_log_ports = {
       claude_code    = 10311
       codex_cli      = 10312

--- a/modules/firewall/variables.tf
+++ b/modules/firewall/variables.tf
@@ -33,6 +33,12 @@ variable "vectordb_container_ids" {
   default     = {}
 }
 
+variable "hindsight_container_ids" {
+  description = "Map of Hindsight agent-memory container names to their IDs (hindsight tag). Stateless API replicas — inbound 8888/9999 from internal; egress outbound-internal + HTTPS."
+  type        = map(number)
+  default     = {}
+}
+
 variable "rag_container_ids" {
   description = "Map of RAG engine container names to their IDs (LlamaIndex)"
   type        = map(number)
@@ -201,6 +207,7 @@ variable "pipeline_constants" {
     netflow_ports      = map(number)
     notification_ports = map(number)
     vector_db_ports    = map(number)
+    memory_ports       = map(number)
     honeypot_ports     = map(number)
     ai_log_ports       = map(number)
     media_ports        = map(number)

--- a/modules/proxmox-stack/constants.tf
+++ b/modules/proxmox-stack/constants.tf
@@ -141,6 +141,14 @@ locals {
       qdrant_http = 6333
       qdrant_grpc = 6334
     }
+    # Agent memory service (Hindsight, ai VLAN). hindsight_api serves the REST
+    # API and the built-in MCP endpoint (/mcp); hindsight_cp is the Control
+    # Plane admin UI. Two stateless replicas share one Postgres and sit behind
+    # a Traefik load-balanced pool (locals-ingress-backends.tf).
+    memory_ports = {
+      hindsight_api = 8888
+      hindsight_cp  = 9999
+    }
     # AI / LLM log-ingest ports — one dedicated Cribl TCP-JSON receiver per source
     # family (defined in constants-ai-log.tf to keep this file under the shared
     # _file-size 12 KB gate; locals merge across files in the module).

--- a/modules/proxmox-stack/firewall.tf
+++ b/modules/proxmox-stack/firewall.tf
@@ -34,6 +34,9 @@ module "firewall" {
   # Vector database containers: Qdrant (vectordb tag)
   vectordb_container_ids = local.vectordb_container_ids
 
+  # Hindsight agent-memory containers (hindsight tag) — API 8888 / CP UI 9999
+  hindsight_container_ids = local.hindsight_container_ids
+
   # RAG engine containers: LlamaIndex (rag tag)
   rag_container_ids = local.rag_container_ids
 

--- a/modules/proxmox-stack/inventory_publish.tf
+++ b/modules/proxmox-stack/inventory_publish.tf
@@ -177,11 +177,11 @@ resource "aws_s3_object" "ansible_inventory" {
       condition = alltrue([
         for k in [
           "service_ports", "syslog_ports", "syslog_port_map", "netflow_ports",
-          "notification_ports", "vector_db_ports", "media_ports",
+          "notification_ports", "vector_db_ports", "memory_ports", "media_ports",
           "ai_log_ports", "ai_log_routing",
         ] : can(local.ansible_inventory.constants[k])
       ])
-      error_message = "pipeline_constants is missing one or more required keys (service_ports, syslog_ports, syslog_port_map, netflow_ports, notification_ports, vector_db_ports, media_ports, ai_log_ports, ai_log_routing). Inspect constants.tf."
+      error_message = "pipeline_constants is missing one or more required keys (service_ports, syslog_ports, syslog_port_map, netflow_ports, notification_ports, vector_db_ports, memory_ports, media_ports, ai_log_ports, ai_log_routing). Inspect constants.tf."
     }
     precondition {
       condition = alltrue([

--- a/modules/proxmox-stack/locals-ingress-backends.tf
+++ b/modules/proxmox-stack/locals-ingress-backends.tf
@@ -36,6 +36,19 @@ locals {
     if contains(keys(var.containers), k)
   ]
 
+  # Hindsight agent-memory pool. Every LXC tagged "hindsight" is load-balanced
+  # behind a single hindsight.<domain> route with health checks. The replicas
+  # are stateless (all state in the ai-VLAN Postgres cluster), so no sticky.
+  # Clients — agentgateway's MCP target, Hermes remote memory, Claude Code —
+  # all dial this one pooled hostname.
+  hindsight_backend_keys = sort([
+    for k, v in var.containers : k
+    if contains(coalesce(try(v.tags, null), []), "hindsight")
+  ])
+  hindsight_backends = [
+    for k in local.hindsight_backend_keys : local.container_address[k]
+  ]
+
   # Zammad HA backend pool. Every LXC tagged "zammad" is load-balanced
   # behind a single zammad.<domain> route with sticky sessions.
   zammad_backend_keys = sort([
@@ -144,6 +157,28 @@ locals {
         port              = local.pipeline_constants.service_ports.llm_router_api
         health_check      = true
         health_check_path = "/health/liveliness"
+      }
+    ] : [],
+    # Hindsight agent memory: one hindsight.<domain> route load-balancing the
+    # stateless API replicas. No sticky — every replica serves every bank from
+    # the same Postgres. /health is the upstream readiness endpoint.
+    length(local.hindsight_backends) > 0 ? [
+      {
+        name              = "hindsight"
+        backends          = local.hindsight_backends
+        port              = local.pipeline_constants.memory_ports.hindsight_api
+        health_check      = true
+        health_check_path = "/health"
+      },
+      {
+        # Control Plane admin UI (access-key gated in the app). Same attribute
+        # shape as the API route above — both arms of the conditional must
+        # unify to one object type.
+        name              = "hindsight-cp"
+        backends          = local.hindsight_backends
+        port              = local.pipeline_constants.memory_ports.hindsight_cp
+        health_check      = false
+        health_check_path = "/"
       }
     ] : [],
     # Zammad HA: one zammad.<domain> route load-balancing the application nodes.

--- a/modules/proxmox-stack/locals-memory.tf
+++ b/modules/proxmox-stack/locals-memory.tf
@@ -1,0 +1,19 @@
+# Database + agent-memory tag-filter locals — split from locals.tf to keep it
+# under the shared _file-size workflow's 12 KB gate (locals merge across files
+# in the module, same split as locals-honeypot.tf / locals-ingress-backends.tf).
+locals {
+  # Postgres LXCs — the shared native cluster ("postgres" tag) plus the ai-VLAN
+  # memory cluster ("postgres_ai" tag; primary + streaming standby backing
+  # Hindsight). Both take the same postgres-svc firewall shape (5432 from
+  # internal); Ansible grouping stays separate via the distinct tags.
+  postgres_container_ids = {
+    for k, v in var.containers : k => v.vm_id
+    if length(setintersection(toset(coalesce(try(v.tags, null), [])), toset(["postgres", "postgres_ai"]))) > 0
+  }
+
+  # Hindsight agent-memory containers (hindsight tag) — stateless API replicas.
+  hindsight_container_ids = {
+    for k, v in var.containers : k => v.vm_id
+    if contains(coalesce(try(v.tags, null), []), "hindsight")
+  }
+}

--- a/modules/proxmox-stack/locals.tf
+++ b/modules/proxmox-stack/locals.tf
@@ -230,11 +230,19 @@ locals {
     if contains(coalesce(try(v.tags, null), []), "hermes-agent")
   }
 
-  # Postgres LXC (postgres tag) — the shared native Postgres backing Nautobot
-  # (and later Vikunja/EspoCRM). modules/firewall opens 5432 to it from internal.
+  # Postgres LXCs — the shared native cluster ("postgres" tag) plus the ai-VLAN
+  # memory cluster ("postgres_ai" tag; primary + streaming standby backing
+  # Hindsight). Both take the same postgres-svc firewall shape (5432 from
+  # internal); Ansible grouping stays separate via the distinct tags.
   postgres_container_ids = {
     for k, v in var.containers : k => v.vm_id
-    if contains(coalesce(try(v.tags, null), []), "postgres")
+    if length(setintersection(toset(coalesce(try(v.tags, null), [])), toset(["postgres", "postgres_ai"]))) > 0
+  }
+
+  # Hindsight agent-memory containers (hindsight tag) — stateless API replicas.
+  hindsight_container_ids = {
+    for k, v in var.containers : k => v.vm_id
+    if contains(coalesce(try(v.tags, null), []), "hindsight")
   }
 
   # Nautobot LXC (nautobot tag) — native IPAM/DCIM source of truth, web UI on

--- a/modules/proxmox-stack/locals.tf
+++ b/modules/proxmox-stack/locals.tf
@@ -230,20 +230,8 @@ locals {
     if contains(coalesce(try(v.tags, null), []), "hermes-agent")
   }
 
-  # Postgres LXCs — the shared native cluster ("postgres" tag) plus the ai-VLAN
-  # memory cluster ("postgres_ai" tag; primary + streaming standby backing
-  # Hindsight). Both take the same postgres-svc firewall shape (5432 from
-  # internal); Ansible grouping stays separate via the distinct tags.
-  postgres_container_ids = {
-    for k, v in var.containers : k => v.vm_id
-    if length(setintersection(toset(coalesce(try(v.tags, null), [])), toset(["postgres", "postgres_ai"]))) > 0
-  }
-
-  # Hindsight agent-memory containers (hindsight tag) — stateless API replicas.
-  hindsight_container_ids = {
-    for k, v in var.containers : k => v.vm_id
-    if contains(coalesce(try(v.tags, null), []), "hindsight")
-  }
+  # postgres_container_ids + hindsight_container_ids live in
+  # locals-memory.tf to keep this file under the 12 KB size gate.
 
   # Nautobot LXC (nautobot tag) — native IPAM/DCIM source of truth, web UI on
   # nautobot_web (8080). modules/firewall opens 8080 to it from internal.

--- a/modules/proxmox-stack/tests/ansible_inventory_contract.tftest.hcl
+++ b/modules/proxmox-stack/tests/ansible_inventory_contract.tftest.hcl
@@ -174,6 +174,15 @@ run "ansible_inventory_constants_vector_db_ports_exists" {
   }
 }
 
+run "ansible_inventory_constants_memory_ports_exists" {
+  command = plan
+
+  assert {
+    condition     = can(output.ansible_inventory.constants.memory_ports)
+    error_message = "ansible_inventory.constants must contain 'memory_ports' key"
+  }
+}
+
 run "ansible_inventory_constants_media_ports_exists" {
   command = plan
 

--- a/modules/proxmox-stack/tests/locals.tftest.hcl
+++ b/modules/proxmox-stack/tests/locals.tftest.hcl
@@ -392,6 +392,20 @@ run "pipeline_constants_vector_db_ports" {
   }
 }
 
+run "pipeline_constants_memory_ports" {
+  command = plan
+
+  assert {
+    condition     = local.pipeline_constants.memory_ports.hindsight_api == 8888
+    error_message = "hindsight_api port should be 8888"
+  }
+
+  assert {
+    condition     = local.pipeline_constants.memory_ports.hindsight_cp == 9999
+    error_message = "hindsight_cp port should be 9999"
+  }
+}
+
 run "pipeline_constants_db_ports" {
   command = plan
 


### PR DESCRIPTION
## Summary
- New `memory_ports` pipeline constants: Hindsight REST API + built-in MCP endpoint (8888) and Control Plane UI (9999).
- Traefik load-balanced backend pool for the `hindsight` tag: `hindsight.<domain>` (health-checked at `/health`, no sticky — replicas are stateless) and `hindsight-cp.<domain>`.
- New `memory-svc` guest firewall security group (default-deny per-service allow model); Docker-in-LXC egress shape matches the vectordb guests.
- `postgres_container_ids` now also matches the `postgres_ai` tag so the ai-VLAN Postgres cluster reuses the existing `postgres-svc` firewall shape; Ansible grouping stays separate.
- Inventory-publish precondition + module tests extended for the new constants key.

Part of the Hindsight standalone-memory-service campaign (Hermes embedded → HA service; downstream Ansible PRs follow).

## Test plan
- `tofu validate` clean
- `modules/proxmox-stack` tests: 118 passed
- `modules/firewall` tests: 30 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BgTn2CxMJmyY9yKXndsNaq