### PR TITLE
feat(container): resolve guest DNS via homelab resolvers, not the node's upstream

### DIFF
--- a/modules/proxmox-container/main.tf
+++ b/modules/proxmox-container/main.tf
@@ -59,11 +59,16 @@ resource "proxmox_virtual_environment_container" "containers" {
       }
     }
 
-    # DNS search domain for FQDN resolution
+    # DNS search domain + explicit nameservers. servers points guests at the
+    # homelab's own resolvers (Technitium/Pi-hole, inside the internal networks
+    # the outbound-internal firewall group already permits) instead of inheriting
+    # the node's upstream gateway resolver, which a DROP-policy guest cannot reach.
+    # Empty servers list => omit the arg => inherit the node's resolv.conf.
     dynamic "dns" {
-      for_each = var.domain != "" ? [1] : []
+      for_each = var.domain != "" || length(var.dns_servers) > 0 ? [1] : []
       content {
-        domain = var.domain
+        domain  = var.domain != "" ? var.domain : null
+        servers = length(var.dns_servers) > 0 ? var.dns_servers : null
       }
     }
 

--- a/modules/proxmox-container/variables.tf
+++ b/modules/proxmox-container/variables.tf
@@ -88,6 +88,19 @@ variable "domain" {
   default     = ""
 }
 
+variable "dns_servers" {
+  description = <<-EOT
+    Nameservers for the container's resolv.conf (the homelab's own authoritative
+    resolvers — Technitium primary, Pi-hole secondary). Set explicitly so guests
+    resolve via internal DNS that the outbound-internal firewall group already
+    permits, rather than inheriting the Proxmox node's upstream gateway resolver
+    (which sits on a VLAN a DROP-policy guest cannot egress to). Empty = inherit
+    the node's resolv.conf (previous behaviour).
+  EOT
+  type        = list(string)
+  default     = []
+}
+
 variable "environment" {
   description = "Environment name for resource tagging"
   type        = string

--- a/modules/proxmox-stack/main.tf
+++ b/modules/proxmox-stack/main.tf
@@ -134,6 +134,7 @@ module "containers" {
   environment       = var.environment
   default_datastore = var.datastore_default
   domain            = var.domain
+  dns_servers       = local.dns_servers
 
   depends_on = [module.pools, module.storage]
 }

--- a/modules/proxmox-stack/tests/locals.tftest.hcl
+++ b/modules/proxmox-stack/tests/locals.tftest.hcl
@@ -98,6 +98,19 @@ run "container_ipv4_uses_vlan_cidr" {
     error_message = "dns-VLAN gateway should be 192.168.2.1, got ${local.container_gateway["technitium-dns"]}"
   }
 
+  # Guests must resolve via the homelab's own resolver (an internal address the
+  # outbound-internal firewall group permits), not the node's upstream gateway
+  # resolver a DROP-policy guest cannot reach. dns_servers is the technitium-dns
+  # address (CIDR stripped), fed into every container's initialization.dns.servers.
+  # Asserted by derivation, not a literal, so no real address appears here.
+  assert {
+    condition = contains(
+      local.dns_servers,
+      split("/", local.container_ipv4["technitium-dns"])[0]
+    )
+    error_message = "dns_servers must include the technitium-dns resolver address, got ${jsonencode(local.dns_servers)}"
+  }
+
   # DHCP-first guest short-circuits cidrhost — the positional VMID must never
   # be interpreted as a /24 host number.
   assert {


### PR DESCRIPTION
## Summary

Firewalled (DROP-policy) LXC guests could not resolve any FQDN. They inherited
the Proxmox node's `resolv.conf`, whose resolver sits on an infra VLAN **outside
the guest CIDR map** — the `outbound-internal` firewall group never permits
egress there. Observed tonight: the Authelia guest `getent`-failed `mailpit`
even with DNS otherwise healthy.

This sets each container's `initialization.dns.servers` to `local.dns_servers`
(Technitium primary, Pi-hole secondary) — internal addresses the
`outbound-internal` group **already** permits — so guests resolve via the
homelab's own authoritative DNS instead of the upstream gateway resolver. An
empty list preserves the previous inherit-the-node behaviour.

## Why this over a firewall hole

The alternative (poke a port-53 rule to the node's upstream resolver) would open
egress to an IP that isn't otherwise in the tofu model, against the repo's
no-unmodeled-IP grain. Pointing guests at the resolvers already inside the
permitted internal networks needs **no** new firewall rule.

## Safety

`tofu plan`: **63 containers updated in-place, 0 replacements, 0 destroys.** The
only change is `dns.servers` gaining the resolver addresses.

## Tests

`tofu test` (30 passed) — added a derivation assertion that `dns_servers`
includes the technitium-dns resolver address (no literal IP in the test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)