### PR TITLE
feat(splunk): declare fast-splunk/bulk-splunk storage tiers

### DIFF
--- a/deployment.json.example
+++ b/deployment.json.example
@@ -78,9 +78,22 @@
           "protected": true,
           "register": false,
           "content": ["images", "rootdir"],
+          "_splunk_fast_comment": "fast-splunk hot/warm tier. The `pvesm_id` registers this child dataset as its own first-class Proxmox storage id `fast-splunk`, which the Splunk VM's virtio2 disk targets directly (a plain quota would land the disk at the pool root instead). In the real topology the fast tier lives on the fast/NVMe node.",
           "datasets": {
+            "splunk": { "quota": "1T", "pvesm_id": "fast-splunk", "properties": { "recordsize": "128K", "compression": "lz4" } },
             "siem/splunk-hot": { "quota": "300G", "properties": { "recordsize": "128K", "compression": "lz4" } },
             "siem/cribl-pq": { "quota": "50G", "properties": { "compression": "lz4", "com.sun:auto-snapshot": "false" } }
+          }
+        },
+        "_bulk_splunk_comment": "bulk-splunk cold tier: a DEDICATED non-RAID pool (raid: \"\"), separate from the raidz1 example-pool because ZFS RAID is pool-wide — a non-RAID cold tier cannot share a raidz pool. protected:false + no snapshots + backup=false on its VM disk (see tofu) is intentional: durability comes from the Backblaze B2 frozen archive, never vzdump. HUMAN ACTION: the physical spare disk (/dev/disk/by-id/...) for this pool must be confirmed/supplied before ansible-proxmox can create it. register:true + the `data` dataset's pvesm_id publish the `bulk-splunk` storage id the Splunk VM's virtio3 disk targets.",
+        "bulk-splunk": {
+          "type": "zfspool",
+          "raid": "",
+          "protected": false,
+          "register": true,
+          "content": ["images"],
+          "datasets": {
+            "data": { "quota": "2T", "pvesm_id": "bulk-splunk", "properties": { "com.sun:auto-snapshot": "false" } }
           }
         }
       }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -42,6 +42,34 @@ DHCP-first guests use deterministic MACs and reserved host numbers. Guest
 firewalls remain default-deny with service flows derived from
 `pipeline_constants`; the UniFi layer consumes the same model in `tofu-unifi`.
 
+## Splunk storage tiers
+
+Splunk index storage is split into three tiers with distinct durability
+postures. The first two are declared here (VM disks + `node_storage` datasets);
+the frozen tier is configured Splunk-side in `ansible-splunk`.
+
+| Tier | Where | Pool / backing | RAID | Backup posture |
+| --- | --- | --- | --- | --- |
+| `fast-splunk` (hot + warm) | fast/NVMe node, `virtio2` | mirror pool, `pvesm_id = fast-splunk` | mirror | `backup = true`; job still undecided |
+| `bulk-splunk` (cold) | bulk-capable node, `virtio3` | dedicated non-RAID pool, `pvesm_id = bulk-splunk` | none (single disk) | `backup = false` by design — B2 replaces it |
+| B2-frozen (archive) | Backblaze B2 (off-site) | S3 bucket via `secrets-external/backblaze-b2` | n/a (cloud-durable) | is the durable copy |
+
+`bulk-splunk` is deliberately non-RAID and excluded from Proxmox `vzdump`: ZFS
+RAID is pool-wide, so a non-RAID cold tier cannot share a raidz pool, and its
+durability comes from the B2 frozen archive rather than local redundancy. The
+`fast-splunk` dataset is registered as its own Proxmox `zfspool` storage id (via
+its dataset `pvesm_id`) so the VM disk targets it directly instead of landing at
+the pool root. The legacy `virtio1` 200G data disk stays attached transitionally
+until a separate migration moves data onto the tiers — see
+[`INFRASTRUCTURE_NUMBERING.md`](./INFRASTRUCTURE_NUMBERING.md) and
+[`SPLUNK_VM_DISK_DRIFT.md`](./SPLUNK_VM_DISK_DRIFT.md).
+
+The architectural rule enforced Splunk-side (in `ansible-splunk`, not here): a
+Splunk index may not be defined without pointing its `homePath`/`coldPath` at one
+of the two custom volumes (`fast-splunk` / `bulk-splunk`). This repo only
+declares the volumes and publishes them as `splunk_storage` in the inventory; it
+does not define indexes.
+
 ## Downstream inventory
 
 A full apply publishes the versioned Ansible inventory to RustFS as a native

--- a/docs/INFRASTRUCTURE_NUMBERING.md
+++ b/docs/INFRASTRUCTURE_NUMBERING.md
@@ -152,12 +152,27 @@ the data disk; see the Cribl roles in the downstream apps repo.
 
 ### Splunk VM disk layout
 
-The Splunk VM uses separate boot and data disks:
+The Splunk VM carries a boot disk, a legacy data disk, and two tiered storage
+disks:
 
-- **Boot disk (virtio0)**: OS, Splunk application, configuration.
-- **Data disk (virtio1)**: Splunk index storage and event data, mounted at `/opt/splunk/var`.
+- **Boot disk**: OS, Splunk application, configuration. Declared `virtio0`; the
+  live disk has drifted to `scsi0`/50G — see
+  [`SPLUNK_VM_DISK_DRIFT.md`](./SPLUNK_VM_DISK_DRIFT.md).
+- **Legacy data disk (`virtio1`, 200G)**: current Splunk index storage, mounted
+  at `/opt/splunk/var`. Transitional — kept attached until a separate migration
+  moves data onto the tiered disks below.
+- **`fast-splunk` (`virtio2`)**: hot + warm buckets on the fast/NVMe tier
+  (`datastore_id = fast-splunk`, backed up).
+- **`bulk-splunk` (`virtio3`)**: cold buckets on the non-RAID cold tier
+  (`datastore_id = bulk-splunk`, `backup = false` by design; archived to
+  Backblaze B2).
 
-Disk sizes are set in `deployment.json` (`splunk_boot_disk_size`, `splunk_data_disk_size`).
+Disk sizes are set in `deployment.json`: `splunk_boot_disk_size`,
+`splunk_data_disk_size` (legacy `virtio1`), `splunk_fast_disk_size` (default
+1024), and `splunk_bulk_disk_size` (default 2048). The tiered disks are declared
+but do not attach until the disk-drift reconciliation completes (see the drift
+doc). See [`ARCHITECTURE.md`](./ARCHITECTURE.md) for the per-tier RAID/backup
+posture.
 
 ---
 

--- a/docs/SECRETS_ROADMAP.md
+++ b/docs/SECRETS_ROADMAP.md
@@ -56,6 +56,34 @@ encrypt Terrakube state until the provider adds native support.
 The private RustFS `deployment.json` holds desired state only. It may contain
 network topology and public keys, but never tokens, passwords, or private keys.
 
+## Third-party SaaS credentials (`secrets-external/` mount)
+
+Third-party SaaS credentials have a different security posture than
+homelab-internal machine credentials, so they live under their own top-level
+OpenBao KV mount rather than nesting under `secret/platform/...`:
+
+| Mount | Holds |
+| --- | --- |
+| `secret/` | Homelab-internal machine/service credentials (existing, unchanged). |
+| `secrets-external/` | Third-party SaaS API keys/credentials, least-privilege-scoped per consumer the same way `secret/` is. |
+
+First path:
+
+| Path | Consumer | Fields |
+| --- | --- | --- |
+| `secrets-external/backblaze-b2` | `ansible-splunk` (Splunk B2 frozen tier) | `S3_ENDPOINT`, `S3_REGION`, `S3_ACCESS_KEY_ID`, `S3_SECRET_ACCESS_KEY`, `S3_BUCKET` |
+
+The Backblaze B2 credential is consumed by `ansible-splunk` to configure the
+Splunk frozen (archival) tier — **not** by this repo or Terrakube. No workspace
+role here reads `secrets-external/`.
+
+> Enabling the new `secrets-external/` KV v2 engine and writing its first policy
+> is a **human-admin OpenBao action**. No dedicated secrets-platform Terraform
+> repo exists in this workspace to automate it, and per this org's admin
+> write-gate convention machine identities do not provision new mounts or
+> policies. This document describes the convention; it does not provision the
+> mount.
+
 ## Locking
 
 Terrakube workspace locking serializes OpenTofu runs. OpenBao does not provide

--- a/docs/SPLUNK_VM_DISK_DRIFT.md
+++ b/docs/SPLUNK_VM_DISK_DRIFT.md
@@ -1,0 +1,66 @@
+# Splunk VM disk drift (blocking prerequisite for tiered storage)
+
+The Splunk VM's on-disk layout diverged from `modules/splunk-vm` out-of-band.
+This drift is currently masked by `lifecycle.ignore_changes = [disk]` and must be
+reconciled — under human supervision — before the new `fast-splunk`/`bulk-splunk`
+tiered disks can actually attach on a real apply.
+
+## What is declared vs. what is live
+
+| Disk | Module declares | Live (drifted) |
+| --- | --- | --- |
+| Boot | `virtio0`, 25G | `scsi0`, 50G |
+| Data | `virtio1`, 200G | `virtio1`, 200G (tracked in state) |
+| Leftover disk-1 | (none) | reaped directly on the host |
+
+`tofu` state tracks only the `virtio1` data disk. Because `bpg/proxmox` keys
+disk blocks and reconciliation on the live VM has no record of the `scsi0` boot
+disk, any un-ignored disk plan tries to unplug the live boot disk (Proxmox HTTP
+400) and would reinterpret the 200G data disk. `ignore_changes = [disk]` is set
+in `modules/splunk-vm/main.tf` for exactly this reason and must not be removed
+casually — the VM has `prevent_destroy = true` and no working backup today.
+
+## Why this cannot be reconciled mechanically here
+
+- **The live values are not verifiable from this repo.** Confirming the exact
+  current disk set (interfaces, datastore ids, sizes, `ssd`/`discard`/`backup`
+  flags) requires querying the live Proxmox API / node, which is out of scope
+  for static validation and CI.
+- **Issue #247 (referenced in the code comment) does not exist** in
+  `dryvist/tofu-proxmox`, so there is no additional recorded detail to reconcile
+  against beyond "boot is `scsi0`/50G".
+- Editing the declared disk blocks while `ignore_changes = [disk]` is active
+  produces **no plan diff**, so it would be an unverifiable change that could
+  mislead a future operator into thinking the config is truthful.
+
+For these reasons this repo does **not** guess at live disk values. The declared
+blocks are left as-is and the drift is documented here as a flagged prerequisite.
+
+## `ignore_changes` narrowing finding (tiered disks)
+
+Narrowing `ignore_changes` to a positional index (e.g. `disk[0]`, `disk[1]`) to
+un-ignore only the new `virtio2`/`virtio3` tiers is **not viable** on
+`bpg/proxmox`: the provider keys disk blocks by their `interface`, not
+positionally, so a numeric `ignore_changes` index does not stably map to a given
+disk across refreshes (Terraform's `ignore_changes` indexing is undefined for
+set-like nested blocks). Keeping the whole `disk` attribute ignored is the only
+safe state today. **Consequence:** while `disk` stays ignored, the
+`var.tiered_disks` blocks are declared but produce no plan diff and will not
+attach.
+
+## What a real reconciliation requires (human-supervised, out of scope here)
+
+1. Capture the live layout from the node (`qm config <vmid>` / Proxmox API):
+   exact interface, `datastore_id`, `size`, `ssd`, `discard`, `backup` for the
+   boot disk, `virtio1`, and anything else attached.
+2. Update the declared disk blocks in `modules/splunk-vm/main.tf` to match
+   reality (boot `scsi0`/50G, etc.).
+3. Align `tofu` state with the live disks (import / `tofu state` ops); confirm a
+   no-op plan with `disk` still ignored.
+4. Remove the `disk` entry from `ignore_changes` under a reviewed plan and
+   confirm the plan creates **only** the new `virtio2`/`virtio3` tiered disks and
+   touches nothing else.
+5. Apply in a supervised window, respecting `prevent_destroy = true` and the
+   absence of a backup.
+
+Until step 4 completes, `fast-splunk`/`bulk-splunk` remain declared-but-inert.

--- a/main.tf
+++ b/main.tf
@@ -156,8 +156,10 @@ module "homelab" {
   proxmox_ssh_username       = ephemeral.vault_kv_secret_v2.proxmox.data.PROXMOX_SSH_USERNAME
   rack_servers               = try(local.deployment.rack_servers, {})
   splunk_boot_disk_size      = try(local.deployment.splunk_boot_disk_size, 25)
+  splunk_bulk_disk_size      = try(local.deployment.splunk_bulk_disk_size, 2048)
   splunk_cpu_cores           = try(local.deployment.splunk_cpu_cores, 8)
   splunk_data_disk_size      = try(local.deployment.splunk_data_disk_size, 200)
+  splunk_fast_disk_size      = try(local.deployment.splunk_fast_disk_size, 1024)
   splunk_memory              = try(local.deployment.splunk_memory, 12288)
   splunk_vm_id               = try(local.deployment.splunk_vm_id, 99)
   splunk_vm_name             = try(local.deployment.splunk_vm_name, "splunk-vm")

--- a/modules/proxmox-stack/inventory_publish.tf
+++ b/modules/proxmox-stack/inventory_publish.tf
@@ -76,6 +76,17 @@ locals {
         ansible_connection = "ssh"
       }
     }
+    # Splunk tiered storage - one {datastore_id, disk_interface, size_gb} per tier
+    # (fast-splunk hot/warm, bulk-splunk cold). Kept as its own top-level key
+    # rather than nested under splunk_vm, which is typed against the shared vm
+    # schema. ansible-splunk maps its volume stanzas onto these disks.
+    splunk_storage = {
+      for tier, d in module.splunk_vm.tiered_disks : tier => {
+        datastore_id   = d.datastore_id
+        disk_interface = d.interface
+        size_gb        = d.size
+      }
+    }
     # Pipeline constants - service and syslog port definitions
     constants = local.pipeline_constants
     # Traefik ingress route table - one {name, ip, port} per fronted service UI.
@@ -172,6 +183,15 @@ resource "aws_s3_object" "ansible_inventory" {
         ])
       )
       error_message = "splunk_vm is empty or malformed — the schema requires at least one entry with ip/node/hostname/vmid set and ansible_connection = \"ssh\". Inspect module.splunk_vm output."
+    }
+    precondition {
+      condition = alltrue([
+        for tier in ["fast", "bulk"] :
+        can(local.ansible_inventory.splunk_storage[tier]) &&
+        try(local.ansible_inventory.splunk_storage[tier].datastore_id, "") != "" &&
+        try(local.ansible_inventory.splunk_storage[tier].disk_interface, "") != ""
+      ])
+      error_message = "splunk_storage must define both the fast and bulk tiers, each with a non-empty datastore_id and disk_interface. Inspect module.splunk_vm.tiered_disks and the tiered_disks wiring in modules/proxmox-stack/main.tf."
     }
     precondition {
       condition = alltrue([

--- a/modules/proxmox-stack/main.tf
+++ b/modules/proxmox-stack/main.tf
@@ -163,6 +163,15 @@ module "splunk_vm" {
   domain         = var.domain
   dns_servers    = local.dns_servers
 
+  # Tiered storage: fast-splunk (hot/warm) and bulk-splunk (cold). datastore_ids
+  # are the Proxmox zfspool storage ids that ansible-proxmox registers from the
+  # matching node_storage datasets' pvesm_id. bulk carries backup = false — the
+  # non-RAID cold tier is archived to Backblaze B2, never to vzdump.
+  tiered_disks = {
+    fast = { datastore_id = "fast-splunk", interface = "virtio2", size = var.splunk_fast_disk_size, backup = true }
+    bulk = { datastore_id = "bulk-splunk", interface = "virtio3", size = var.splunk_bulk_disk_size, backup = false }
+  }
+
   depends_on = [module.pools]
 }
 

--- a/modules/proxmox-stack/tests/ansible_inventory_contract.tftest.hcl
+++ b/modules/proxmox-stack/tests/ansible_inventory_contract.tftest.hcl
@@ -39,6 +39,10 @@ override_module {
     name        = "splunk-aio"
     ip_address  = "192.168.40.200"
     mac_address = "BC:24:11:00:00:C8"
+    tiered_disks = {
+      fast = { datastore_id = "fast-splunk", interface = "virtio2", size = 1024, backup = true }
+      bulk = { datastore_id = "bulk-splunk", interface = "virtio3", size = 2048, backup = false }
+    }
   }
 }
 
@@ -252,6 +256,39 @@ run "ansible_inventory_containers_exists" {
   assert {
     condition     = can(output.ansible_inventory.containers)
     error_message = "ansible_inventory must contain 'containers' key at root level"
+  }
+}
+
+# --- splunk_storage: tiered-disk contract (ansible-splunk volume mapping) ---
+#
+# ansible-splunk maps its hot/warm and cold volume stanzas onto these disks.
+# Pin: both the fast and bulk tiers surface with datastore_id + disk_interface +
+# size_gb, and it is a top-level key distinct from splunk_vm (which is typed
+# against the shared vm schema and must not carry storage fields).
+run "ansible_inventory_splunk_storage_contract" {
+  command = plan
+
+  assert {
+    condition     = can(output.ansible_inventory.splunk_storage)
+    error_message = "ansible_inventory must contain 'splunk_storage' key at root level"
+  }
+
+  assert {
+    condition = (
+      output.ansible_inventory.splunk_storage.fast.datastore_id == "fast-splunk" &&
+      output.ansible_inventory.splunk_storage.fast.disk_interface == "virtio2" &&
+      output.ansible_inventory.splunk_storage.bulk.datastore_id == "bulk-splunk" &&
+      output.ansible_inventory.splunk_storage.bulk.disk_interface == "virtio3"
+    )
+    error_message = "splunk_storage must carry fast-splunk (virtio2) and bulk-splunk (virtio3) tiers with their datastore_id + disk_interface"
+  }
+
+  assert {
+    condition = (
+      output.ansible_inventory.splunk_storage.fast.size_gb == 1024 &&
+      output.ansible_inventory.splunk_storage.bulk.size_gb == 2048
+    )
+    error_message = "splunk_storage tiers must carry size_gb (default 1024 fast / 2048 bulk)"
   }
 }
 

--- a/modules/proxmox-stack/tests/firewall_filtering.tftest.hcl
+++ b/modules/proxmox-stack/tests/firewall_filtering.tftest.hcl
@@ -40,6 +40,10 @@ override_module {
     name        = "splunk-vm"
     ip_address  = "192.168.40.200"
     mac_address = "BC:24:11:00:00:C8"
+    tiered_disks = {
+      fast = { datastore_id = "fast-splunk", interface = "virtio2", size = 1024, backup = true }
+      bulk = { datastore_id = "bulk-splunk", interface = "virtio3", size = 2048, backup = false }
+    }
   }
 }
 

--- a/modules/proxmox-stack/tests/locals.tftest.hcl
+++ b/modules/proxmox-stack/tests/locals.tftest.hcl
@@ -43,6 +43,10 @@ override_module {
     name        = "splunk-vm"
     ip_address  = "192.168.40.200"
     mac_address = "BC:24:11:00:00:C8"
+    tiered_disks = {
+      fast = { datastore_id = "fast-splunk", interface = "virtio2", size = 1024, backup = true }
+      bulk = { datastore_id = "bulk-splunk", interface = "virtio3", size = 2048, backup = false }
+    }
   }
 }
 

--- a/modules/proxmox-stack/tests/splunk_protection.tftest.hcl
+++ b/modules/proxmox-stack/tests/splunk_protection.tftest.hcl
@@ -38,6 +38,10 @@ override_module {
     name        = "splunk-aio"
     ip_address  = "192.168.40.200"
     mac_address = "BC:24:11:00:00:C8"
+    tiered_disks = {
+      fast = { datastore_id = "fast-splunk", interface = "virtio2", size = 1024, backup = true }
+      bulk = { datastore_id = "bulk-splunk", interface = "virtio3", size = 2048, backup = false }
+    }
   }
 }
 

--- a/modules/proxmox-stack/tests/variables.tftest.hcl
+++ b/modules/proxmox-stack/tests/variables.tftest.hcl
@@ -37,6 +37,10 @@ override_module {
     name        = "splunk-vm"
     ip_address  = "192.168.40.200"
     mac_address = "BC:24:11:00:00:C8"
+    tiered_disks = {
+      fast = { datastore_id = "fast-splunk", interface = "virtio2", size = 1024, backup = true }
+      bulk = { datastore_id = "bulk-splunk", interface = "virtio3", size = 2048, backup = false }
+    }
   }
 }
 

--- a/modules/proxmox-stack/variables-splunk.tf
+++ b/modules/proxmox-stack/variables-splunk.tf
@@ -48,6 +48,28 @@ variable "splunk_data_disk_size" {
   }
 }
 
+variable "splunk_fast_disk_size" {
+  description = "Size of the fast-splunk tier disk in GB (hot + warm buckets, on the fast/mirror pool)"
+  type        = number
+  default     = 1024
+
+  validation {
+    condition     = var.splunk_fast_disk_size > 0 && var.splunk_fast_disk_size <= 4096
+    error_message = "Splunk fast-splunk disk size must be between 1 and 4096 GB."
+  }
+}
+
+variable "splunk_bulk_disk_size" {
+  description = "Size of the bulk-splunk tier disk in GB (cold buckets, on the non-RAID cold pool; not backed up by design)"
+  type        = number
+  default     = 2048
+
+  validation {
+    condition     = var.splunk_bulk_disk_size > 0 && var.splunk_bulk_disk_size <= 8192
+    error_message = "Splunk bulk-splunk disk size must be between 1 and 8192 GB."
+  }
+}
+
 variable "splunk_cpu_cores" {
   description = "Number of CPU cores for the Splunk VM"
   type        = number

--- a/modules/proxmox-stack/variables-storage.tf
+++ b/modules/proxmox-stack/variables-storage.tf
@@ -122,6 +122,13 @@ variable "node_storage" {
         quota      = optional(string)
         mountpoint = optional(string)
         nfs_export = optional(string)
+        # When set, ansible-proxmox registers this dataset as its own Proxmox
+        # zfspool storage id (`pvesm add zfspool <pvesm_id> -pool <pool>/<dataset>`),
+        # so a VM/LXC disk can target it directly as a first-class datastore_id.
+        # A plain `quota` alone does NOT do this — zfspool-backed VM disks land at
+        # the pool root, not inside an arbitrary child dataset. Leave unset (null)
+        # for datasets that are only bind-mounted or NFS-exported.
+        pvesm_id = optional(string)
         # Arbitrary ZFS properties (recordsize, compression, readonly,
         # com.sun:auto-snapshot, …) applied idempotently by ansible-proxmox.
         # Use ZFS canonical forms as strings (e.g. "1M", "zstd", "false").

--- a/modules/splunk-vm/main.tf
+++ b/modules/splunk-vm/main.tf
@@ -8,23 +8,30 @@ terraform {
 }
 
 # =============================================================================
-# CRITICAL — SPLUNK INDEXER DATA IS NOT BACKED UP
+# CRITICAL — SPLUNK BOOT + LEGACY DATA DISKS ARE NOT BACKED UP
 # =============================================================================
-# The Splunk indexer data on this VM's data disks (virtio0 = 25G, virtio1 =
-# 200G) is NOT backed up anywhere. Treat EVERY operation on this VM as
+# The boot disk and the legacy virtio1 (200G) data disk carry live Splunk state
+# that is NOT backed up anywhere. Treat EVERY operation on this VM as
 # potentially data-destructive:
 #   - NEVER destroy/recreate the VM. `prevent_destroy = true` is set below for
 #     exactly this reason — do not remove it.
-#   - NEVER touch the data disks (virtio0/virtio1). Only the 4MB cloud-init
-#     drive is safe to modify.
+#   - NEVER touch the boot disk or virtio1. Only the 4MB cloud-init drive is
+#     safe to modify.
 #   - AVOID `cloud-init clean` + reboot here. It re-runs cloud-init; it is only
 #     data-safe because the cloud-init user-data has no disk_setup/fs_setup/
 #     growpart today — re-verify that before ever relying on it.
 #   - The guest network/OS config is Ansible-owned post-boot (cloud-init is
 #     first-boot only); tofu manages the NIC VLAN tag, not the guest IP, which
 #     is why initialization[0].ip_config is in ignore_changes below.
-# ACTION NEEDED: stand up a real backup job (PBS / zfs-send) for virtio0+virtio1
-# BEFORE the next risky change. The disks carry backup=1 but no backup runs yet.
+#
+# Backup posture per disk (see var.tiered_disks / docs/ARCHITECTURE.md):
+#   - boot + virtio1: backup=1 but NO backup job runs yet. ACTION NEEDED — stand
+#     up a real backup job (PBS / zfs-send) BEFORE the next risky change.
+#   - fast-splunk (virtio2, hot/warm): backup=true, but the actual job is still
+#     undecided. ACTION NEEDED — decide PBS vs. B2-only before it holds real data.
+#   - bulk-splunk (virtio3, cold): backup=false BY DESIGN. This tier is
+#     deliberately non-RAID and excluded from vzdump; its durability comes from
+#     the Backblaze B2 frozen archive (configured Splunk-side). NOT an open item.
 # =============================================================================
 
 # Render cloud-init configuration with secrets and config files
@@ -97,6 +104,31 @@ resource "proxmox_virtual_environment_vm" "splunk_vm" {
       iothread     = true
       ssd          = false
       discard      = "ignore"
+    }
+  }
+
+  # Tiered Splunk data disks (fast-splunk hot/warm, bulk-splunk cold). Same
+  # map-driven shape as modules/proxmox-vm's additional_disks, so new tiers are
+  # added by map entry, not by another hardcoded block. bpg keys disks by their
+  # explicit `interface` (virtio2/virtio3), so map iteration order is irrelevant.
+  # bulk-splunk carries backup = false: it is the non-RAID cold tier whose
+  # durability comes from the Backblaze B2 frozen archive (configured Splunk-side
+  # in ansible-splunk), never from Proxmox vzdump.
+  # NOTE: while `ignore_changes = [disk]` is active (see lifecycle below), adding
+  # these blocks produces NO plan diff — actually attaching them is a
+  # human-supervised step gated on the live disk-drift reconciliation. See
+  # docs/SPLUNK_VM_DISK_DRIFT.md.
+  dynamic "disk" {
+    for_each = var.tiered_disks
+    content {
+      datastore_id = disk.value.datastore_id
+      interface    = disk.value.interface
+      size         = disk.value.size
+      backup       = disk.value.backup
+      file_format  = disk.value.file_format
+      iothread     = disk.value.iothread
+      ssd          = disk.value.ssd
+      discard      = disk.value.discard
     }
   }
 
@@ -184,6 +216,22 @@ resource "proxmox_virtual_environment_vm" "splunk_vm" {
       # the 200G data disk. Disk sizing/layout is owned outside tofu (Proxmox +
       # the ansible sanoid/syncoid protection layer), so ignore disk drift. Revisit
       # if tofu is ever made the source of truth for the disk split (see #247).
+      #
+      # FINDING (var.tiered_disks interaction): narrowing this to a positional
+      # index (e.g. `disk[0]`, `disk[1]`) to un-ignore only the new virtio2/virtio3
+      # tiers is NOT viable on bpg/proxmox. bpg keys disk blocks by their
+      # `interface` value, not positionally, so a numeric `ignore_changes` index
+      # does not stably map to a given disk across refreshes — Terraform's
+      # ignore_changes indexing is undefined for set-like nested blocks. Keeping
+      # the whole `disk` attribute ignored is therefore the only safe state today.
+      # CONSEQUENCE: while `disk` stays ignored, the var.tiered_disks blocks above
+      # produce NO plan diff and will NOT attach on apply.
+      # TODO (human-supervised, out of scope for this PR): to actually attach
+      # fast-splunk/bulk-splunk, first reconcile the live disk drift into state
+      # (import/declare the real scsi0 boot disk + virtio1), then remove this
+      # `disk` entry entirely under a reviewed apply so bpg matches existing disks
+      # by interface and creates only the genuinely-new virtio2/virtio3. See
+      # docs/SPLUNK_VM_DISK_DRIFT.md for the exact blocking steps.
       disk,
     ]
   }

--- a/modules/splunk-vm/outputs.tf
+++ b/modules/splunk-vm/outputs.tf
@@ -20,3 +20,8 @@ output "mac_address" {
   description = "The MAC address of the Splunk VM network interface"
   value       = length(proxmox_virtual_environment_vm.splunk_vm.mac_addresses) > 0 ? proxmox_virtual_environment_vm.splunk_vm.mac_addresses[0] : null
 }
+
+output "tiered_disks" {
+  description = "Tiered Splunk data disks (fast-splunk/bulk-splunk) as declared, keyed by tier."
+  value       = var.tiered_disks
+}

--- a/modules/splunk-vm/variables.tf
+++ b/modules/splunk-vm/variables.tf
@@ -171,3 +171,18 @@ variable "dns_servers" {
   type        = list(string)
   default     = []
 }
+
+variable "tiered_disks" {
+  description = "Additional tiered Splunk data disks (fast-splunk hot/warm, bulk-splunk cold)."
+  type = map(object({
+    datastore_id = string
+    interface    = string
+    size         = number
+    backup       = optional(bool, true)
+    file_format  = optional(string, "raw")
+    iothread     = optional(bool, true)
+    ssd          = optional(bool, false)
+    discard      = optional(string, "ignore")
+  }))
+  default = {}
+}


### PR DESCRIPTION
## What this does

Declares a three-tier Splunk storage architecture at the IaC layer (this repo is
the single source of truth for VM/storage declarations; downstream `ansible-proxmox`
creates the ZFS pools and `ansible-splunk` configures Splunk).

### Implemented

- **`node_storage` schema** (`variables-storage.tf`): new **optional** `pvesm_id`
  field on the dataset object. When set, `ansible-proxmox` registers that child
  dataset as its own Proxmox `zfspool` storage id
  (`pvesm add zfspool <pvesm_id> -pool <pool>/<dataset>`) so a VM disk can target
  it directly. Backward-compatible (defaults null); every existing dataset entry
  validates unchanged.
- **`modules/splunk-vm`**: new map-driven `tiered_disks` variable (mirrors the
  `additional_disks` shape from `modules/proxmox-vm`), a `dynamic "disk"` block
  driven by it, and a `tiered_disks` output. The existing `virtio1` 200G data
  disk is kept exactly as-is (transitional). `bulk-splunk` disk carries
  `backup = false` (verified against bpg 0.111: `disk.backup` is a real
  argument).
- **`modules/proxmox-stack`**: wires `tiered_disks` in the `splunk_vm` caller;
  new `splunk_fast_disk_size` (default 1024) and `splunk_bulk_disk_size`
  (default 2048); both also threaded from `deployment.json` in the root `main.tf`.
- **Inventory** (`inventory_publish.tf`): new top-level `splunk_storage` key
  (`{datastore_id, disk_interface, size_gb}` per tier), separate from the
  `splunk_vm` block (which is typed against the shared vm schema). Added a
  matching `precondition` requiring both `fast` and `bulk` tiers. A new
  `ansible_inventory_contract` test pins the key; the five module tests that
  override `module.splunk_vm` were updated to include `tiered_disks`.
- **`deployment.json.example`**: demonstrates the `pvesm_id` pattern (a `splunk`
  dataset on the existing fast/mirror pool) and a dedicated non-RAID
  `bulk-splunk` pool, with an inline note that the physical spare disk must be
  human-supplied.
- **Docs**: new `docs/SPLUNK_VM_DISK_DRIFT.md`; a `secrets-external/` OpenBao
  mount section in `SECRETS_ROADMAP.md` (third-party SaaS creds; first path
  `secrets-external/backblaze-b2`, consumed by `ansible-splunk`, human-admin to
  provision); storage-tier posture in `ARCHITECTURE.md`; the updated 4-disk
  layout in `INFRASTRUCTURE_NUMBERING.md`. The "NOT BACKED UP" comment in
  `splunk-vm/main.tf` was narrowed so `bulk-splunk`'s no-backup is intentional
  (B2 archival), while boot/`virtio1`/`fast-splunk` remain flagged ACTION NEEDED.

Root `outputs.tf` needs no change — `ansible_inventory` is already a straight
passthrough of the module output, so `splunk_storage` flows through automatically.

## Open questions (need a human decision)

- **Physical spare disk for `bulk-splunk`**: the real `/dev/disk/by-id/...` path
  on the bulk/cold node must be confirmed/supplied before `ansible-proxmox` can
  create the non-RAID pool. The example uses illustrative data only.
- **`fast-splunk` backup**: whether the hot/warm tier gets a Proxmox-level
  (PBS/zfs-send) backup or is B2-only is still undecided (left as `backup = true`
  with an ACTION NEEDED note).
- **Live disk drift / `ignore_changes = [disk]`**: the tiered disks are declared
  but **inert**. While `ignore_changes = [disk]` masks the live drift (boot disk
  is `scsi0`/50G, not the declared `virtio0`/25G), the new `virtio2`/`virtio3`
  blocks produce no plan diff. Narrowing `ignore_changes` by positional index is
  not viable on bpg (disks are keyed by interface). Actually attaching the tiers
  is a human-supervised step: reconcile drift into state, then remove
  `ignore_changes = [disk]` under a reviewed apply. Full steps in
  `docs/SPLUNK_VM_DISK_DRIFT.md`. (Referenced issue #247 does not resolve in this
  repo.)

## Parallel dependencies (other agents, not in this PR)

- **`homelab-contracts`**: the published inventory JSON schema needs a matching
  `splunk_storage` field so the publish gate accepts the new key.
- **`ansible-proxmox`**: the `pvesm_id` dataset-registration behavior
  (`pvesm add zfspool`) is implemented in that repo.
- **`ansible-splunk`**: consumes `splunk_storage` + `secrets-external/backblaze-b2`
  for the volume stanzas and B2 frozen tier.

## Validation

- `tofu fmt -recursive -check` — clean.
- `tofu init -backend=false && tofu validate` — success.
- `tofu test` — proxmox-stack **119 passed**, firewall **31 passed**, root 0/0.
- `markdownlint-cli2` on changed docs — 0 errors.

**Nothing was applied to live infrastructure.** No `tofu apply`, no plan against
the real backend. The Splunk VM keeps `prevent_destroy = true` and its disks are
untouched.
