### PR TITLE
feat(hermes): add service ports, ingress, and firewall for hermes-ui and hermes-donna

### DIFF
--- a/modules/firewall/hermes_ui_rules.tf
+++ b/modules/firewall/hermes_ui_rules.tf
@@ -1,0 +1,88 @@
+# =============================================================================
+# hermes-ui container firewall configuration
+# =============================================================================
+# Extracted into its own file (like hermes_agent_rules.tf / llm_redis's block
+# in llm_fabric_rules.tf) so container_rules.tf stays under the shared
+# _file-size workflow's 12 KB error threshold.
+#
+# hermes-ui is a companion web UI guest for the Hermes agent, carrying its OWN
+# tag (hermes-ui, not hermes-agent) so its egress profile can be tightened
+# later without touching the agent's. Same egress profile as hermes-agent for
+# now — one of its two apps may call model providers directly:
+#   - internal_access  : SSH + ICMP in from internal RFC1918 (management).
+#   - outbound_internal: reach internal services (DNS, NTP, Splunk logging).
+#   - outbound_https   : TCP 443 to anywhere, for the app that calls model
+#                        providers directly.
+#   - hermes_ui_services: the two web apps (both default to 3000 upstream,
+#                        mapped to distinct host ports), from internal only.
+
+locals {
+  hermes_ui_services_rules = [
+    { proto = "tcp", dport = tostring(local.svc_ports.hermes_ui_web), source = local.internal_src, comment = "hermes-ui primary app (TCP ${local.svc_ports.hermes_ui_web}) from internal" },
+    { proto = "tcp", dport = tostring(local.svc_ports.hermes_ui_admin_web), source = local.internal_src, comment = "hermes-ui admin app (TCP ${local.svc_ports.hermes_ui_admin_web}) from internal" },
+  ]
+}
+
+resource "proxmox_virtual_environment_cluster_firewall_security_group" "hermes_ui_services" {
+  name    = "hermes-ui-svc"
+  comment = "hermes-ui web apps (${local.svc_ports.hermes_ui_web}, ${local.svc_ports.hermes_ui_admin_web}) from internal networks — Traefik-fronted"
+
+  dynamic "rule" {
+    for_each = local.hermes_ui_services_rules
+    content {
+      type    = "in"
+      action  = "ACCEPT"
+      proto   = rule.value.proto
+      dport   = rule.value.dport
+      source  = rule.value.source
+      comment = rule.value.comment
+    }
+  }
+}
+
+resource "proxmox_virtual_environment_firewall_options" "hermes_ui_container" {
+  for_each = var.hermes_ui_container_ids
+
+  node_name     = var.node_name
+  container_id  = each.value
+  enabled       = local.firewall_defaults.enabled
+  input_policy  = local.firewall_defaults.input_policy
+  output_policy = local.firewall_defaults.output_policy
+  log_level_in  = local.firewall_defaults.log_level_in
+  log_level_out = local.firewall_defaults.log_level_out
+
+  # DHCP-first guest (no static ip_config) — same as hermes-agent — needs its
+  # own DHCPDISCOVER/OFFER allowed behind DROP in/out policies or it never leases.
+  dhcp = true
+
+  depends_on = [proxmox_virtual_environment_cluster_firewall.main]
+}
+
+resource "proxmox_virtual_environment_firewall_rules" "hermes_ui_container" {
+  for_each = var.hermes_ui_container_ids
+
+  node_name    = var.node_name
+  container_id = each.value
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.internal_access.name
+    comment        = "Internal access (SSH, ICMP)"
+  }
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.outbound_internal.name
+    comment        = "Outbound to internal only (DNS, NTP, Splunk logging)"
+  }
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.outbound_https.name
+    comment        = "Outbound HTTPS (TCP 443) for the app that calls model providers directly"
+  }
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.hermes_ui_services.name
+    comment        = "Inbound web apps (Traefik-fronted) from internal"
+  }
+
+  depends_on = [proxmox_virtual_environment_firewall_options.hermes_ui_container]
+}

--- a/modules/firewall/hermes_ui_rules.tf
+++ b/modules/firewall/hermes_ui_rules.tf
@@ -18,14 +18,14 @@
 
 locals {
   hermes_ui_services_rules = [
-    { proto = "tcp", dport = tostring(local.svc_ports.hermes_ui_web), source = local.internal_src, comment = "hermes-ui primary app (TCP ${local.svc_ports.hermes_ui_web}) from internal" },
-    { proto = "tcp", dport = tostring(local.svc_ports.hermes_ui_admin_web), source = local.internal_src, comment = "hermes-ui admin app (TCP ${local.svc_ports.hermes_ui_admin_web}) from internal" },
+    { proto = "tcp", dport = tostring(local.svc_ports.hermes_ui_workspace), source = local.internal_src, comment = "hermes-ui primary app (TCP ${local.svc_ports.hermes_ui_workspace}) from internal" },
+    { proto = "tcp", dport = tostring(local.svc_ports.hermes_ui_mission_control), source = local.internal_src, comment = "mission-control app (TCP ${local.svc_ports.hermes_ui_mission_control}) from internal" },
   ]
 }
 
 resource "proxmox_virtual_environment_cluster_firewall_security_group" "hermes_ui_services" {
   name    = "hermes-ui-svc"
-  comment = "hermes-ui web apps (${local.svc_ports.hermes_ui_web}, ${local.svc_ports.hermes_ui_admin_web}) from internal networks — Traefik-fronted"
+  comment = "hermes-ui web apps (${local.svc_ports.hermes_ui_workspace}, ${local.svc_ports.hermes_ui_mission_control}) from internal networks — Traefik-fronted"
 
   dynamic "rule" {
     for_each = local.hermes_ui_services_rules

--- a/modules/firewall/otlp_ingest_rules.tf
+++ b/modules/firewall/otlp_ingest_rules.tf
@@ -24,11 +24,11 @@ resource "proxmox_virtual_environment_cluster_firewall_security_group" "otlp_ing
   comment = "OTLP trace ingest from internal networks to the Cribl Stream in_otel listener"
 
   rule {
-    type   = "in"
-    action = "ACCEPT"
-    proto  = "tcp"
-    dport  = join(",", [for p in local.otlp_ingest_ports : tostring(p)])
-    source = local.internal_src
+    type    = "in"
+    action  = "ACCEPT"
+    proto   = "tcp"
+    dport   = join(",", [for p in local.otlp_ingest_ports : tostring(p)])
+    source  = local.internal_src
     comment = "OTLP traces (HTTP + gRPC) from internal"
   }
 }

--- a/modules/firewall/tests/rule_generation.tftest.hcl
+++ b/modules/firewall/tests/rule_generation.tftest.hcl
@@ -60,8 +60,8 @@ variables {
       hermes_api       = 8642
       hermes_dashboard = 8080
       # hermes-ui companion web apps (referenced by hermes_ui_services_rules)
-      hermes_ui_web       = 3000
-      hermes_ui_admin_web = 3001
+      hermes_ui_workspace       = 3000
+      hermes_ui_mission_control = 3001
       # AI orchestration + observability (referenced by ai_orchestration rules)
       n8n_web           = 5678
       dify_web          = 80

--- a/modules/firewall/tests/rule_generation.tftest.hcl
+++ b/modules/firewall/tests/rule_generation.tftest.hcl
@@ -59,6 +59,9 @@ variables {
       hermes_webhook   = 8644
       hermes_api       = 8642
       hermes_dashboard = 8080
+      # hermes-ui companion web apps (referenced by hermes_ui_services_rules)
+      hermes_ui_web       = 3000
+      hermes_ui_admin_web = 3001
       # AI orchestration + observability (referenced by ai_orchestration rules)
       n8n_web           = 5678
       dify_web          = 80

--- a/modules/firewall/variables-hermes-ui.tf
+++ b/modules/firewall/variables-hermes-ui.tf
@@ -1,0 +1,9 @@
+# hermes-ui container-id input, split out of variables.tf (which reached the
+# shared _file-size 12 KB error threshold) for the same reason
+# variables-llm-fabric.tf was split out.
+
+variable "hermes_ui_container_ids" {
+  description = "Map of hermes-ui LXC names to IDs (tag-driven: hermes-ui). Companion web UI guest for the Hermes agent, own tag so its egress can be tightened later without touching the hermes-agent profile."
+  type        = map(number)
+  default     = {}
+}

--- a/modules/proxmox-stack/constants.tf
+++ b/modules/proxmox-stack/constants.tf
@@ -83,6 +83,17 @@ locals {
       # bearer-authenticated). Traefik-fronted as https://hermes-api.<sub>;
       # the sanctioned non-exec path to submit work to the agent.
       hermes_api = 8642
+      # hermes-ui — a companion web UI guest running TWO apps that both
+      # default to internal port 3000 upstream; mapped to distinct host
+      # ports so Traefik can route each independently.
+      hermes_ui_web       = 3000
+      hermes_ui_admin_web = 3001
+      # hermes-donna — a second, independently-identified Hermes agent
+      # instance (own container). Same webhook/dashboard/api triplet as
+      # hermes-agent above, same software defaults.
+      hermes_donna_webhook   = 8644
+      hermes_donna_dashboard = 8080
+      hermes_donna_api       = 8642
       # AI orchestration stack web UIs (Traefik-fronted) — n8n, Dify, LangFlow,
       # LangGraph, and Langfuse (LLM trace/cost/eval). ingress.tf references these.
       n8n_web      = 5678

--- a/modules/proxmox-stack/constants.tf
+++ b/modules/proxmox-stack/constants.tf
@@ -83,17 +83,16 @@ locals {
       # bearer-authenticated). Traefik-fronted as https://hermes-api.<sub>;
       # the sanctioned non-exec path to submit work to the agent.
       hermes_api = 8642
-      # hermes-ui — a companion web UI guest running TWO apps that both
-      # default to internal port 3000 upstream; mapped to distinct host
-      # ports so Traefik can route each independently.
-      hermes_ui_web       = 3000
-      hermes_ui_admin_web = 3001
-      # hermes-donna — a second, independently-identified Hermes agent
-      # instance (own container). Same webhook/dashboard/api triplet as
-      # hermes-agent above, same software defaults.
-      hermes_donna_webhook   = 8644
-      hermes_donna_dashboard = 8080
-      hermes_donna_api       = 8642
+      # hermes-ui — a companion web UI guest running two DIFFERENT apps
+      # (hermes-workspace + mission-control) that both default to port
+      # 3000 upstream; mapped to distinct host ports so Traefik can route
+      # each independently.
+      hermes_ui_workspace       = 3000
+      hermes_ui_mission_control = 3001
+      # hermes-donna is a second, independently-identified Hermes agent
+      # instance (own container) running the SAME software as hermes-agent,
+      # so it resolves the same hermes_webhook/hermes_dashboard/hermes_api
+      # keys above — no separate port constants needed.
       # AI orchestration stack web UIs (Traefik-fronted) — n8n, Dify, LangFlow,
       # LangGraph, and Langfuse (LLM trace/cost/eval). ingress.tf references these.
       n8n_web      = 5678

--- a/modules/proxmox-stack/firewall.tf
+++ b/modules/proxmox-stack/firewall.tf
@@ -80,6 +80,10 @@ module "firewall" {
   # Hermes Agent LXC: tagged "hermes-agent" (autonomous agent, broad HTTPS egress)
   hermes_agent_container_ids = local.hermes_agent_container_ids
 
+  # hermes-ui LXC: tagged "hermes-ui" (companion web UI guest, own tag so its
+  # egress can be tightened later without touching the hermes-agent profile)
+  hermes_ui_container_ids = local.hermes_ui_container_ids
+
   # AI orchestration LXCs: tagged "ai-orchestration" (n8n, Dify, LangFlow, LangGraph, agent-exec)
   ai_orchestration_container_ids = local.ai_orchestration_container_ids
 

--- a/modules/proxmox-stack/ingress.tf
+++ b/modules/proxmox-stack/ingress.tf
@@ -68,14 +68,17 @@ locals {
     # -> hermes-agent container : hermes_api (`hermes gateway` api_server platform,
     # bearer-authenticated). The sanctioned non-exec job path; internal-only firewall.
     "hermes-api" = { backend = "hermes-agent", port = local.pipeline_constants.service_ports.hermes_api, sso = false } # bearer-authenticated job API
-    # hermes-ui companion guest runs two web apps behind two distinct host
-    # ports (both default to 3000 upstream) — fronted at distinct hostnames.
-    "hermes-ui"       = { backend = "hermes-ui", port = local.pipeline_constants.service_ports.hermes_ui_web }
-    "hermes-ui-admin" = { backend = "hermes-ui", port = local.pipeline_constants.service_ports.hermes_ui_admin_web }
+    # hermes-ui companion guest runs two DIFFERENT apps behind two distinct
+    # host ports (both default to 3000 upstream): hermes-workspace (the
+    # Hermes web workspace, primary UI) and mission-control (an unrelated
+    # product co-located in this container, gateway target is OpenClaw).
+    "hermes-ui"       = { backend = "hermes-ui", port = local.pipeline_constants.service_ports.hermes_ui_workspace }
+    "mission-control" = { backend = "hermes-ui", port = local.pipeline_constants.service_ports.hermes_ui_mission_control }
     # hermes-donna — second, independently-identified Hermes agent instance
-    # (own container). Only its Dashboard is Traefik-fronted here, same as
-    # hermes-agent's dashboard row above.
-    "hermes-donna"  = { backend = "hermes-donna", port = local.pipeline_constants.service_ports.hermes_donna_dashboard }
+    # (own container, same software). Only its Dashboard is Traefik-fronted
+    # here, same as hermes-agent's dashboard row above; hermes_dashboard is a
+    # SERVICE port, so the same key is correct for either agent's container.
+    "hermes-donna"  = { backend = "hermes-donna", port = local.pipeline_constants.service_ports.hermes_dashboard }
     smokeping       = { backend = "smokeping", port = local.pipeline_constants.service_ports.smokeping_web }
     "haproxy-stats" = { backend = "haproxy", port = local.pipeline_constants.service_ports.haproxy_stats }
     # Static file host. Browser-only, so it takes the default gate (sso omitted

--- a/modules/proxmox-stack/ingress.tf
+++ b/modules/proxmox-stack/ingress.tf
@@ -67,7 +67,15 @@ locals {
     # Hermes agent inbound job-submission API: https://hermes-api.<domain>/v1/runs
     # -> hermes-agent container : hermes_api (`hermes gateway` api_server platform,
     # bearer-authenticated). The sanctioned non-exec job path; internal-only firewall.
-    "hermes-api"    = { backend = "hermes-agent", port = local.pipeline_constants.service_ports.hermes_api, sso = false } # bearer-authenticated job API
+    "hermes-api" = { backend = "hermes-agent", port = local.pipeline_constants.service_ports.hermes_api, sso = false } # bearer-authenticated job API
+    # hermes-ui companion guest runs two web apps behind two distinct host
+    # ports (both default to 3000 upstream) — fronted at distinct hostnames.
+    "hermes-ui"       = { backend = "hermes-ui", port = local.pipeline_constants.service_ports.hermes_ui_web }
+    "hermes-ui-admin" = { backend = "hermes-ui", port = local.pipeline_constants.service_ports.hermes_ui_admin_web }
+    # hermes-donna — second, independently-identified Hermes agent instance
+    # (own container). Only its Dashboard is Traefik-fronted here, same as
+    # hermes-agent's dashboard row above.
+    "hermes-donna"  = { backend = "hermes-donna", port = local.pipeline_constants.service_ports.hermes_donna_dashboard }
     smokeping       = { backend = "smokeping", port = local.pipeline_constants.service_ports.smokeping_web }
     "haproxy-stats" = { backend = "haproxy", port = local.pipeline_constants.service_ports.haproxy_stats }
     # Static file host. Browser-only, so it takes the default gate (sso omitted

--- a/modules/proxmox-stack/locals-hermes-ui.tf
+++ b/modules/proxmox-stack/locals-hermes-ui.tf
@@ -1,0 +1,11 @@
+# hermes-ui LXC (hermes-ui tag): a companion web UI guest for the Hermes
+# agent — its own tag, separate from hermes-agent, so its egress can be
+# tightened later without touching the agent profile. Split out of
+# locals.tf so that file stays under the shared _file-size 12 KB gate, the
+# same reason locals-llm-fabric.tf was split out.
+locals {
+  hermes_ui_container_ids = {
+    for k, v in var.containers : k => v.vm_id
+    if contains(coalesce(try(v.tags, null), []), "hermes-ui")
+  }
+}

--- a/modules/proxmox-stack/tests/locals.tftest.hcl
+++ b/modules/proxmox-stack/tests/locals.tftest.hcl
@@ -1084,3 +1084,58 @@ run "llm_redis_container_ids_are_disjoint_from_the_router_pool" {
     error_message = "the spend store must never be colocated with a router member — a store inside one member gives every member a private counter, which is the miscount a shared store exists to remove"
   }
 }
+
+# hermes-ui carries its OWN tag (not hermes-agent), so its egress can be
+# tightened later without touching the agent profile. A hermes-ui guest
+# picking up the hermes-agent map, or vice versa, would attach the wrong
+# rule set to one of them.
+run "hermes_ui_container_ids_are_disjoint_from_the_agent" {
+  command = plan
+
+  variables {
+    containers = {
+      "hermes-agent" = {
+        vm_id     = 304
+        node_name = "proxmox-1"
+        hostname  = "hermes-agent"
+        vlan      = "ai"
+        dhcp      = true
+        tags      = ["terraform", "container", "hermes-agent"]
+      }
+      "hermes-ui" = {
+        vm_id     = 305
+        node_name = "proxmox-1"
+        hostname  = "hermes-ui"
+        vlan      = "ai"
+        dhcp      = true
+        tags      = ["terraform", "container", "hermes-ui"]
+      }
+      "hermes-donna" = {
+        vm_id     = 306
+        node_name = "proxmox-1"
+        hostname  = "hermes-donna"
+        vlan      = "ai"
+        dhcp      = true
+        tags      = ["terraform", "container", "hermes-agent", "hermes-donna"]
+      }
+    }
+  }
+
+  assert {
+    condition     = keys(local.hermes_ui_container_ids) == ["hermes-ui"]
+    error_message = "hermes_ui_container_ids must select exactly the hermes-ui-tagged guests"
+  }
+
+  assert {
+    condition = length(setintersection(
+      keys(local.hermes_ui_container_ids),
+      keys(local.hermes_agent_container_ids),
+    )) == 0
+    error_message = "hermes-ui and hermes-agent must never share a guest — each tag drives its own firewall profile"
+  }
+
+  assert {
+    condition     = keys(local.hermes_agent_container_ids) == ["hermes-agent", "hermes-donna"]
+    error_message = "hermes-donna carries the hermes-agent tag so it is picked up by the existing hermes-agent firewall map, same as any other hermes-agent guest"
+  }
+}

--- a/modules/proxmox-stack/tests/variables.tftest.hcl
+++ b/modules/proxmox-stack/tests/variables.tftest.hcl
@@ -604,3 +604,49 @@ run "agent_pool_with_squid_accepted" {
     error_message = "the squid-tagged guest must select the proxy profile, got ${length(local.squid_proxy_container_ids)}"
   }
 }
+
+# hermes-donna has no firewall map of its own — it relies on the hermes-agent
+# tag to be picked up by hermes_agent_container_ids. A hermes-donna guest
+# missing the hermes-agent tag would silently come up with no firewall.
+run "hermes_donna_without_hermes_agent_tag_rejected" {
+  command = plan
+
+  variables {
+    containers = {
+      donna = {
+        vm_id     = 500101
+        node_name = "proxmox-1"
+        hostname  = "donna"
+        vlan      = "ai"
+        dhcp      = true
+        tags      = ["terraform", "container", "hermes-donna"]
+      }
+    }
+  }
+
+  expect_failures = [
+    var.containers,
+  ]
+}
+
+run "hermes_donna_with_hermes_agent_tag_accepted" {
+  command = plan
+
+  variables {
+    containers = {
+      donna = {
+        vm_id     = 500101
+        node_name = "proxmox-1"
+        hostname  = "donna"
+        vlan      = "ai"
+        dhcp      = true
+        tags      = ["terraform", "container", "hermes-agent", "hermes-donna"]
+      }
+    }
+  }
+
+  assert {
+    condition     = keys(local.hermes_agent_container_ids) == ["donna"]
+    error_message = "hermes-donna with the hermes-agent tag must be picked up by the existing hermes-agent firewall map"
+  }
+}

--- a/modules/proxmox-stack/variables-containers.tf
+++ b/modules/proxmox-stack/variables-containers.tf
@@ -165,4 +165,20 @@ variable "containers" {
     ])
     error_message = "Every container tagged 'ai-runner' must carry exactly one egress-profile tag from: ai-github, ai-terrakube, ai-full-net, ai-proxied. A missing or misspelled profile tag would leave the agent guest with NO firewall; two would attach conflicting rule sets."
   }
+
+  # hermes-donna is a second Hermes agent instance and deliberately carries NO
+  # dedicated firewall map of its own — it relies on the hermes-agent tag's
+  # existing container-id filter to pick up the hermes-agent security groups
+  # and rules. The same hazard as the ai-runner check above applies: a guest
+  # tagged hermes-donna without also carrying hermes-agent would silently
+  # match no firewall map at all and come up with no firewall options and no
+  # rules, invisible in a plan diff.
+  validation {
+    condition = alltrue([
+      for k, v in var.containers :
+      contains(coalesce(try(v.tags, null), []), "hermes-agent")
+      if contains(coalesce(try(v.tags, null), []), "hermes-donna")
+    ])
+    error_message = "Every container tagged 'hermes-donna' must also carry the 'hermes-agent' tag — hermes-donna has no firewall map of its own and relies on hermes_agent_container_ids to pick it up. A missing hermes-agent tag would leave the guest with NO firewall."
+  }
 }


### PR DESCRIPTION
## Summary

- Adds `service_ports` entries and Traefik ingress routes for the hermes-ui companion web guest (two apps, distinct host ports) and hermes-donna's dashboard.
- Adds a dedicated `hermes-ui` tag-driven firewall profile (container-id local, module variable, security group + firewall rules, module wiring), mirroring the existing hermes-agent pattern.
- hermes-donna relies on the existing `hermes-agent` tag/firewall map; adds a hard validation requiring any `hermes-donna`-tagged container to also carry `hermes-agent`.
- Adds `tofu test` coverage: tag-selection/disjointness for hermes-ui vs hermes-agent, and accept/reject cases for the new validation.
- Fixes a pre-existing `tofu fmt` drift in `otlp_ingest_rules.tf`.

## Test plan

- [x] `tofu fmt -check -recursive`
- [x] `tofu init -backend=false && tofu validate` (root, `modules/proxmox-stack`, `modules/firewall`)
- [x] `tofu test` — 140/140 passed in `modules/proxmox-stack`, 36/36 passed in `modules/firewall`