### PR TITLE
fix(dns): pin container resolvers explicitly (durable #688 fix)

### DIFF
--- a/modules/proxmox-container/main.tf
+++ b/modules/proxmox-container/main.tf
@@ -59,11 +59,18 @@ resource "proxmox_virtual_environment_container" "containers" {
       }
     }
 
-    # DNS search domain for FQDN resolution
+    # DNS search domain + explicit resolvers. Without explicit servers a
+    # container inherits the host node's /etc/resolv.conf at creation and keeps
+    # it forever, so guests created against different nodes/points-in-time drift
+    # onto different resolvers — when one resolver was retired, exactly the
+    # guests that had inherited it lost DNS, taking down the OpenBao->Terrakube
+    # workload-identity path estate-wide (2026-07-17). Pinning servers here
+    # (same derived list the VMs use) makes the resolver deterministic.
     dynamic "dns" {
-      for_each = var.domain != "" ? [1] : []
+      for_each = var.domain != "" || length(var.dns_servers) > 0 ? [1] : []
       content {
-        domain = var.domain
+        domain  = var.domain != "" ? var.domain : null
+        servers = length(var.dns_servers) > 0 ? var.dns_servers : null
       }
     }
 

--- a/modules/proxmox-container/variables.tf
+++ b/modules/proxmox-container/variables.tf
@@ -88,6 +88,12 @@ variable "domain" {
   default     = ""
 }
 
+variable "dns_servers" {
+  description = "Resolver IPs for guest DNS. Derived by the root module from the DNS containers' addresses — never literals. Empty preserves node-inherited behavior."
+  type        = list(string)
+  default     = []
+}
+
 variable "environment" {
   description = "Environment name for resource tagging"
   type        = string

--- a/modules/proxmox-stack/locals.tf
+++ b/modules/proxmox-stack/locals.tf
@@ -95,10 +95,11 @@ locals {
   # VGA type validation helper
   valid_vga_types = ["std", "cirrus", "vmware", "qxl"]
 
-  # Resolver list for guest cloud-init DNS: Technitium primary, Pi-hole
-  # secondary. Derived via container_ipv4 (honors static ip pins) so no
-  # literal resolver IPs exist anywhere in the repo. Containers inherit the
-  # node's resolv.conf instead; this feeds VMs only.
+  # Resolver list for guest DNS: Technitium primary, Pi-hole secondary. Derived
+  # via container_ipv4 (honors static ip pins) so no literal resolver IPs exist
+  # anywhere in the repo. Feeds BOTH VMs and containers (the container module
+  # now pins these explicitly instead of silently inheriting the host node's
+  # resolv.conf, which had drifted and broke DNS estate-wide on 2026-07-17).
   dns_servers = [
     for name in ["technitium-dns", "pi-hole"] :
     split("/", local.container_ipv4[name])[0]

--- a/modules/proxmox-stack/main.tf
+++ b/modules/proxmox-stack/main.tf
@@ -134,6 +134,7 @@ module "containers" {
   environment       = var.environment
   default_datastore = var.datastore_default
   domain            = var.domain
+  dns_servers       = local.dns_servers
 
   depends_on = [module.pools, module.storage]
 }


### PR DESCRIPTION
## Summary
Pin container DNS resolvers explicitly instead of letting each LXC inherit its host node's `/etc/resolv.conf` at creation.

**Root cause of #688 (estate-wide IaC-apply outage, 2026-07-17):** containers set only the DNS *search domain*; the resolver was inherited from the host node at creation and never managed. Guests created against different nodes/points-in-time drifted onto different resolvers. When one resolver was retired, exactly the guests that had inherited it lost DNS — including the active OpenBao node, which could then no longer resolve the Terrakube OIDC issuer, so every workload-identity login failed and no `VAULT_TOKEN` was injected into any run.

The VM modules already fixed this same class of drift on 2026-06-10 by pinning `dns { servers }`. This applies the identical, already-derived `local.dns_servers` (Technitium + Pi-hole, no literal IPs) to the container module — so the resolver is deterministic and single-sourced across VMs and containers.

## Changes
- `modules/proxmox-container/main.tf` — `initialization.dns` now sets `servers` (mirrors the VM block).
- `modules/proxmox-container/variables.tf` — add `dns_servers` (list, default `[]` = preserve node-inherited behavior).
- `modules/proxmox-stack/main.tf` — pass `dns_servers = local.dns_servers` to the container module.
- `modules/proxmox-stack/locals.tf` — correct the now-stale "feeds VMs only" comment.

## Test plan
- `tofu validate` — **passes**.
- Blast radius: **verified via remote plan — every container is `~ update in-place`, 0 to replace, 0 to destroy.** Config-only change; guests pick up the new resolver on restart. No literal IPs introduced (derived list only).

## Security notes
No secrets. Removes an unmanaged-config drift vector that took down the machine-identity path estate-wide.

## Context
A live break-glass repoint of the affected nodes' resolvers already restored service; this is the durable IaC fix so a guest restart can't re-inherit a stale resolver. Follow-up (separate): manage the Proxmox **node** resolv.conf in ansible-proxmox and publish the resolver list to `secret/public/*` for cross-repo consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
