### PR TITLE
fix(ingress): explicit sso flags on hindsight routes

### DIFF
--- a/modules/proxmox-stack/locals-ingress-backends.tf
+++ b/modules/proxmox-stack/locals-ingress-backends.tf
@@ -178,6 +178,7 @@ locals {
         port              = local.pipeline_constants.memory_ports.hindsight_api
         health_check      = true
         health_check_path = "/health"
+        sso               = false # agent/machine memory API
       },
       {
         # Control Plane admin UI (access-key gated in the app). Same attribute
@@ -188,6 +189,7 @@ locals {
         port              = local.pipeline_constants.memory_ports.hindsight_cp
         health_check      = false
         health_check_path = "/"
+        sso               = true # browser admin UI — gated
       }
     ] : [],
     # Zammad HA: one zammad.<domain> route load-balancing the application nodes.


### PR DESCRIPTION
Follow-up to #677/#675: the hindsight rows merged without the now-required explicit `sso` flag. `hindsight` (machine memory API) opts out; `hindsight-cp` (browser admin UI) is gated. 119 module tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)