### PR TITLE
feat(ingress): Authelia SSO guest, portal route, per-route sso gate flag

### DIFF
--- a/deployment.json.example
+++ b/deployment.json.example
@@ -277,6 +277,23 @@
         { "volume": "local-zfs", "size": "10G", "path": "/var/lib/vikunja" }
       ]
     },
+    "authelia": {
+      "vm_id": 100050,
+      "vlan": "mgmt",
+      "ip_config": { "ipv4_address": "198.51.100.6/24" },
+      "hostname": "authelia",
+      "description": "Authelia SSO portal / Traefik forwardAuth provider — criticality-1 core service (auth plane, beside ingress/DNS): native Go binary, portal + authz API on 9091 fronted by Traefik; passkey-first login; state in local SQLite on persistent /var/lib/authelia.",
+      "cpu_cores": 1,
+      "memory_dedicated": 512,
+      "tags": ["terraform", "container", "authelia"],
+      "pool_id": "infrastructure",
+      "node_name": "proxmox-1",
+      "unprivileged": true,
+      "root_disk": { "size": 8 },
+      "mount_points": [
+        { "volume": "local-zfs", "size": "2G", "path": "/var/lib/authelia" }
+      ]
+    },
     "zammad-20": {
       "vm_id": 605020,
       "dhcp": true,

--- a/modules/firewall/authelia_rules.tf
+++ b/modules/firewall/authelia_rules.tf
@@ -1,0 +1,74 @@
+# Authelia LXC firewall — native single-binary SSO portal / forwardAuth
+# provider, portal + authz API on authelia_portal (9091). Its security group
+# and *_services_rules local live here, not in locals_rules.tf /
+# security_groups.tf, to keep those files under the shared _file-size
+# workflow's 12 KB gate — same split as vikunja_rules.tf.
+#
+# Live guest-layer rule: 9091 open from internal RFC1918 — Traefik dials it for
+# every forwardAuth subrequest and browsers reach the portal through Traefik
+# (ingress.tf authelia route). State is local SQLite, notifications go to the
+# internal SMTP relay, and the binary is controller-staged (no package-manager
+# egress), so egress is outbound-internal only.
+
+locals {
+  authelia_services_rules = [
+    { proto = "tcp", dport = tostring(local.svc_ports.authelia_portal), source = local.internal_src, comment = "Authelia portal + forwardAuth API from internal" },
+  ]
+}
+
+resource "proxmox_virtual_environment_cluster_firewall_security_group" "authelia_services" {
+  name    = "authelia-svc"
+  comment = "Authelia portal/authz (${local.svc_ports.authelia_portal}) from internal networks — Traefik-fronted"
+
+  dynamic "rule" {
+    for_each = local.authelia_services_rules
+    content {
+      type    = "in"
+      action  = "ACCEPT"
+      proto   = rule.value.proto
+      dport   = rule.value.dport
+      source  = rule.value.source
+      comment = rule.value.comment
+    }
+  }
+}
+
+resource "proxmox_virtual_environment_firewall_options" "authelia_container" {
+  for_each = var.authelia_container_ids
+
+  node_name     = var.node_name
+  container_id  = each.value
+  enabled       = local.firewall_defaults.enabled
+  input_policy  = local.firewall_defaults.input_policy
+  output_policy = local.firewall_defaults.output_policy
+  log_level_in  = local.firewall_defaults.log_level_in
+  log_level_out = local.firewall_defaults.log_level_out
+
+  # Static mgmt-VLAN core guest (vmid-derived IP, like traefik/technitium) —
+  # no dhcp allow needed.
+  depends_on = [proxmox_virtual_environment_cluster_firewall.main]
+}
+
+resource "proxmox_virtual_environment_firewall_rules" "authelia_container" {
+  for_each = var.authelia_container_ids
+
+  node_name    = var.node_name
+  container_id = each.value
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.internal_access.name
+    comment        = "Internal access (SSH, ICMP)"
+  }
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.authelia_services.name
+    comment        = "Authelia portal/authz (TCP/${local.svc_ports.authelia_portal})"
+  }
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.outbound_internal.name
+    comment        = "Outbound to internal only"
+  }
+
+  depends_on = [proxmox_virtual_environment_firewall_options.authelia_container]
+}

--- a/modules/firewall/tests/rule_generation.tftest.hcl
+++ b/modules/firewall/tests/rule_generation.tftest.hcl
@@ -34,6 +34,7 @@ variables {
       redis_default          = 6379
       nautobot_web           = 8080
       vikunja_web            = 3456
+      authelia_portal        = 9091
       zammad_web             = 8080
       ntp                    = 123
       idrac_kvm_r410         = 5410
@@ -695,6 +696,32 @@ run "nautobot_rule_tracks_constant_and_internal_scope" {
   assert {
     condition     = local.nautobot_services_rules[0].proto == "tcp" && local.nautobot_services_rules[0].dport == tostring(var.pipeline_constants.service_ports.nautobot_web)
     error_message = "nautobot rule must be TCP tracking service_ports.nautobot_web, got proto='${local.nautobot_services_rules[0].proto}' dport='${local.nautobot_services_rules[0].dport}'"
+  }
+}
+
+# --- authelia service rules ---
+
+run "authelia_rule_tracks_constant_and_internal_scope" {
+  command = plan
+
+  variables {
+    internal_networks = ["192.168.10.0/24", "192.168.20.0/24"]
+  }
+
+  # Exactly one live rule: TCP authelia_portal (9091) from the internal networks.
+  assert {
+    condition     = length(local.authelia_services_rules) == 1
+    error_message = "authelia_services_rules must be exactly 1 (TCP authelia_portal), got ${length(local.authelia_services_rules)}"
+  }
+
+  assert {
+    condition     = local.authelia_services_rules[0].proto == "tcp" && local.authelia_services_rules[0].dport == tostring(var.pipeline_constants.service_ports.authelia_portal)
+    error_message = "authelia rule must be TCP tracking service_ports.authelia_portal, got proto='${local.authelia_services_rules[0].proto}' dport='${local.authelia_services_rules[0].dport}'"
+  }
+
+  assert {
+    condition     = local.authelia_services_rules[0].source == "192.168.10.0/24,192.168.20.0/24"
+    error_message = "authelia rule source must be the comma-joined internal networks, got '${local.authelia_services_rules[0].source}'"
   }
 }
 

--- a/modules/firewall/variables.tf
+++ b/modules/firewall/variables.tf
@@ -81,6 +81,12 @@ variable "nautobot_container_ids" {
   default     = {}
 }
 
+variable "authelia_container_ids" {
+  description = "Map of Authelia container names to their IDs (authelia tag). Native SSO portal / Traefik forwardAuth provider — inbound authelia_portal (9091) from internal; egress outbound-internal only (SQLite local, SMTP relay internal, binary controller-staged)."
+  type        = map(number)
+  default     = {}
+}
+
 variable "vikunja_container_ids" {
   description = "Map of Vikunja container names to their IDs (vikunja tag). Native task-management app — inbound vikunja_web (3456) from internal; egress outbound-internal only (no package-manager egress, binary is controller-staged)."
   type        = map(number)

--- a/modules/proxmox-stack/constants.tf
+++ b/modules/proxmox-stack/constants.tf
@@ -28,6 +28,7 @@ locals {
       # every port lives in one place and the ingress table (below) references
       # constants, never literals.
       technitium_web    = 5380
+      authelia_portal   = 9091
       phpipam_web       = 80
       nautobot_web      = 8080
       vikunja_web       = 3456

--- a/modules/proxmox-stack/firewall.tf
+++ b/modules/proxmox-stack/firewall.tf
@@ -57,6 +57,7 @@ module "firewall" {
   postgres_container_ids = local.postgres_container_ids
   nautobot_container_ids = local.nautobot_container_ids
   vikunja_container_ids  = local.vikunja_container_ids
+  authelia_container_ids = local.authelia_container_ids
   zammad_container_ids   = local.zammad_container_ids
 
   # Ingress (Traefik HA) containers (ingress tag) — define-disabled guest firewall

--- a/modules/proxmox-stack/ingress.tf
+++ b/modules/proxmox-stack/ingress.tf
@@ -9,8 +9,14 @@ locals {
   # name = the hostname label -> https://<name>.<domain>.
   # backend = the container key whose IP is resolved from the inventory.
   # port = a pipeline_constants reference (never a literal, so ports stay DRY).
+  # sso = whether Traefik attaches the Authelia forwardAuth middleware to the
+  #       route (default true when omitted). false for machine/API endpoints
+  #       (clients cannot do a browser login) and for apps whose non-browser
+  #       clients authenticate natively (e.g. Plex apps).
   ingress_services = {
-    plex             = { backend = "plex", port = local.pipeline_constants.media_ports.plex_web }
+    # Authelia portal itself — never gated (it IS the login page).
+    authelia         = { backend = "authelia", port = local.pipeline_constants.service_ports.authelia_portal, sso = false }
+    plex             = { backend = "plex", port = local.pipeline_constants.media_ports.plex_web, sso = false } # Plex clients auth via plex.tv
     seerr            = { backend = "seerr", port = local.pipeline_constants.media_ports.seerr_web }
     sonarr           = { backend = "sonarr", port = local.pipeline_constants.media_ports.sonarr_web }
     radarr           = { backend = "radarr", port = local.pipeline_constants.media_ports.radarr_web }
@@ -19,21 +25,21 @@ locals {
     prowlarr         = { backend = "download-vpn", port = local.pipeline_constants.media_ports.prowlarr_web }
     technitium       = { backend = "technitium-dns", port = local.pipeline_constants.service_ports.technitium_web }
     phpipam          = { backend = "phpipam", port = local.pipeline_constants.service_ports.phpipam_web }
-    nautobot         = { backend = "nautobot", port = local.pipeline_constants.service_ports.nautobot_web } # native IPAM/DCIM UI; Postgres has NO ingress row (in-cluster 5432 only)
-    vikunja          = { backend = "vikunja", port = local.pipeline_constants.service_ports.vikunja_web }
+    nautobot         = { backend = "nautobot", port = local.pipeline_constants.service_ports.nautobot_web, sso = false } # GraphQL dynamic-inventory clients; native IPAM/DCIM UI; Postgres has NO ingress row (in-cluster 5432 only)
+    vikunja          = { backend = "vikunja", port = local.pipeline_constants.service_ports.vikunja_web, sso = false }   # MCP API tokens hit /api/v1 on this host
     "object-storage" = { backend = "s3", port = local.pipeline_constants.service_ports.object_storage_console }
     # RustFS S3 API fronted by a valid-TLS hostname. Path-style S3 format.
-    s3 = { backend = "s3", port = local.pipeline_constants.service_ports.object_storage_s3 }
+    s3 = { backend = "s3", port = local.pipeline_constants.service_ports.object_storage_s3, sso = false } # machine S3 clients
     # openbao is fronted as a load-balanced pool (openbao_backends below).
     mailpit           = { backend = "mailpit", port = local.pipeline_constants.notification_ports.mailpit_web }
-    ntfy              = { backend = "ntfy", port = local.pipeline_constants.notification_ports.ntfy_http }
-    "honeypot-notify" = { backend = "honeypot-notify", port = local.pipeline_constants.honeypot_ports.apprise_api }
-    homeassistant     = { backend = "homeassistant", port = local.pipeline_constants.service_ports.homeassistant_web }
+    ntfy              = { backend = "ntfy", port = local.pipeline_constants.notification_ports.ntfy_http, sso = false }             # publish clients POST here
+    "honeypot-notify" = { backend = "honeypot-notify", port = local.pipeline_constants.honeypot_ports.apprise_api, sso = false }    # machine notify API
+    homeassistant     = { backend = "homeassistant", port = local.pipeline_constants.service_ports.homeassistant_web, sso = false } # companion apps auth natively
     openproject       = { backend = "openproject", port = local.pipeline_constants.service_ports.openproject_web }
     prometheus        = { backend = "prometheus", port = local.pipeline_constants.service_ports.prometheus_web }
     # llm is fronted as a load-balanced router pool (llm_router_backends below).
     chat   = { backend = "open-webui", port = local.pipeline_constants.service_ports.open_webui_web }
-    qdrant = { backend = "qdrant", port = local.pipeline_constants.vector_db_ports.qdrant_http }
+    qdrant = { backend = "qdrant", port = local.pipeline_constants.vector_db_ports.qdrant_http, sso = false } # vector API for agents/MCP
     # AI orchestration stack UIs (ai VLAN) + Langfuse LLM observability (siem VLAN).
     n8n          = { backend = "n8n", port = local.pipeline_constants.service_ports.n8n_web }
     dify         = { backend = "dify", port = local.pipeline_constants.service_ports.dify_web }
@@ -42,20 +48,20 @@ locals {
     agentgateway = { backend = "agentgateway", port = local.pipeline_constants.service_ports.agentgateway_admin }
     # MCP tool-plane front door (the `llm`-alias pattern, for tools): clients
     # dial https://mcp.<domain>/<target>/mcp; `agentgateway` stays the admin UI.
-    mcp = { backend = "agentgateway", port = local.pipeline_constants.service_ports.agentgateway_proxy }
+    mcp = { backend = "agentgateway", port = local.pipeline_constants.service_ports.agentgateway_proxy, sso = false } # MCP tool clients
     # LangGraph (self-hosted): the `langgraph dev` server API + its Agent Chat UI,
     # both backed by the one `langgraph` guest. Chat UI is the primary play surface;
     # the API host also lets browser Studio point its ?baseUrl at it.
-    langgraph        = { backend = "langgraph", port = local.pipeline_constants.service_ports.langgraph_api }
+    langgraph        = { backend = "langgraph", port = local.pipeline_constants.service_ports.langgraph_api, sso = false } # API + Studio ?baseUrl clients
     "langgraph-chat" = { backend = "langgraph", port = local.pipeline_constants.service_ports.agent_chat_ui_web }
     # Hermes agent inbound webhook front door: https://hermes.<domain>/webhooks/<name>
     # -> hermes-agent container : hermes_webhook (HMAC-signed, event-driven trigger
     # for the one non-A2A agent). Guest firewall opens the port from internal.
-    hermes = { backend = "hermes-agent", port = local.pipeline_constants.service_ports.hermes_webhook }
+    hermes = { backend = "hermes-agent", port = local.pipeline_constants.service_ports.hermes_webhook, sso = false } # HMAC-signed webhooks
     # Hermes agent inbound job-submission API: https://hermes-api.<domain>/v1/runs
     # -> hermes-agent container : hermes_api (`hermes gateway` api_server platform,
     # bearer-authenticated). The sanctioned non-exec job path; internal-only firewall.
-    "hermes-api"    = { backend = "hermes-agent", port = local.pipeline_constants.service_ports.hermes_api }
+    "hermes-api"    = { backend = "hermes-agent", port = local.pipeline_constants.service_ports.hermes_api, sso = false } # bearer-authenticated job API
     smokeping       = { backend = "smokeping", port = local.pipeline_constants.service_ports.smokeping_web }
     "haproxy-stats" = { backend = "haproxy", port = local.pipeline_constants.service_ports.haproxy_stats }
   }

--- a/modules/proxmox-stack/locals-authelia.tf
+++ b/modules/proxmox-stack/locals-authelia.tf
@@ -1,0 +1,13 @@
+# Authelia tag-filter local — same locals-split treatment as locals-vikunja.tf
+# (locals merge across files in a module). Consumed by the firewall module call
+# in main.tf.
+
+locals {
+  # Authelia LXC (authelia tag) — native SSO portal / Traefik forwardAuth
+  # provider, portal + authz API on authelia_portal (9091), state in local
+  # SQLite. modules/firewall opens 9091 to it from internal.
+  authelia_container_ids = {
+    for k, v in var.containers : k => v.vm_id
+    if contains(coalesce(try(v.tags, null), []), "authelia")
+  }
+}

--- a/modules/proxmox-stack/locals-ingress-backends.tf
+++ b/modules/proxmox-stack/locals-ingress-backends.tf
@@ -75,6 +75,7 @@ locals {
         # Consumers default scheme=http / insecure_tls=false when absent.
         scheme       = "https"
         insecure_tls = true
+        sso          = true # browser UI — gated
       },
       {
         # Splunk management / REST API (splunkd, 8089) fronted at
@@ -163,6 +164,7 @@ locals {
         port         = local.pipeline_constants.service_ports.zammad_web
         sticky       = true
         health_check = true
+        sso          = true # browser UI — gated
       }
     ] : [],
     # IaC automation platform (Terrakube + Semaphore UI) on the iac-platform VM

--- a/modules/proxmox-stack/locals-ingress-backends.tf
+++ b/modules/proxmox-stack/locals-ingress-backends.tf
@@ -59,6 +59,9 @@ locals {
         name = name
         ip   = local.container_address[svc.backend]
         port = svc.port
+        # Authelia forwardAuth gate flag, consumed by the ansible traefik role.
+        # Defaults true (gated) unless the table row opts out (sso = false).
+        sso = try(svc.sso, true)
       }
       if contains(keys(var.containers), svc.backend)
     ],
@@ -84,6 +87,7 @@ locals {
         port         = local.pipeline_constants.service_ports.splunk_mgmt
         scheme       = "https"
         insecure_tls = true
+        sso          = false # REST API clients (CLI, automation)
       },
       {
         # Splunk HEC (8088) fronted at splunk-hec.<domain> on the standard
@@ -96,6 +100,7 @@ locals {
         port         = local.pipeline_constants.service_ports.splunk_hec
         scheme       = "https"
         insecure_tls = true
+        sso          = false # HEC token senders (Cribl edges)
       }
     ],
     # Proxmox cluster UI apex (the ingress subdomain apex), load-balanced.
@@ -113,6 +118,7 @@ locals {
         insecure_tls = true
         sticky       = true
         health_check = true
+        sso          = false # tofu provider / API clients share this route
       }
     ] : [],
     # OpenBao HA: one openbao.<domain> route load-balancing the Raft peers.
@@ -133,6 +139,7 @@ locals {
         sticky            = true
         health_check      = true
         health_check_path = "/v1/sys/health?standbyok=true"
+        sso               = false # token/AppRole/JWT API clients (CLI, Terrakube, roles)
       }
     ] : [],
     # LiteLLM router pool: llm.<domain> load-balancing the stateless routers.
@@ -144,6 +151,7 @@ locals {
         port              = local.pipeline_constants.service_ports.llm_router_api
         health_check      = true
         health_check_path = "/health/liveliness"
+        sso               = false # OpenAI-compatible API clients
       }
     ] : [],
     # Zammad HA: one zammad.<domain> route load-balancing the application nodes.
@@ -167,15 +175,18 @@ locals {
     # off nightly — consumers must treat these routes as daytime-available.
     contains(keys(var.vms), "iac-platform") ? [
       for svc in [
+        # UI hosts stay gated (sso omitted -> true); the API/registry/dex hosts
+        # serve machine clients (CLI, dex OIDC redirects) and opt out.
         { name = "terrakube", port = local.pipeline_constants.iac_platform_ports.terrakube_ui },
-        { name = "terrakube-api", port = local.pipeline_constants.iac_platform_ports.terrakube_api },
-        { name = "terrakube-registry", port = local.pipeline_constants.iac_platform_ports.terrakube_registry },
-        { name = "terrakube-dex", port = local.pipeline_constants.iac_platform_ports.terrakube_dex },
+        { name = "terrakube-api", port = local.pipeline_constants.iac_platform_ports.terrakube_api, sso = false },
+        { name = "terrakube-registry", port = local.pipeline_constants.iac_platform_ports.terrakube_registry, sso = false },
+        { name = "terrakube-dex", port = local.pipeline_constants.iac_platform_ports.terrakube_dex, sso = false },
         { name = "semaphore", port = local.pipeline_constants.iac_platform_ports.semaphore_web },
         ] : {
         name = svc.name
         ip   = local.vm_address["iac-platform"]
         port = svc.port
+        sso  = try(svc.sso, true)
       }
     ] : []
   )

--- a/modules/proxmox-stack/tests/ansible_inventory_contract.tftest.hcl
+++ b/modules/proxmox-stack/tests/ansible_inventory_contract.tftest.hcl
@@ -356,6 +356,29 @@ run "ansible_inventory_ingress_route_table" {
     error_message = "ingress must front seerr at 192.168.70.211:5055"
   }
 
+  # Every published ingress row carries an explicit sso flag (the forwardAuth
+  # gate contract — the ansible consumer treats a missing flag as ungated, so
+  # an absent key would silently drop a route out of the SSO gate).
+  assert {
+    condition = alltrue([
+      for r in output.ansible_inventory.ingress : can(r.sso)
+    ])
+    error_message = "every ingress row must carry an explicit sso flag"
+  }
+
+  # Table rows without an explicit opt-out default to gated (sso = true):
+  # seerr omits sso in ingress_services; plex opts out (native client auth).
+  assert {
+    condition = length([
+      for r in output.ansible_inventory.ingress :
+      r if r.name == "seerr" && r.sso == true
+      ]) == 1 && length([
+      for r in output.ansible_inventory.ingress :
+      r if r.name == "plex" && r.sso == false
+    ]) == 1
+    error_message = "sso must default true for unmarked rows (seerr) and honor explicit opt-outs (plex)"
+  }
+
   # Services whose backend container is absent are skipped (sonarr not deployed).
   assert {
     condition     = length([for r in output.ansible_inventory.ingress : r if r.name == "sonarr"]) == 0

--- a/modules/proxmox-stack/tests/firewall_filtering.tftest.hcl
+++ b/modules/proxmox-stack/tests/firewall_filtering.tftest.hcl
@@ -564,6 +564,34 @@ run "vikunja_tag_filters_correctly" {
   }
 }
 
+# --- authelia_container_ids test ---
+
+run "authelia_tag_filters_correctly" {
+  command = plan
+
+  variables {
+    containers = {
+      "authelia" = {
+        vm_id     = 100050
+        hostname  = "authelia"
+        vlan      = "mgmt"
+        ip_config = { ipv4_address = "192.168.5.6/24" }
+        tags      = ["terraform", "container", "authelia"]
+      }
+    }
+  }
+
+  assert {
+    condition     = local.authelia_container_ids["authelia"] == 100050 && length(local.authelia_container_ids) == 1
+    error_message = "authelia-tagged container must be the sole member of authelia_container_ids"
+  }
+
+  assert {
+    condition     = !contains(keys(local.pipeline_container_ids), "authelia")
+    error_message = "authelia must not land in pipeline_container_ids"
+  }
+}
+
 # A generic 'database'-tagged guest (e.g. mssql) must NOT be pulled into
 # postgres_container_ids — only the specific 'postgres' tag opens the 5432 rule.
 run "generic_database_tag_not_in_postgres_ids" {


### PR DESCRIPTION
## What

- New `authelia` LXC guest (positional VMID `100050` — tier 1 core · user-facing · crit 0; static core-block IP, mgmt VLAN; persistent state mount). Entry added to `deployment.json.example`; the live desired-state object was updated in the same shape.
- `ingress.tf`: `authelia` portal row (new `authelia_portal` constant, 9091) and a per-row `sso` flag (default true). Machine/API endpoints and apps whose non-browser clients authenticate natively opt out — the row comments document each exclusion.
- `locals-ingress-backends.tf`: the assembled ingress list now carries `sso` on every row (splunk-mgmt/hec, openbao, llm, proxmox apex, terrakube api/registry/dex opt out).
- `modules/firewall`: default-deny `authelia` profile — portal port from internal, outbound-internal-only egress (binary is controller-staged).

## Consumer

The ansible traefik role (dryvist/ansible-proxmox-apps#1038) attaches its forwardAuth middleware to exactly the `sso: true` routes; an inventory without the flag gates nothing, so the two PRs merge independently.

## Verification

- `tofu validate`: proxmox-stack + firewall modules pass; `tofu fmt -check -recursive` clean.
- Both deployment JSON documents parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)