### PR TITLE
feat(imports): populate node_services.traefik and import the running ingress guest

### DIFF
--- a/imports.tf
+++ b/imports.tf
@@ -93,3 +93,28 @@ import {
   to = module.homelab.module.containers[0].proxmox_virtual_environment_container.containers["technitium-30"]
   id = "${local.deployment.containers["technitium-30"].node_name}/${local.deployment.containers["technitium-30"].vm_id}"
 }
+
+# Adoption of a live, running Traefik ingress instance that Terraform has
+# never declared -- the same shape as the technitium-30 adoption in the
+# sibling PR, but resolved through a different path: this guest has never
+# been in state at all, so there is no stale entry to remove first, only a
+# first-time adopt.
+#
+# Traefik is the first consumer of the per-node "DaemonSet" service pattern
+# (locals-node-services.tf / node_service_containers), documented in
+# deployment.json.example under node_services.traefik. That template was
+# never populated in the live private object, so the generator currently
+# expands zero per_node entries and produces no "traefik-30" key. The
+# companion (uncommitted) deployment.json change adds one per_node entry
+# matching this guest's live spec (vm_id, tags, disk, unprivileged flag)
+# exactly, so the import adopts in place instead of planning a
+# destroy-and-recreate of a running guest.
+#
+# The id is resolved against local.containers (the merged map), never
+# local.deployment.containers, for the same reason the relocation block
+# above does: "traefik-30" is synthesised by node_service_containers and
+# does not exist in the raw declared map.
+import {
+  to = module.homelab.module.containers[0].proxmox_virtual_environment_container.containers["traefik-30"]
+  id = "${local.containers["traefik-30"].node_name}/${local.containers["traefik-30"].vm_id}"
+}


### PR DESCRIPTION
## Summary
- Adds an `import` block adopting a live, running Traefik ingress container that Terraform has never declared, under the per-node "DaemonSet" service pattern (`locals-node-services.tf` / `node_service_containers`) that already exists in this codebase.
- Sibling of #857 (same class of adoption; both trace to one event) but resolved through a different path: Traefik is the first consumer of `node_services.traefik`, a template already fully documented in `deployment.json.example` but never populated with live data. So the companion `deployment.json` change here is a `per_node` entry, not a bare `containers` entry like #857's `technitium-30` — and the import id is resolved against `local.containers` (the merged map that `node_service_containers` feeds into), not `local.deployment.containers`.
- No prior declaration exists for this guest to retire (unlike #857's `technitium-dns`), so no `tofu state rm` step is required before this apply.

## Plan verification
- `tofu fmt -check` and `tofu validate` pass.
- A live `tofu plan` was not run this session — the workstation has no network path to the state backend (see `docs/EXECUTION_HOSTS.md`); a remote plan needs the `iac-platform` guest.
- #857 documented every existing `import`-block target currently failing with `error retrieving container: received an HTTP 595 response - Reason: No route to host`, reproduced on unmodified `origin/main` — a pre-existing, environment-level condition unrelated to either change. Expect the same failure to apply here until that is resolved. Recommend reviewing this alongside #857 for that reason.

## Test plan
- [x] `tofu fmt -check`, `tofu validate` pass
- [ ] Full `tofu plan` showing zero destroys — blocked on the pre-existing import-fetch issue noted in #857, and on running from `iac-platform`
- [ ] Not applied