### PR TITLE
fix(openbao): route ingress to active peer only (drop standbyok) — fixes intermittent mint failures

### DIFF
--- a/modules/proxmox-stack/locals-ingress-backends.tf
+++ b/modules/proxmox-stack/locals-ingress-backends.tf
@@ -139,12 +139,19 @@ locals {
     # backends (plural) -> multi-server loadBalancer; health_check drops a down
     # node; sticky keeps a browser UI session pinned. Omitted if no peer exists.
     #
-    # health_check_path forces ?standbyok=true: only the active OpenBao peer
-    # returns 200 on /v1/sys/health — standby peers return 429, which Traefik
-    # would otherwise read as unhealthy and evict from the pool, killing the
-    # standby-forwarding the HA design depends on. ?standbyok=true makes standbys
-    # return 200 so they stay in the pool. The `traefik` role renders this path
-    # for the route's health check (defaulting to "/" when unset).
+    # health_check_path is /v1/sys/health WITHOUT ?standbyok — so ONLY the active
+    # peer returns 200; standby peers return 429 and Traefik evicts them, routing
+    # every request straight to the active node. This is deliberate: a mint/write
+    # must be served by the Raft leader anyway, and the previous ?standbyok=true
+    # (which kept standbys in the pool) meant ~6/7 requests hit a standby that
+    # then had to FORWARD to the leader — and that inter-node forward path is the
+    # one that intermittently fails ("internal error"), so pooling standbys
+    # amplified the failure rather than adding resilience (verified 2026-07-20;
+    # see ansible-proxmox-apps#1125 for the underlying Raft comms issue). Trade-off:
+    # during a leader election there is a brief window until Traefik's health check
+    # re-converges on the new active — far cheaper than the continuous failure rate
+    # standby-pooling caused. The `traefik` role renders this path for the route's
+    # health check (defaulting to "/" when unset).
     length(local.openbao_backends) > 0 ? [
       {
         name              = "openbao"
@@ -152,7 +159,7 @@ locals {
         port              = local.pipeline_constants.service_ports.openbao_api
         sticky            = true
         health_check      = true
-        health_check_path = "/v1/sys/health?standbyok=true"
+        health_check_path = "/v1/sys/health"
         sso               = false # token/AppRole/JWT API clients (CLI, Terrakube, roles)
       }
     ] : [],

--- a/modules/proxmox-stack/tests/ansible_inventory_contract.tftest.hcl
+++ b/modules/proxmox-stack/tests/ansible_inventory_contract.tftest.hcl
@@ -684,9 +684,9 @@ run "ansible_inventory_ingress_openbao_ha_pool" {
       && try(r.port, 0) == 8200
       && try(r.sticky, false)
       && try(r.health_check, false)
-      && try(r.health_check_path, "") == "/v1/sys/health?standbyok=true"
+      && try(r.health_check_path, "") == "/v1/sys/health"
     ]) == 1
-    error_message = "ingress must front OpenBao with a sorted, sticky, standby-aware 5-backend HA pool"
+    error_message = "ingress must front OpenBao with a sorted, sticky, active-only 5-backend HA pool (health check /v1/sys/health, no standbyok — routes to the Raft leader)"
   }
 }
 


### PR DESCRIPTION
## Answer to "why don't we route only to healthy instances?"

We *do* have Traefik health-checking the 7-node OpenBao pool — but it checks `/v1/sys/health?standbyok=true`, which makes **standby** peers return 200, so all 7 stay in rotation and Traefik round-robins them. Verified live: 5 of 6 `/sys/health` probes hit a standby.

That's the bug. Every standby-routed request must **forward to the Raft leader**, and that inter-node forward is the path intermittently failing with a bare `internal error` (root cause: ansible-proxmox-apps#1125). So standby-pooling *amplified* the failure — ~6/7 requests took the flaky hop.

## Fix

Drop `?standbyok` → standbys return 429 → Traefik evicts them → **every request goes straight to the active node**. Writes (mints) must be served by the leader anyway, so nothing is lost.

## Evidence

- OpenBao mint: ~67% success. Direct App-JWT (same token, bypasses OpenBao): **100%**.
- `/sys/health` via the endpoint: 5/6 standby → confirms round-robin over all peers.
- DNS (20/20) and TCP-443-to-GitHub (10/10) from the active node are fine — this is purely LB routing + the standby-forward path.

## Trade-off

Active-only means a brief re-converge window on leader election (Traefik health-check interval) vs. the *continuous* ~33% failure standby-pooling caused. Net large win. The deeper Raft inter-node comms fix is tracked separately (#1125).

Test assertion updated to expect the active-only health-check path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)