### PR TITLE
feat(nodes): publish a node's inventory-system device name

### DIFF
--- a/modules/proxmox-stack/tests/ansible_inventory_contract.tftest.hcl
+++ b/modules/proxmox-stack/tests/ansible_inventory_contract.tftest.hcl
@@ -1018,6 +1018,33 @@ run "ansible_inventory_nodes_commissioned_propagated" {
   }
 }
 
+# The node object type strips any attribute it does not declare, and it does so
+# silently — an undeclared key reaches neither the output nor an error. The
+# consumer of this field matches its records by name alone, so losing it makes
+# that consumer create a duplicate record rather than match the existing one.
+# Assert it survives the type, and that omitting it stays null rather than
+# inventing a value.
+run "ansible_inventory_nodes_device_name_propagated" {
+  command = plan
+
+  variables {
+    nodes = {
+      proxmox-1 = { role = "node-1", nautobot_device_name = "renamed-1" }
+      proxmox-3 = { role = "node-3" }
+    }
+  }
+
+  assert {
+    condition     = output.ansible_inventory.nodes["proxmox-1"].nautobot_device_name == "renamed-1"
+    error_message = "nautobot_device_name must survive the node object type and reach ansible_inventory"
+  }
+
+  assert {
+    condition     = output.ansible_inventory.nodes["proxmox-3"].nautobot_device_name == null
+    error_message = "an unset nautobot_device_name must publish as null, so a consumer can fall back to the key"
+  }
+}
+
 run "ansible_inventory_node_storage_propagated" {
   command = plan
 

--- a/modules/proxmox-stack/variables-infrastructure.tf
+++ b/modules/proxmox-stack/variables-infrastructure.tf
@@ -92,6 +92,16 @@ variable "nodes" {
     # services built on the same pattern); does not affect anything else a
     # commissioned node already runs.
     services_enabled = optional(bool, true)
+    # Name this node carries in the inventory system of record, when it differs
+    # from the key. Consumers match that system on name alone, so a node whose
+    # record was created ahead of a rename needs the record's name published
+    # here — otherwise the consumer creates a second record and strands the
+    # first. Unset means the two already agree.
+    #
+    # Declaring it is what makes it survive: this type strips any attribute it
+    # does not name, so an undeclared key would vanish between the deployment
+    # object and ansible_inventory with no error.
+    nautobot_device_name = optional(string)
   }))
   default = {}
 }


### PR DESCRIPTION
## What

Adds an optional `nautobot_device_name` to the `nodes` object type, published
through to `ansible_inventory`.

The node object type strips any attribute it does not declare, and does so
silently — an undeclared key reaches neither the output nor an error. Declaring
it is what makes a value survive from the deployment object to the inventory.

Consumers of the inventory system of record match their records by name alone.
Where a record was created under a name that differs from the node key, that
name has to be published, or the consumer creates a second record and strands
the existing one. Unset means the two names already agree, and publishes null
so a consumer can fall back to the key.

## Tests

Two assertions in the inventory contract suite: the value survives the type and
reaches the output, and an unset value publishes null. Both were confirmed to
fail with the declaration removed — the attribute does not exist on the output
at all, which is the silent-strip case being guarded.

53 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)