### PR TITLE
fix(dns): derive resolver list from all technitium nodes, drop pi-hole

### DIFF
--- a/modules/proxmox-container/main.tf
+++ b/modules/proxmox-container/main.tf
@@ -60,7 +60,7 @@ resource "proxmox_virtual_environment_container" "containers" {
     }
 
     # DNS search domain + explicit nameservers. servers points guests at the
-    # homelab's own resolvers (Technitium/Pi-hole, inside the internal networks
+    # homelab's own resolvers (Technitium nodes, inside the internal networks
     # the outbound-internal firewall group already permits) instead of inheriting
     # the node's upstream gateway resolver, which a DROP-policy guest cannot reach.
     # Empty servers list => omit the arg => inherit the node's resolv.conf.

--- a/modules/proxmox-container/variables.tf
+++ b/modules/proxmox-container/variables.tf
@@ -91,7 +91,7 @@ variable "domain" {
 variable "dns_servers" {
   description = <<-EOT
     Nameservers for the container's resolv.conf (the homelab's own authoritative
-    resolvers — Technitium primary, Pi-hole secondary). Set explicitly so guests
+    resolvers — Technitium nodes, one per Proxmox host). Set explicitly so guests
     resolve via internal DNS that the outbound-internal firewall group already
     permits, rather than inheriting the Proxmox node's upstream gateway resolver
     (which sits on a VLAN a DROP-policy guest cannot egress to). Empty = inherit

--- a/modules/proxmox-stack/locals.tf
+++ b/modules/proxmox-stack/locals.tf
@@ -95,14 +95,21 @@ locals {
   # VGA type validation helper
   valid_vga_types = ["std", "cirrus", "vmware", "qxl"]
 
-  # Resolver list for guest cloud-init DNS: Technitium primary, Pi-hole
-  # secondary. Derived via container_ipv4 (honors static ip pins) so no
-  # literal resolver IPs exist anywhere in the repo. Containers inherit the
-  # node's resolv.conf instead; this feeds VMs only.
+  # Resolver list for guest cloud-init DNS: every deployed Technitium node,
+  # each on its own Proxmox host, for real cross-host HA (a single-node
+  # resolver, or a resolver pinned to the same host as its dependents, isn't
+  # HA — verified 2026-07-19: the estate DNS outage traced to guests pointed
+  # at an unreachable resolver with no working fallback). Derived via
+  # container_ipv4 (honors static ip pins) so no literal resolver IPs exist
+  # anywhere in the repo; self-extending — a new "technitium-dns-N" container
+  # joins the list with zero code changes. Pi-hole was never brought up
+  # (stopped, VMID-derived IP) and is intentionally excluded — Technitium is
+  # the estate's only resolver. Containers inherit the node's resolv.conf
+  # instead; this feeds VMs only.
   dns_servers = [
-    for name in ["technitium-dns", "pi-hole"] :
+    for name in sort(keys(var.containers)) :
     split("/", local.container_ipv4[name])[0]
-    if contains(keys(var.containers), name)
+    if can(regex("^technitium-dns", name))
   ]
 
   # Internal networks for guest-firewall source scoping — derived from the

--- a/modules/proxmox-stack/locals.tf
+++ b/modules/proxmox-stack/locals.tf
@@ -95,17 +95,10 @@ locals {
   # VGA type validation helper
   valid_vga_types = ["std", "cirrus", "vmware", "qxl"]
 
-  # Resolver list for guest cloud-init DNS: every deployed Technitium node,
-  # each on its own Proxmox host, for real cross-host HA (a single-node
-  # resolver, or a resolver pinned to the same host as its dependents, isn't
-  # HA — verified 2026-07-19: the estate DNS outage traced to guests pointed
-  # at an unreachable resolver with no working fallback). Derived via
-  # container_ipv4 (honors static ip pins) so no literal resolver IPs exist
-  # anywhere in the repo; self-extending — a new "technitium-dns-N" container
-  # joins the list with zero code changes. Pi-hole was never brought up
-  # (stopped, VMID-derived IP) and is intentionally excluded — Technitium is
-  # the estate's only resolver. Containers inherit the node's resolv.conf
-  # instead; this feeds VMs only.
+  # Resolver list for guest cloud-init DNS: every technitium-dns* node (each on
+  # its own Proxmox host) for real cross-host HA. Derived via container_ipv4
+  # (honors static ip pins; no literal IPs in-repo) and self-extending. Pi-hole
+  # is excluded — never brought up, VMID-derived IP was the 2026-07-19 outage.
   dns_servers = [
     for name in sort(keys(var.containers)) :
     split("/", local.container_ipv4[name])[0]

--- a/modules/proxmox-stack/tests/locals.tftest.hcl
+++ b/modules/proxmox-stack/tests/locals.tftest.hcl
@@ -586,15 +586,17 @@ run "dns_servers_derived_from_dns_containers" {
 
   variables {
     containers = {
-      "technitium-dns" = { vm_id = 103, hostname = "technitium-dns", vlan = "dns", ip_config = { ipv4_address = "192.168.2.2/24" } }
-      "pi-hole"        = { vm_id = 104, hostname = "pi-hole", vlan = "dns" }
+      "technitium-dns"   = { vm_id = 103, hostname = "technitium-dns", vlan = "dns", ip_config = { ipv4_address = "192.0.2.2/24" } }
+      "technitium-dns-2" = { vm_id = 113, hostname = "technitium-dns-2", vlan = "dns", ip_config = { ipv4_address = "192.0.2.3/24" } }
+      "pi-hole"          = { vm_id = 104, hostname = "pi-hole", vlan = "dns" }
     }
   }
 
-  # Static pin honored for Technitium; Pi-hole derived from vm_id; order fixed
+  # Every technitium-dns* node (static pins honored, sorted by key) for real
+  # cross-host HA; pi-hole is excluded (never brought up, VMID-derived IP).
   assert {
-    condition     = jsonencode(local.dns_servers) == jsonencode(["192.168.2.2", "192.168.2.104"])
-    error_message = "dns_servers must be [technitium (pinned), pi-hole (derived)], got ${jsonencode(local.dns_servers)}"
+    condition     = jsonencode(local.dns_servers) == jsonencode(["192.0.2.2", "192.0.2.3"])
+    error_message = "dns_servers must be all technitium nodes sorted, pi-hole excluded, got ${jsonencode(local.dns_servers)}"
   }
 }
 


### PR DESCRIPTION
## What

Replace the hardcoded guest cloud-init DNS list `[technitium-dns, pi-hole]` in `modules/proxmox-stack/locals.tf` with a self-extending match over every `technitium-dns*` container, derived via `container_ipv4` so no literal resolver IP exists in the repo.

## Why

The estate DNS outage (2026-07-19) traced to guests pointed at an unreachable resolver with no working fallback. Pi-hole was never brought up; its VMID-derived IP (`.104` from vmid 104) is exactly the fragility flagged. Technitium is the estate's only resolver going forward, with a node per Proxmox host for real cross-host HA. A new `technitium-dns-N` container joins the resolver list with zero code changes.

Comment-only Pi-hole references in `modules/proxmox-container/{main,variables}.tf` updated to match.

## Note

The private `deployment.json` desired-state (which removes the stopped pi-hole container, vmid 104) is applied separately as a reviewed destroy — not in this code PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)