### PR TITLE
chore: promote develop to main

### DIFF
--- a/deployment.json.example
+++ b/deployment.json.example
@@ -277,6 +277,23 @@
         { "volume": "local-zfs", "size": "10G", "path": "/var/lib/vikunja" }
       ]
     },
+    "authelia": {
+      "vm_id": 100050,
+      "vlan": "mgmt",
+      "ip_config": { "ipv4_address": "198.51.100.6/24" },
+      "hostname": "authelia",
+      "description": "Authelia SSO portal / Traefik forwardAuth provider — criticality-1 core service (auth plane, beside ingress/DNS): native Go binary, portal + authz API on 9091 fronted by Traefik; passkey-first login; state in local SQLite on persistent /var/lib/authelia.",
+      "cpu_cores": 1,
+      "memory_dedicated": 512,
+      "tags": ["terraform", "container", "authelia"],
+      "pool_id": "infrastructure",
+      "node_name": "proxmox-1",
+      "unprivileged": true,
+      "root_disk": { "size": 8 },
+      "mount_points": [
+        { "volume": "local-zfs", "size": "2G", "path": "/var/lib/authelia" }
+      ]
+    },
     "zammad-20": {
       "vm_id": 605020,
       "dhcp": true,

--- a/modules/firewall/authelia_rules.tf
+++ b/modules/firewall/authelia_rules.tf
@@ -1,0 +1,74 @@
+# Authelia LXC firewall — native single-binary SSO portal / forwardAuth
+# provider, portal + authz API on authelia_portal (9091). Its security group
+# and *_services_rules local live here, not in locals_rules.tf /
+# security_groups.tf, to keep those files under the shared _file-size
+# workflow's 12 KB gate — same split as vikunja_rules.tf.
+#
+# Live guest-layer rule: 9091 open from internal RFC1918 — Traefik dials it for
+# every forwardAuth subrequest and browsers reach the portal through Traefik
+# (ingress.tf authelia route). State is local SQLite, notifications go to the
+# internal SMTP relay, and the binary is controller-staged (no package-manager
+# egress), so egress is outbound-internal only.
+
+locals {
+  authelia_services_rules = [
+    { proto = "tcp", dport = tostring(local.svc_ports.authelia_portal), source = local.internal_src, comment = "Authelia portal + forwardAuth API from internal" },
+  ]
+}
+
+resource "proxmox_virtual_environment_cluster_firewall_security_group" "authelia_services" {
+  name    = "authelia-svc"
+  comment = "Authelia portal/authz (${local.svc_ports.authelia_portal}) from internal networks — Traefik-fronted"
+
+  dynamic "rule" {
+    for_each = local.authelia_services_rules
+    content {
+      type    = "in"
+      action  = "ACCEPT"
+      proto   = rule.value.proto
+      dport   = rule.value.dport
+      source  = rule.value.source
+      comment = rule.value.comment
+    }
+  }
+}
+
+resource "proxmox_virtual_environment_firewall_options" "authelia_container" {
+  for_each = var.authelia_container_ids
+
+  node_name     = var.node_name
+  container_id  = each.value
+  enabled       = local.firewall_defaults.enabled
+  input_policy  = local.firewall_defaults.input_policy
+  output_policy = local.firewall_defaults.output_policy
+  log_level_in  = local.firewall_defaults.log_level_in
+  log_level_out = local.firewall_defaults.log_level_out
+
+  # Static mgmt-VLAN core guest (vmid-derived IP, like traefik/technitium) —
+  # no dhcp allow needed.
+  depends_on = [proxmox_virtual_environment_cluster_firewall.main]
+}
+
+resource "proxmox_virtual_environment_firewall_rules" "authelia_container" {
+  for_each = var.authelia_container_ids
+
+  node_name    = var.node_name
+  container_id = each.value
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.internal_access.name
+    comment        = "Internal access (SSH, ICMP)"
+  }
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.authelia_services.name
+    comment        = "Authelia portal/authz (TCP/${local.svc_ports.authelia_portal})"
+  }
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.outbound_internal.name
+    comment        = "Outbound to internal only"
+  }
+
+  depends_on = [proxmox_virtual_environment_firewall_options.authelia_container]
+}

--- a/modules/firewall/hindsight_rules.tf
+++ b/modules/firewall/hindsight_rules.tf
@@ -1,0 +1,83 @@
+# Hindsight agent-memory LXC firewall — two stateless API replicas (hindsight
+# tag, ai VLAN) behind a Traefik load-balanced pool. Its security group and
+# *_services_rules local live here, not in security_groups.tf /
+# locals_rules.tf, to keep those files under the shared _file-size workflow's
+# 12 KB gate — same split as postgres_rules.tf.
+#
+# Live guest-layer rules: the REST API + built-in MCP endpoint (8888) and the
+# Control Plane UI (9999) open from internal RFC1918, following the existing
+# default-deny per-service allow model. Egress: outbound-internal (Postgres,
+# LiteLLM router) plus outbound HTTPS (Docker install/images, embedding-model
+# download) — same shape as the vectordb (Qdrant) Docker-in-LXC guests.
+
+locals {
+  memory_ports = var.pipeline_constants.memory_ports
+
+  hindsight_services_rules = [
+    { proto = "tcp", dport = tostring(local.memory_ports.hindsight_api), source = local.internal_src, comment = "Hindsight API + MCP from internal" },
+    { proto = "tcp", dport = tostring(local.memory_ports.hindsight_cp), source = local.internal_src, comment = "Hindsight Control Plane UI from internal" },
+  ]
+}
+
+resource "proxmox_virtual_environment_cluster_firewall_security_group" "hindsight_services" {
+  name    = "memory-svc"
+  comment = "Hindsight agent memory (${local.memory_ports.hindsight_api} API/MCP, ${local.memory_ports.hindsight_cp} CP UI) from internal networks"
+
+  dynamic "rule" {
+    for_each = local.hindsight_services_rules
+    content {
+      type    = "in"
+      action  = "ACCEPT"
+      proto   = rule.value.proto
+      dport   = rule.value.dport
+      source  = rule.value.source
+      comment = rule.value.comment
+    }
+  }
+}
+
+resource "proxmox_virtual_environment_firewall_options" "hindsight_container" {
+  for_each = var.hindsight_container_ids
+
+  node_name     = var.node_name
+  container_id  = each.value
+  enabled       = local.firewall_defaults.enabled
+  input_policy  = local.firewall_defaults.input_policy
+  output_policy = local.firewall_defaults.output_policy
+  log_level_in  = local.firewall_defaults.log_level_in
+  log_level_out = local.firewall_defaults.log_level_out
+
+  # DHCP-first guest behind DROP policies (same reason as llm_fabric_rules.tf).
+  dhcp = true
+
+  depends_on = [proxmox_virtual_environment_cluster_firewall.main]
+}
+
+resource "proxmox_virtual_environment_firewall_rules" "hindsight_container" {
+  for_each = var.hindsight_container_ids
+
+  node_name    = var.node_name
+  container_id = each.value
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.internal_access.name
+    comment        = "Internal access (SSH, ICMP)"
+  }
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.hindsight_services.name
+    comment        = "Hindsight (API/MCP, CP UI)"
+  }
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.outbound_internal.name
+    comment        = "Outbound to internal only"
+  }
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.outbound_https.name
+    comment        = "Outbound HTTPS (Docker install/images, embedding model)"
+  }
+
+  depends_on = [proxmox_virtual_environment_firewall_options.hindsight_container]
+}

--- a/modules/firewall/outputs.tf
+++ b/modules/firewall/outputs.tf
@@ -23,6 +23,11 @@ output "vectordb_container_firewall_enabled" {
   value       = { for k, v in proxmox_virtual_environment_firewall_options.vectordb_container : k => v.enabled }
 }
 
+output "hindsight_container_firewall_enabled" {
+  description = "Map of Hindsight agent-memory container IDs with firewall enabled"
+  value       = { for k, v in proxmox_virtual_environment_firewall_options.hindsight_container : k => v.enabled }
+}
+
 output "rag_container_firewall_enabled" {
   description = "Map of RAG engine container IDs with firewall enabled (LlamaIndex)"
   value       = { for k, v in proxmox_virtual_environment_firewall_options.rag_container : k => v.enabled }

--- a/modules/firewall/tests/rule_generation.tftest.hcl
+++ b/modules/firewall/tests/rule_generation.tftest.hcl
@@ -34,6 +34,7 @@ variables {
       redis_default          = 6379
       nautobot_web           = 8080
       vikunja_web            = 3456
+      authelia_portal        = 9091
       zammad_web             = 8080
       ntp                    = 123
       idrac_kvm_r410         = 5410
@@ -699,6 +700,32 @@ run "nautobot_rule_tracks_constant_and_internal_scope" {
   assert {
     condition     = local.nautobot_services_rules[0].proto == "tcp" && local.nautobot_services_rules[0].dport == tostring(var.pipeline_constants.service_ports.nautobot_web)
     error_message = "nautobot rule must be TCP tracking service_ports.nautobot_web, got proto='${local.nautobot_services_rules[0].proto}' dport='${local.nautobot_services_rules[0].dport}'"
+  }
+}
+
+# --- authelia service rules ---
+
+run "authelia_rule_tracks_constant_and_internal_scope" {
+  command = plan
+
+  variables {
+    internal_networks = ["192.168.10.0/24", "192.168.20.0/24"]
+  }
+
+  # Exactly one live rule: TCP authelia_portal (9091) from the internal networks.
+  assert {
+    condition     = length(local.authelia_services_rules) == 1
+    error_message = "authelia_services_rules must be exactly 1 (TCP authelia_portal), got ${length(local.authelia_services_rules)}"
+  }
+
+  assert {
+    condition     = local.authelia_services_rules[0].proto == "tcp" && local.authelia_services_rules[0].dport == tostring(var.pipeline_constants.service_ports.authelia_portal)
+    error_message = "authelia rule must be TCP tracking service_ports.authelia_portal, got proto='${local.authelia_services_rules[0].proto}' dport='${local.authelia_services_rules[0].dport}'"
+  }
+
+  assert {
+    condition     = local.authelia_services_rules[0].source == "192.168.10.0/24,192.168.20.0/24"
+    error_message = "authelia rule source must be the comma-joined internal networks, got '${local.authelia_services_rules[0].source}'"
   }
 }
 

--- a/modules/firewall/tests/rule_generation.tftest.hcl
+++ b/modules/firewall/tests/rule_generation.tftest.hcl
@@ -96,6 +96,10 @@ variables {
       qdrant_http = 6333
       qdrant_grpc = 6334
     }
+    memory_ports = {
+      hindsight_api = 8888
+      hindsight_cp  = 9999
+    }
     ai_log_ports = {
       claude_code    = 10311
       codex_cli      = 10312

--- a/modules/firewall/variables.tf
+++ b/modules/firewall/variables.tf
@@ -87,6 +87,12 @@ variable "nautobot_container_ids" {
   default     = {}
 }
 
+variable "authelia_container_ids" {
+  description = "Map of Authelia container names to their IDs (authelia tag). Native SSO portal / Traefik forwardAuth provider — inbound authelia_portal (9091) from internal; egress outbound-internal only (SQLite local, SMTP relay internal, binary controller-staged)."
+  type        = map(number)
+  default     = {}
+}
+
 variable "vikunja_container_ids" {
   description = "Map of Vikunja container names to their IDs (vikunja tag). Native task-management app — inbound vikunja_web (3456) from internal; egress outbound-internal only (no package-manager egress, binary is controller-staged)."
   type        = map(number)

--- a/modules/firewall/variables.tf
+++ b/modules/firewall/variables.tf
@@ -33,6 +33,12 @@ variable "vectordb_container_ids" {
   default     = {}
 }
 
+variable "hindsight_container_ids" {
+  description = "Map of Hindsight agent-memory container names to their IDs (hindsight tag). Stateless API replicas — inbound 8888/9999 from internal; egress outbound-internal + HTTPS."
+  type        = map(number)
+  default     = {}
+}
+
 variable "rag_container_ids" {
   description = "Map of RAG engine container names to their IDs (LlamaIndex)"
   type        = map(number)
@@ -201,6 +207,7 @@ variable "pipeline_constants" {
     netflow_ports      = map(number)
     notification_ports = map(number)
     vector_db_ports    = map(number)
+    memory_ports       = map(number)
     honeypot_ports     = map(number)
     ai_log_ports       = map(number)
     media_ports        = map(number)

--- a/modules/proxmox-stack/constants.tf
+++ b/modules/proxmox-stack/constants.tf
@@ -141,6 +141,14 @@ locals {
       qdrant_http = 6333
       qdrant_grpc = 6334
     }
+    # Agent memory service (Hindsight, ai VLAN). hindsight_api serves the REST
+    # API and the built-in MCP endpoint (/mcp); hindsight_cp is the Control
+    # Plane admin UI. Two stateless replicas share one Postgres and sit behind
+    # a Traefik load-balanced pool (locals-ingress-backends.tf).
+    memory_ports = {
+      hindsight_api = 8888
+      hindsight_cp  = 9999
+    }
     # AI / LLM log-ingest ports — one dedicated Cribl TCP-JSON receiver per source
     # family (defined in constants-ai-log.tf to keep this file under the shared
     # _file-size 12 KB gate; locals merge across files in the module).

--- a/modules/proxmox-stack/constants.tf
+++ b/modules/proxmox-stack/constants.tf
@@ -28,6 +28,7 @@ locals {
       # every port lives in one place and the ingress table (below) references
       # constants, never literals.
       technitium_web    = 5380
+      authelia_portal   = 9091
       phpipam_web       = 80
       nautobot_web      = 8080
       vikunja_web       = 3456

--- a/modules/proxmox-stack/firewall.tf
+++ b/modules/proxmox-stack/firewall.tf
@@ -34,6 +34,9 @@ module "firewall" {
   # Vector database containers: Qdrant (vectordb tag)
   vectordb_container_ids = local.vectordb_container_ids
 
+  # Hindsight agent-memory containers (hindsight tag) — API 8888 / CP UI 9999
+  hindsight_container_ids = local.hindsight_container_ids
+
   # RAG engine containers: LlamaIndex (rag tag)
   rag_container_ids = local.rag_container_ids
 

--- a/modules/proxmox-stack/firewall.tf
+++ b/modules/proxmox-stack/firewall.tf
@@ -60,6 +60,7 @@ module "firewall" {
   postgres_container_ids = local.postgres_container_ids
   nautobot_container_ids = local.nautobot_container_ids
   vikunja_container_ids  = local.vikunja_container_ids
+  authelia_container_ids = local.authelia_container_ids
   zammad_container_ids   = local.zammad_container_ids
 
   # Ingress (Traefik HA) containers (ingress tag) — define-disabled guest firewall

--- a/modules/proxmox-stack/ingress.tf
+++ b/modules/proxmox-stack/ingress.tf
@@ -9,8 +9,14 @@ locals {
   # name = the hostname label -> https://<name>.<domain>.
   # backend = the container key whose IP is resolved from the inventory.
   # port = a pipeline_constants reference (never a literal, so ports stay DRY).
+  # sso = whether Traefik attaches the Authelia forwardAuth middleware to the
+  #       route (default true when omitted). false for machine/API endpoints
+  #       (clients cannot do a browser login) and for apps whose non-browser
+  #       clients authenticate natively (e.g. Plex apps).
   ingress_services = {
-    plex             = { backend = "plex", port = local.pipeline_constants.media_ports.plex_web }
+    # Authelia portal itself — never gated (it IS the login page).
+    authelia         = { backend = "authelia", port = local.pipeline_constants.service_ports.authelia_portal, sso = false }
+    plex             = { backend = "plex", port = local.pipeline_constants.media_ports.plex_web, sso = false } # Plex clients auth via plex.tv
     seerr            = { backend = "seerr", port = local.pipeline_constants.media_ports.seerr_web }
     sonarr           = { backend = "sonarr", port = local.pipeline_constants.media_ports.sonarr_web }
     radarr           = { backend = "radarr", port = local.pipeline_constants.media_ports.radarr_web }
@@ -19,21 +25,21 @@ locals {
     prowlarr         = { backend = "download-vpn", port = local.pipeline_constants.media_ports.prowlarr_web }
     technitium       = { backend = "technitium-dns", port = local.pipeline_constants.service_ports.technitium_web }
     phpipam          = { backend = "phpipam", port = local.pipeline_constants.service_ports.phpipam_web }
-    nautobot         = { backend = "nautobot", port = local.pipeline_constants.service_ports.nautobot_web } # native IPAM/DCIM UI; Postgres has NO ingress row (in-cluster 5432 only)
-    vikunja          = { backend = "vikunja", port = local.pipeline_constants.service_ports.vikunja_web }
+    nautobot         = { backend = "nautobot", port = local.pipeline_constants.service_ports.nautobot_web, sso = false } # GraphQL dynamic-inventory clients; native IPAM/DCIM UI; Postgres has NO ingress row (in-cluster 5432 only)
+    vikunja          = { backend = "vikunja", port = local.pipeline_constants.service_ports.vikunja_web, sso = false }   # MCP API tokens hit /api/v1 on this host
     "object-storage" = { backend = "s3", port = local.pipeline_constants.service_ports.object_storage_console }
     # RustFS S3 API fronted by a valid-TLS hostname. Path-style S3 format.
-    s3 = { backend = "s3", port = local.pipeline_constants.service_ports.object_storage_s3 }
+    s3 = { backend = "s3", port = local.pipeline_constants.service_ports.object_storage_s3, sso = false } # machine S3 clients
     # openbao is fronted as a load-balanced pool (openbao_backends below).
     mailpit           = { backend = "mailpit", port = local.pipeline_constants.notification_ports.mailpit_web }
-    ntfy              = { backend = "ntfy", port = local.pipeline_constants.notification_ports.ntfy_http }
-    "honeypot-notify" = { backend = "honeypot-notify", port = local.pipeline_constants.honeypot_ports.apprise_api }
-    homeassistant     = { backend = "homeassistant", port = local.pipeline_constants.service_ports.homeassistant_web }
+    ntfy              = { backend = "ntfy", port = local.pipeline_constants.notification_ports.ntfy_http, sso = false }             # publish clients POST here
+    "honeypot-notify" = { backend = "honeypot-notify", port = local.pipeline_constants.honeypot_ports.apprise_api, sso = false }    # machine notify API
+    homeassistant     = { backend = "homeassistant", port = local.pipeline_constants.service_ports.homeassistant_web, sso = false } # companion apps auth natively
     openproject       = { backend = "openproject", port = local.pipeline_constants.service_ports.openproject_web }
     prometheus        = { backend = "prometheus", port = local.pipeline_constants.service_ports.prometheus_web }
     # llm is fronted as a load-balanced router pool (llm_router_backends below).
     chat   = { backend = "open-webui", port = local.pipeline_constants.service_ports.open_webui_web }
-    qdrant = { backend = "qdrant", port = local.pipeline_constants.vector_db_ports.qdrant_http }
+    qdrant = { backend = "qdrant", port = local.pipeline_constants.vector_db_ports.qdrant_http, sso = false } # vector API for agents/MCP
     # AI orchestration stack UIs (ai VLAN) + Langfuse LLM observability (siem VLAN).
     n8n          = { backend = "n8n", port = local.pipeline_constants.service_ports.n8n_web }
     dify         = { backend = "dify", port = local.pipeline_constants.service_ports.dify_web }
@@ -42,20 +48,20 @@ locals {
     agentgateway = { backend = "agentgateway", port = local.pipeline_constants.service_ports.agentgateway_admin }
     # MCP tool-plane front door (the `llm`-alias pattern, for tools): clients
     # dial https://mcp.<domain>/<target>/mcp; `agentgateway` stays the admin UI.
-    mcp = { backend = "agentgateway", port = local.pipeline_constants.service_ports.agentgateway_proxy }
+    mcp = { backend = "agentgateway", port = local.pipeline_constants.service_ports.agentgateway_proxy, sso = false } # MCP tool clients
     # LangGraph (self-hosted): the `langgraph dev` server API + its Agent Chat UI,
     # both backed by the one `langgraph` guest. Chat UI is the primary play surface;
     # the API host also lets browser Studio point its ?baseUrl at it.
-    langgraph        = { backend = "langgraph", port = local.pipeline_constants.service_ports.langgraph_api }
+    langgraph        = { backend = "langgraph", port = local.pipeline_constants.service_ports.langgraph_api, sso = false } # API + Studio ?baseUrl clients
     "langgraph-chat" = { backend = "langgraph", port = local.pipeline_constants.service_ports.agent_chat_ui_web }
     # Hermes agent inbound webhook front door: https://hermes.<domain>/webhooks/<name>
     # -> hermes-agent container : hermes_webhook (HMAC-signed, event-driven trigger
     # for the one non-A2A agent). Guest firewall opens the port from internal.
-    hermes = { backend = "hermes-agent", port = local.pipeline_constants.service_ports.hermes_webhook }
+    hermes = { backend = "hermes-agent", port = local.pipeline_constants.service_ports.hermes_webhook, sso = false } # HMAC-signed webhooks
     # Hermes agent inbound job-submission API: https://hermes-api.<domain>/v1/runs
     # -> hermes-agent container : hermes_api (`hermes gateway` api_server platform,
     # bearer-authenticated). The sanctioned non-exec job path; internal-only firewall.
-    "hermes-api"    = { backend = "hermes-agent", port = local.pipeline_constants.service_ports.hermes_api }
+    "hermes-api"    = { backend = "hermes-agent", port = local.pipeline_constants.service_ports.hermes_api, sso = false } # bearer-authenticated job API
     smokeping       = { backend = "smokeping", port = local.pipeline_constants.service_ports.smokeping_web }
     "haproxy-stats" = { backend = "haproxy", port = local.pipeline_constants.service_ports.haproxy_stats }
   }

--- a/modules/proxmox-stack/inventory_publish.tf
+++ b/modules/proxmox-stack/inventory_publish.tf
@@ -177,11 +177,11 @@ resource "aws_s3_object" "ansible_inventory" {
       condition = alltrue([
         for k in [
           "service_ports", "syslog_ports", "syslog_port_map", "netflow_ports",
-          "notification_ports", "vector_db_ports", "media_ports",
+          "notification_ports", "vector_db_ports", "memory_ports", "media_ports",
           "ai_log_ports", "ai_log_routing",
         ] : can(local.ansible_inventory.constants[k])
       ])
-      error_message = "pipeline_constants is missing one or more required keys (service_ports, syslog_ports, syslog_port_map, netflow_ports, notification_ports, vector_db_ports, media_ports, ai_log_ports, ai_log_routing). Inspect constants.tf."
+      error_message = "pipeline_constants is missing one or more required keys (service_ports, syslog_ports, syslog_port_map, netflow_ports, notification_ports, vector_db_ports, memory_ports, media_ports, ai_log_ports, ai_log_routing). Inspect constants.tf."
     }
     precondition {
       condition = alltrue([

--- a/modules/proxmox-stack/locals-authelia.tf
+++ b/modules/proxmox-stack/locals-authelia.tf
@@ -1,0 +1,13 @@
+# Authelia tag-filter local — same locals-split treatment as locals-vikunja.tf
+# (locals merge across files in a module). Consumed by the firewall module call
+# in main.tf.
+
+locals {
+  # Authelia LXC (authelia tag) — native SSO portal / Traefik forwardAuth
+  # provider, portal + authz API on authelia_portal (9091), state in local
+  # SQLite. modules/firewall opens 9091 to it from internal.
+  authelia_container_ids = {
+    for k, v in var.containers : k => v.vm_id
+    if contains(coalesce(try(v.tags, null), []), "authelia")
+  }
+}

--- a/modules/proxmox-stack/locals-ingress-backends.tf
+++ b/modules/proxmox-stack/locals-ingress-backends.tf
@@ -72,6 +72,9 @@ locals {
         name = name
         ip   = local.container_address[svc.backend]
         port = svc.port
+        # Authelia forwardAuth gate flag, consumed by the ansible traefik role.
+        # Defaults true (gated) unless the table row opts out (sso = false).
+        sso = try(svc.sso, true)
       }
       if contains(keys(var.containers), svc.backend)
     ],
@@ -85,6 +88,7 @@ locals {
         # Consumers default scheme=http / insecure_tls=false when absent.
         scheme       = "https"
         insecure_tls = true
+        sso          = true # browser UI — gated
       },
       {
         # Splunk management / REST API (splunkd, 8089) fronted at
@@ -97,6 +101,7 @@ locals {
         port         = local.pipeline_constants.service_ports.splunk_mgmt
         scheme       = "https"
         insecure_tls = true
+        sso          = false # REST API clients (CLI, automation)
       },
       {
         # Splunk HEC (8088) fronted at splunk-hec.<domain> on the standard
@@ -109,6 +114,7 @@ locals {
         port         = local.pipeline_constants.service_ports.splunk_hec
         scheme       = "https"
         insecure_tls = true
+        sso          = false # HEC token senders (Cribl edges)
       }
     ],
     # Proxmox cluster UI apex (the ingress subdomain apex), load-balanced.
@@ -126,6 +132,7 @@ locals {
         insecure_tls = true
         sticky       = true
         health_check = true
+        sso          = false # tofu provider / API clients share this route
       }
     ] : [],
     # OpenBao HA: one openbao.<domain> route load-balancing the Raft peers.
@@ -146,6 +153,7 @@ locals {
         sticky            = true
         health_check      = true
         health_check_path = "/v1/sys/health?standbyok=true"
+        sso               = false # token/AppRole/JWT API clients (CLI, Terrakube, roles)
       }
     ] : [],
     # LiteLLM router pool: llm.<domain> load-balancing the stateless routers.
@@ -157,6 +165,7 @@ locals {
         port              = local.pipeline_constants.service_ports.llm_router_api
         health_check      = true
         health_check_path = "/health/liveliness"
+        sso               = false # OpenAI-compatible API clients
       }
     ] : [],
     # Hindsight agent memory: one hindsight.<domain> route load-balancing the
@@ -190,6 +199,7 @@ locals {
         port         = local.pipeline_constants.service_ports.zammad_web
         sticky       = true
         health_check = true
+        sso          = true # browser UI — gated
       }
     ] : [],
     # IaC automation platform (Terrakube + Semaphore UI) on the iac-platform VM
@@ -202,15 +212,18 @@ locals {
     # off nightly — consumers must treat these routes as daytime-available.
     contains(keys(var.vms), "iac-platform") ? [
       for svc in [
+        # UI hosts stay gated (sso omitted -> true); the API/registry/dex hosts
+        # serve machine clients (CLI, dex OIDC redirects) and opt out.
         { name = "terrakube", port = local.pipeline_constants.iac_platform_ports.terrakube_ui },
-        { name = "terrakube-api", port = local.pipeline_constants.iac_platform_ports.terrakube_api },
-        { name = "terrakube-registry", port = local.pipeline_constants.iac_platform_ports.terrakube_registry },
-        { name = "terrakube-dex", port = local.pipeline_constants.iac_platform_ports.terrakube_dex },
+        { name = "terrakube-api", port = local.pipeline_constants.iac_platform_ports.terrakube_api, sso = false },
+        { name = "terrakube-registry", port = local.pipeline_constants.iac_platform_ports.terrakube_registry, sso = false },
+        { name = "terrakube-dex", port = local.pipeline_constants.iac_platform_ports.terrakube_dex, sso = false },
         { name = "semaphore", port = local.pipeline_constants.iac_platform_ports.semaphore_web },
         ] : {
         name = svc.name
         ip   = local.vm_address["iac-platform"]
         port = svc.port
+        sso  = try(svc.sso, true)
       }
     ] : []
   )

--- a/modules/proxmox-stack/locals-ingress-backends.tf
+++ b/modules/proxmox-stack/locals-ingress-backends.tf
@@ -36,6 +36,19 @@ locals {
     if contains(keys(var.containers), k)
   ]
 
+  # Hindsight agent-memory pool. Every LXC tagged "hindsight" is load-balanced
+  # behind a single hindsight.<domain> route with health checks. The replicas
+  # are stateless (all state in the ai-VLAN Postgres cluster), so no sticky.
+  # Clients — agentgateway's MCP target, Hermes remote memory, Claude Code —
+  # all dial this one pooled hostname.
+  hindsight_backend_keys = sort([
+    for k, v in var.containers : k
+    if contains(coalesce(try(v.tags, null), []), "hindsight")
+  ])
+  hindsight_backends = [
+    for k in local.hindsight_backend_keys : local.container_address[k]
+  ]
+
   # Zammad HA backend pool. Every LXC tagged "zammad" is load-balanced
   # behind a single zammad.<domain> route with sticky sessions.
   zammad_backend_keys = sort([
@@ -144,6 +157,28 @@ locals {
         port              = local.pipeline_constants.service_ports.llm_router_api
         health_check      = true
         health_check_path = "/health/liveliness"
+      }
+    ] : [],
+    # Hindsight agent memory: one hindsight.<domain> route load-balancing the
+    # stateless API replicas. No sticky — every replica serves every bank from
+    # the same Postgres. /health is the upstream readiness endpoint.
+    length(local.hindsight_backends) > 0 ? [
+      {
+        name              = "hindsight"
+        backends          = local.hindsight_backends
+        port              = local.pipeline_constants.memory_ports.hindsight_api
+        health_check      = true
+        health_check_path = "/health"
+      },
+      {
+        # Control Plane admin UI (access-key gated in the app). Same attribute
+        # shape as the API route above — both arms of the conditional must
+        # unify to one object type.
+        name              = "hindsight-cp"
+        backends          = local.hindsight_backends
+        port              = local.pipeline_constants.memory_ports.hindsight_cp
+        health_check      = false
+        health_check_path = "/"
       }
     ] : [],
     # Zammad HA: one zammad.<domain> route load-balancing the application nodes.

--- a/modules/proxmox-stack/locals-memory.tf
+++ b/modules/proxmox-stack/locals-memory.tf
@@ -1,0 +1,19 @@
+# Database + agent-memory tag-filter locals — split from locals.tf to keep it
+# under the shared _file-size workflow's 12 KB gate (locals merge across files
+# in the module, same split as locals-honeypot.tf / locals-ingress-backends.tf).
+locals {
+  # Postgres LXCs — the shared native cluster ("postgres" tag) plus the ai-VLAN
+  # memory cluster ("postgres_ai" tag; primary + streaming standby backing
+  # Hindsight). Both take the same postgres-svc firewall shape (5432 from
+  # internal); Ansible grouping stays separate via the distinct tags.
+  postgres_container_ids = {
+    for k, v in var.containers : k => v.vm_id
+    if length(setintersection(toset(coalesce(try(v.tags, null), [])), toset(["postgres", "postgres_ai"]))) > 0
+  }
+
+  # Hindsight agent-memory containers (hindsight tag) — stateless API replicas.
+  hindsight_container_ids = {
+    for k, v in var.containers : k => v.vm_id
+    if contains(coalesce(try(v.tags, null), []), "hindsight")
+  }
+}

--- a/modules/proxmox-stack/locals.tf
+++ b/modules/proxmox-stack/locals.tf
@@ -230,12 +230,8 @@ locals {
     if contains(coalesce(try(v.tags, null), []), "hermes-agent")
   }
 
-  # Postgres LXC (postgres tag) — the shared native Postgres backing Nautobot
-  # (and later Vikunja/EspoCRM). modules/firewall opens 5432 to it from internal.
-  postgres_container_ids = {
-    for k, v in var.containers : k => v.vm_id
-    if contains(coalesce(try(v.tags, null), []), "postgres")
-  }
+  # postgres_container_ids + hindsight_container_ids live in
+  # locals-memory.tf to keep this file under the 12 KB size gate.
 
   # Nautobot LXC (nautobot tag) — native IPAM/DCIM source of truth, web UI on
   # nautobot_web (8080). modules/firewall opens 8080 to it from internal.

--- a/modules/proxmox-stack/tests/ansible_inventory_contract.tftest.hcl
+++ b/modules/proxmox-stack/tests/ansible_inventory_contract.tftest.hcl
@@ -174,6 +174,15 @@ run "ansible_inventory_constants_vector_db_ports_exists" {
   }
 }
 
+run "ansible_inventory_constants_memory_ports_exists" {
+  command = plan
+
+  assert {
+    condition     = can(output.ansible_inventory.constants.memory_ports)
+    error_message = "ansible_inventory.constants must contain 'memory_ports' key"
+  }
+}
+
 run "ansible_inventory_constants_media_ports_exists" {
   command = plan
 

--- a/modules/proxmox-stack/tests/ansible_inventory_contract.tftest.hcl
+++ b/modules/proxmox-stack/tests/ansible_inventory_contract.tftest.hcl
@@ -365,6 +365,29 @@ run "ansible_inventory_ingress_route_table" {
     error_message = "ingress must front seerr at 192.168.70.211:5055"
   }
 
+  # Every published ingress row carries an explicit sso flag (the forwardAuth
+  # gate contract — the ansible consumer treats a missing flag as ungated, so
+  # an absent key would silently drop a route out of the SSO gate).
+  assert {
+    condition = alltrue([
+      for r in output.ansible_inventory.ingress : can(r.sso)
+    ])
+    error_message = "every ingress row must carry an explicit sso flag"
+  }
+
+  # Table rows without an explicit opt-out default to gated (sso = true):
+  # seerr omits sso in ingress_services; plex opts out (native client auth).
+  assert {
+    condition = length([
+      for r in output.ansible_inventory.ingress :
+      r if r.name == "seerr" && r.sso == true
+      ]) == 1 && length([
+      for r in output.ansible_inventory.ingress :
+      r if r.name == "plex" && r.sso == false
+    ]) == 1
+    error_message = "sso must default true for unmarked rows (seerr) and honor explicit opt-outs (plex)"
+  }
+
   # Services whose backend container is absent are skipped (sonarr not deployed).
   assert {
     condition     = length([for r in output.ansible_inventory.ingress : r if r.name == "sonarr"]) == 0

--- a/modules/proxmox-stack/tests/firewall_filtering.tftest.hcl
+++ b/modules/proxmox-stack/tests/firewall_filtering.tftest.hcl
@@ -564,6 +564,34 @@ run "vikunja_tag_filters_correctly" {
   }
 }
 
+# --- authelia_container_ids test ---
+
+run "authelia_tag_filters_correctly" {
+  command = plan
+
+  variables {
+    containers = {
+      "authelia" = {
+        vm_id     = 100050
+        hostname  = "authelia"
+        vlan      = "mgmt"
+        ip_config = { ipv4_address = "192.168.5.6/24" }
+        tags      = ["terraform", "container", "authelia"]
+      }
+    }
+  }
+
+  assert {
+    condition     = local.authelia_container_ids["authelia"] == 100050 && length(local.authelia_container_ids) == 1
+    error_message = "authelia-tagged container must be the sole member of authelia_container_ids"
+  }
+
+  assert {
+    condition     = !contains(keys(local.pipeline_container_ids), "authelia")
+    error_message = "authelia must not land in pipeline_container_ids"
+  }
+}
+
 # A generic 'database'-tagged guest (e.g. mssql) must NOT be pulled into
 # postgres_container_ids — only the specific 'postgres' tag opens the 5432 rule.
 run "generic_database_tag_not_in_postgres_ids" {

--- a/modules/proxmox-stack/tests/locals.tftest.hcl
+++ b/modules/proxmox-stack/tests/locals.tftest.hcl
@@ -392,6 +392,20 @@ run "pipeline_constants_vector_db_ports" {
   }
 }
 
+run "pipeline_constants_memory_ports" {
+  command = plan
+
+  assert {
+    condition     = local.pipeline_constants.memory_ports.hindsight_api == 8888
+    error_message = "hindsight_api port should be 8888"
+  }
+
+  assert {
+    condition     = local.pipeline_constants.memory_ports.hindsight_cp == 9999
+    error_message = "hindsight_cp port should be 9999"
+  }
+}
+
 run "pipeline_constants_db_ports" {
   command = plan
 


### PR DESCRIPTION
## Summary
Promotes the current state of `develop` to `main` (Authelia SSO ingress + Hindsight agent-memory service).

## Notes
- Merge commit only — `main`'s ruleset bans squash and rebase.
- Merging triggers release-please on `main`; versioning is owned there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)