### PR TITLE
feat(ssh): retire the ansible-guest private-key copy (null_resource)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -179,9 +179,8 @@ module "homelab" {
     homeauto  = 80
     nonprod   = 90
   })
-  vm_ssh_private_key = ephemeral.vault_kv_secret_v2.proxmox.data.VM_SSH_PRIVATE_KEY
-  vm_ssh_public_key  = local.deployment.vm_ssh_public_key
-  vms                = try(local.deployment.vms, {})
+  vm_ssh_public_key = local.deployment.vm_ssh_public_key
+  vms               = try(local.deployment.vms, {})
 
   inventory_bucket = var.inventory_bucket
   inventory_key    = var.inventory_key

--- a/migrations.tf
+++ b/migrations.tf
@@ -40,11 +40,6 @@ moved {
   to   = module.homelab.module.firewall
 }
 
-moved {
-  from = null_resource.ansible_ssh_key_setup
-  to   = module.homelab.null_resource.ansible_ssh_key_setup
-}
-
 # The former AWS inventory object remains available during the migration soak.
 # Terrakube creates the replacement in RustFS; retire the orphaned AWS object
 # separately only after every Ansible consumer has proven the native path.

--- a/modules/proxmox-stack/main.tf
+++ b/modules/proxmox-stack/main.tf
@@ -190,33 +190,8 @@ module "rack_server_cluster" {
   rack_servers = var.rack_servers
 }
 
-# Secure SSH key provisioning for Ansible VM
-resource "null_resource" "ansible_ssh_key_setup" {
-  count = contains(keys(var.vms), "ansible") ? 1 : 0
-
-  depends_on = [module.vms]
-
-  connection {
-    type        = "ssh"
-    user        = var.vms["ansible"].user_account.username
-    private_key = var.vm_ssh_private_key
-    host        = cidrhost(var.vms["ansible"].ip_config.ipv4_address, 0)
-    timeout     = "2m"
-  }
-
-  provisioner "file" {
-    content     = var.vm_ssh_private_key
-    destination = "/home/${var.vms["ansible"].user_account.username}/.ssh/id_ed25519"
-  }
-
-  provisioner "remote-exec" {
-    inline = [
-      "chmod 600 /home/${var.vms["ansible"].user_account.username}/.ssh/id_ed25519",
-      "chown ${var.vms["ansible"].user_account.username}:${var.vms["ansible"].user_account.username} /home/${var.vms["ansible"].user_account.username}/.ssh/id_ed25519"
-    ]
-  }
-
-  triggers = {
-    vm_id = module.vms.vm_ids["ansible"]
-  }
-}
+# The former null_resource.ansible_ssh_key_setup (copying the shared VM
+# private key onto the ansible control guest) is retired: automation now
+# authenticates with short-TTL certificates from the OpenBao SSH client CA
+# (ssh-certificate-authority ADR), and the control guest is an LXC converged
+# over pct. Verified absent on the live guest before removal.

--- a/modules/proxmox-stack/tests/ansible_inventory_contract.tftest.hcl
+++ b/modules/proxmox-stack/tests/ansible_inventory_contract.tftest.hcl
@@ -63,7 +63,6 @@ override_module {
 
 variables {
   vm_ssh_public_key       = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITestKeyData test@test"
-  vm_ssh_private_key      = "-----BEGIN OPENSSH PRIVATE KEY-----\ntest\n-----END OPENSSH PRIVATE KEY-----"
   proxmox_ssh_private_key = "-----BEGIN OPENSSH PRIVATE KEY-----\ntest\n-----END OPENSSH PRIVATE KEY-----"
   # vlan_ids uses its variable default (single source of truth); network_cidrs is
   # derived from it as 192.168.<vlan_id>.0/24 — no duplicated VLAN/CIDR list.

--- a/modules/proxmox-stack/tests/firewall_filtering.tftest.hcl
+++ b/modules/proxmox-stack/tests/firewall_filtering.tftest.hcl
@@ -64,7 +64,6 @@ override_module {
 
 variables {
   vm_ssh_public_key       = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITestKeyData test@test"
-  vm_ssh_private_key      = "-----BEGIN OPENSSH PRIVATE KEY-----\ntest\n-----END OPENSSH PRIVATE KEY-----"
   proxmox_ssh_private_key = "-----BEGIN OPENSSH PRIVATE KEY-----\ntest\n-----END OPENSSH PRIVATE KEY-----"
   # vlan_ids uses its variable default (single source of truth); network_cidrs is
   # derived from it as 192.168.<vlan_id>.0/24 — no duplicated VLAN/CIDR list.

--- a/modules/proxmox-stack/tests/locals.tftest.hcl
+++ b/modules/proxmox-stack/tests/locals.tftest.hcl
@@ -70,7 +70,6 @@ variables {
   # derived from it as 192.168.<vlan_id>.0/24 — no duplicated VLAN/CIDR list.
   network_cidrs           = { for name, id in var.vlan_ids : name => "192.168.${id}.0/24" }
   vm_ssh_public_key       = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITestKeyData test@test"
-  vm_ssh_private_key      = "-----BEGIN OPENSSH PRIVATE KEY-----\ntest\n-----END OPENSSH PRIVATE KEY-----"
   proxmox_ssh_private_key = "-----BEGIN OPENSSH PRIVATE KEY-----\ntest\n-----END OPENSSH PRIVATE KEY-----"
 }
 

--- a/modules/proxmox-stack/tests/splunk_protection.tftest.hcl
+++ b/modules/proxmox-stack/tests/splunk_protection.tftest.hcl
@@ -62,7 +62,6 @@ override_module {
 
 variables {
   vm_ssh_public_key       = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITestKeyData test@test"
-  vm_ssh_private_key      = "-----BEGIN OPENSSH PRIVATE KEY-----\ntest\n-----END OPENSSH PRIVATE KEY-----"
   proxmox_ssh_private_key = "-----BEGIN OPENSSH PRIVATE KEY-----\ntest\n-----END OPENSSH PRIVATE KEY-----"
   # vlan_ids uses its variable default (single source of truth); network_cidrs is
   # derived from it as 192.168.<vlan_id>.0/24 — no duplicated VLAN/CIDR list.

--- a/modules/proxmox-stack/tests/variables.tftest.hcl
+++ b/modules/proxmox-stack/tests/variables.tftest.hcl
@@ -62,7 +62,6 @@ override_module {
 # Shared valid defaults for all runs
 variables {
   vm_ssh_public_key       = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITestKeyData test@test"
-  vm_ssh_private_key      = "-----BEGIN OPENSSH PRIVATE KEY-----\ntest\n-----END OPENSSH PRIVATE KEY-----"
   proxmox_ssh_private_key = "-----BEGIN OPENSSH PRIVATE KEY-----\ntest\n-----END OPENSSH PRIVATE KEY-----"
   # vlan_ids uses its variable default (single source of truth); network_cidrs is
   # derived from it as 192.168.<vlan_id>.0/24 — no duplicated VLAN/CIDR list.
@@ -303,18 +302,6 @@ run "vm_ssh_public_key_invalid_content_rejected" {
 
   expect_failures = [
     var.vm_ssh_public_key,
-  ]
-}
-
-run "vm_ssh_private_key_invalid_content_rejected" {
-  command = plan
-
-  variables {
-    vm_ssh_private_key = "relative/ssh/key"
-  }
-
-  expect_failures = [
-    var.vm_ssh_private_key,
   ]
 }
 

--- a/modules/proxmox-stack/variables-vms.tf
+++ b/modules/proxmox-stack/variables-vms.tf
@@ -137,17 +137,6 @@ variable "vm_ssh_public_key" {
   }
 }
 
-variable "vm_ssh_private_key" {
-  description = "Ephemeral SSH private key content for VM provisioning"
-  type        = string
-  sensitive   = true
-  ephemeral   = true
-  validation {
-    condition     = can(regex("^-----BEGIN", trimspace(var.vm_ssh_private_key)))
-    error_message = "SSH private key must be PEM/OpenSSH private-key content."
-  }
-}
-
 # Cloud-init configuration
 variable "ansible_cloud_init_file" {
   description = "Path to the cloud-init configuration file for Ansible server"


### PR DESCRIPTION
## What (SSH-CA Phase D)

Remove `null_resource.ansible_ssh_key_setup` — it copied the shared VM SSH **private** key onto the ansible control guest over SSH, the single worst artifact of the shared-static-key model. Also removes the now-unused `vm_ssh_private_key` module variable + root wiring and the migration moved-block.

## Why safe (verified)

- Automation now authenticates with **short-TTL certs from the OpenBao SSH client CA** — live-proven tonight across PVE + VMs.
- The control guest is an **LXC converged over pct** (not a VM), so the resource's `count` is 0 under the current deployment — the plan is a no-op for real infrastructure (at most a state-only removal of an orphaned null_resource).
- **Verified absent on the live guest** before removal: no `id_ed25519` exists under any home on the control guest (the LXC rebuild already dropped the old copy).
- `tofu fmt -check` / `validate` / `test` clean; the OpenBao KV ephemeral stays (provider creds still use it).

Part of the static-key retirement (tofu-proxmox#637). The provider `ssh{}` static key remains a documented break-glass residual (#661).