### PR TITLE
feat(inventory): publish every guest's MAC, not only DHCP-first ones

### DIFF
--- a/modules/proxmox-container/outputs.tf
+++ b/modules/proxmox-container/outputs.tf
@@ -11,6 +11,15 @@ output "container_details" {
     description = v.description
     tags        = v.tags
     pool_id     = v.pool_id
+    # The guest's live first-NIC MAC, whether we assigned it or the provider did.
+    # `mac_address` is optional+computed, so this reads back the auto-generated
+    # address on static guests instead of reassigning one - nothing on a running
+    # container changes because this is published.
+    #
+    # Lower-cased because the API returns upper-case while local.container_mac
+    # builds lower-case: without this, publishing the computed value would flip
+    # the case of every DHCP guest's MAC and churn the artifact for no reason.
+    mac_address = try(lower(v.network_interface[0].mac_address), null)
   } }
 }
 

--- a/modules/proxmox-stack/inventory_assembly.tf
+++ b/modules/proxmox-stack/inventory_assembly.tf
@@ -28,13 +28,21 @@ locals {
         vmid     = v.id
         hostname = var.containers[k].hostname
         ip       = local.container_address[k] # static: per-VLAN cidrhost IP (CIDR stripped); DHCP guests: FQDN (DNS-first)
-        # Deterministic MAC for DHCP-first guests (null for static guests). It
-        # keeps the guest's lease — and therefore its address and its lease-table
-        # DNS name — stable across a rebuild. It is NOT a reservation key: this
+        # The guest's live MAC, published for EVERY container.
+        #
+        # DHCP-first guests carry the deterministic MAC from local.container_mac,
+        # which keeps the lease — and therefore the address and the lease-table DNS
+        # name — stable across a rebuild. It is NOT a reservation key: this
         # inventory no longer publishes a reserved address, because a leased
         # guest's address exists only in the lease. Consumers address these guests
         # by the FQDN in `ip`, which is the single name for them.
-        mac  = try(var.containers[k].dhcp, false) ? local.container_mac[k] : null
+        #
+        # Static guests used to publish null here, which left them unnameable
+        # downstream: a static guest never sends DHCP option 12, so the network
+        # controller learns no hostname and lists it by MAC. A client alias keyed
+        # on the MAC is the only fix, and it needs this field populated. The value
+        # is READ from the provider, never assigned, so no live guest is touched.
+        mac  = v.mac_address
         node = v.node_name
         # Connection settings for proxmox_pct_remote (community.proxmox)
         ansible_connection = "community.proxmox.proxmox_pct_remote"
@@ -46,13 +54,14 @@ locals {
     # Regular VMs - using SSH connection
     # DRY: static VMs advertise their vm_id-derived IP; DHCP-first VMs advertise
     # their FQDN (local.vm_address) with a lease-stabilizing deterministic MAC,
-    # exactly like the containers block above.
+    # exactly like the containers block above — and, also like that block, every
+    # VM publishes its MAC so a static one can still be named downstream.
     vms = {
       for k, v in module.vms.vm_details : k => {
         vmid               = v.id
         hostname           = v.name
         ip                 = local.vm_address[k]
-        mac                = try(var.vms[k].dhcp, false) ? local.vm_mac[k] : null
+        mac                = v.mac_address
         node               = v.node_name
         ansible_connection = try(var.vms[k].ansible_connection, "ssh")
         # Whether the guest is expected to be running. A guest only an operator
@@ -84,7 +93,7 @@ locals {
         vmid               = v.id
         hostname           = v.name
         ip                 = local.vm_address[k]
-        mac                = try(var.vms[k].dhcp, false) ? local.vm_mac[k] : null
+        mac                = v.mac_address
         node               = v.node_name
         ansible_connection = "ssh"
         tags               = v.tags

--- a/modules/proxmox-stack/tests/locals.tftest.hcl
+++ b/modules/proxmox-stack/tests/locals.tftest.hcl
@@ -784,10 +784,21 @@ run "inventory_publishes_one_address_authority_per_guest" {
     error_message = "the inventory must not publish a reserved address for any guest"
   }
 
-  # Static guest carries no DHCP MAC — nothing to stabilize, its address is declared.
+  # EVERY guest publishes a MAC, static ones included. A static guest sends no
+  # DHCP option 12, so the network controller can only name it from a client
+  # alias, and an alias needs this field. Publishing null here is what left them
+  # listed as bare MACs in the console.
   assert {
-    condition     = output.ansible_inventory.containers["apt-cacher-ng"].mac == null
-    error_message = "static guest inventory mac must be null"
+    condition     = alltrue([for k, c in output.ansible_inventory.containers : c.mac != null])
+    error_message = "every container must publish a mac, including static guests"
+  }
+
+  # The published MAC is lower-case. The API answers in upper case while the
+  # deterministic MAC is built lower-case; without normalization, adopting the
+  # computed value would flip case on every already-published guest.
+  assert {
+    condition     = alltrue([for k, c in output.ansible_inventory.containers : c.mac == lower(c.mac)])
+    error_message = "published container mac must be lower-case"
   }
 
   # Asserted by derivation, not a literal, so no real address appears here.

--- a/modules/proxmox-vm/outputs.tf
+++ b/modules/proxmox-vm/outputs.tf
@@ -17,6 +17,15 @@ output "vm_details" {
     description = v.description
     tags        = v.tags
     pool_id     = v.pool_id
+    # The VM's live first-NIC MAC. Deliberately NOT v.mac_addresses: that list is
+    # reported by the guest agent and enumerates every interface the OS has, so on
+    # a docker host it churns with each container veth. network_device[0] is the
+    # configured NIC and is stable.
+    #
+    # Lower-cased for the same reason as the container output: the API answers in
+    # upper case, local.vm_mac builds lower case, and the artifact should not flip
+    # case on already-published guests.
+    mac_address = try(lower(v.network_device[0].mac_address), null)
   } }
 }
 


### PR DESCRIPTION
## Summary

The published inventory carried a `mac` only for DHCP-first guests; every
static guest published `null`. This reads the live first-NIC MAC off the
container and VM resources and publishes it for all guests.

## What changed

- `modules/proxmox-container/outputs.tf` — `container_details` gains
  `mac_address`, read from `network_interface[0].mac_address` (optional+computed,
  so it reads back the provider-generated address on static guests).
- `modules/proxmox-vm/outputs.tf` — `vm_details` gains `mac_address`, read from
  `network_device[0].mac_address`. Deliberately not `mac_addresses`, which is
  guest-agent reported, enumerates every OS interface, and churns on docker hosts.
- `modules/proxmox-stack/inventory_assembly.tf` — the three `mac` sites publish
  the computed value instead of branching on `dhcp`.

Values are **read, never assigned**. No running guest is modified.

Lower-cased at the module output: the API answers in upper case while the
deterministic MAC is built in lower case, and the consumer contract's pattern is
lower-case only.

## Tests

Replaces the "static guest mac must be null" assertion with two that hold under
the new contract: every container publishes a `mac`, and it is lower-case.
Both were confirmed to fail when the change is reverted. 149 passed, 0 failed.

## Verification

Plan against live state gated on: only the published inventory object changes,
0 destroy, 0 replace.