### PR TITLE
feat(homarr): add firewall, port constant and ingress route for a homarr guest

### DIFF
--- a/modules/firewall/homarr_rules.tf
+++ b/modules/firewall/homarr_rules.tf
@@ -1,0 +1,93 @@
+# Homarr LXC firewall — dashboard, web UI on homarr_web (7575), sqlite on its
+# own rootfs, redis colocated and bound to loopback by the installer. Its
+# security group and *_services_rules local live here, not in locals_rules.tf /
+# security_groups.tf, to keep those under the shared _file-size workflow's 12 KB
+# gate — same split as vikunja_rules.tf / zammad_rules.tf.
+#
+# Live guest-layer rule: 7575 open from internal RFC1918, following the existing
+# default-deny per-service allow model. The UI is reached through Traefik
+# (ingress.tf homarr route).
+#
+# Egress differs from vikunja on purpose. Vikunja's binary is controller-staged,
+# so it needs no package-manager egress. Homarr is installed by a borrowed
+# community-scripts installer that resolves its release from the GitHub API and
+# pulls it from the release CDN at converge time, and runs an apt transaction
+# first — so outbound HTTPS and HTTP are load-bearing here, not incidental.
+# That extra egress surface is a real cost of borrowing the install step, and is
+# recorded as such in the private docs ADR.
+
+locals {
+  homarr_services_rules = [
+    { proto = "tcp", dport = tostring(local.svc_ports.homarr_web), source = local.internal_src, comment = "Homarr dashboard from internal" },
+  ]
+}
+
+resource "proxmox_virtual_environment_cluster_firewall_security_group" "homarr_services" {
+  name    = "homarr-svc"
+  comment = "Homarr dashboard (${local.svc_ports.homarr_web}) from internal networks — Traefik-fronted"
+
+  dynamic "rule" {
+    for_each = local.homarr_services_rules
+    content {
+      type    = "in"
+      action  = "ACCEPT"
+      proto   = rule.value.proto
+      dport   = rule.value.dport
+      source  = rule.value.source
+      comment = rule.value.comment
+    }
+  }
+}
+
+resource "proxmox_virtual_environment_firewall_options" "homarr_container" {
+  for_each = var.homarr_container_ids
+
+  node_name     = var.node_name
+  container_id  = each.value
+  enabled       = local.firewall_defaults.enabled
+  input_policy  = local.firewall_defaults.input_policy
+  output_policy = local.firewall_defaults.output_policy
+  log_level_in  = local.firewall_defaults.log_level_in
+  log_level_out = local.firewall_defaults.log_level_out
+
+  # DHCP-first guest (deployment.json dhcp=true) behind DROP in/out. Without the
+  # firewall's dhcp allow, its own DHCPDISCOVER/OFFER is dropped and it never
+  # leases its apps-VLAN IP. Same treatment as the vikunja container.
+  dhcp = true
+
+  depends_on = [proxmox_virtual_environment_cluster_firewall.main]
+}
+
+resource "proxmox_virtual_environment_firewall_rules" "homarr_container" {
+  for_each = var.homarr_container_ids
+
+  node_name    = var.node_name
+  container_id = each.value
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.internal_access.name
+    comment        = "Internal access (SSH, ICMP)"
+  }
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.homarr_services.name
+    comment        = "Homarr dashboard (TCP/${local.svc_ports.homarr_web})"
+  }
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.outbound_internal.name
+    comment        = "Outbound to internal only"
+  }
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.outbound_https.name
+    comment        = "Outbound HTTPS (GitHub API + release CDN during the borrowed install)"
+  }
+
+  rule {
+    security_group = proxmox_virtual_environment_cluster_firewall_security_group.outbound_http.name
+    comment        = "Outbound HTTP (apt via the internal proxy, OCSP/CRL during TLS handshake)"
+  }
+
+  depends_on = [proxmox_virtual_environment_firewall_options.homarr_container]
+}

--- a/modules/firewall/tests/rule_generation.tftest.hcl
+++ b/modules/firewall/tests/rule_generation.tftest.hcl
@@ -36,6 +36,7 @@ variables {
       redis_default          = 6379
       nautobot_web           = 8080
       vikunja_web            = 3456
+      homarr_web             = 7575
       authelia_portal        = 9091
       zammad_web             = 8080
       ntp                    = 123
@@ -852,6 +853,32 @@ run "vikunja_rule_tracks_constant_and_internal_scope" {
   assert {
     condition     = local.vikunja_services_rules[0].source == "192.168.10.0/24,192.168.20.0/24"
     error_message = "vikunja rule source must be the comma-joined internal networks, got '${local.vikunja_services_rules[0].source}'"
+  }
+}
+
+# --- homarr service rules (community-scripts install-layer pilot) ---
+
+run "homarr_rule_tracks_constant_and_internal_scope" {
+  command = plan
+
+  variables {
+    internal_networks = ["192.168.10.0/24", "192.168.20.0/24"]
+  }
+
+  # Exactly one live rule: TCP homarr_web (7575) from the internal networks.
+  assert {
+    condition     = length(local.homarr_services_rules) == 1
+    error_message = "homarr_services_rules must be exactly 1 (TCP homarr_web), got ${length(local.homarr_services_rules)}"
+  }
+
+  assert {
+    condition     = local.homarr_services_rules[0].proto == "tcp" && local.homarr_services_rules[0].dport == tostring(var.pipeline_constants.service_ports.homarr_web)
+    error_message = "homarr rule must be TCP tracking service_ports.homarr_web, got proto='${local.homarr_services_rules[0].proto}' dport='${local.homarr_services_rules[0].dport}'"
+  }
+
+  assert {
+    condition     = local.homarr_services_rules[0].source == "192.168.10.0/24,192.168.20.0/24"
+    error_message = "homarr rule source must be the comma-joined internal networks, got '${local.homarr_services_rules[0].source}'"
   }
 }
 

--- a/modules/firewall/variables.tf
+++ b/modules/firewall/variables.tf
@@ -99,6 +99,12 @@ variable "vikunja_container_ids" {
   default     = {}
 }
 
+variable "homarr_container_ids" {
+  description = "Map of Homarr container names to their IDs (homarr tag). Dashboard — inbound homarr_web (7575) from internal; egress internal plus HTTPS/HTTP, because the app is installed by a borrowed community-scripts installer that resolves its release from GitHub at converge time."
+  type        = map(number)
+  default     = {}
+}
+
 variable "zammad_container_ids" {
   description = "Map of Zammad container names to their IDs (zammad tag). Native ITSM/ticketing app (Rails + colocated Elasticsearch + Redis) — inbound zammad_web (8080) from internal; egress outbound-internal only (Postgres/Redis/DNS/Mailpit internal; apt via the internal apt-cacher-ng proxy, no direct package-manager egress)."
   type        = map(number)

--- a/modules/proxmox-stack/constants.tf
+++ b/modules/proxmox-stack/constants.tf
@@ -43,6 +43,7 @@ locals {
       openproject_web   = 80
       prometheus_web    = 9090
       docs_static_web   = 80 # nginx document root on the static file host
+      homarr_web        = 7575
       # Proxmox cluster web UI (:8006) — fronted by Traefik at the ingress
       # subdomain apex, load-balanced across every commissioned node's UI.
       proxmox_web = 8006

--- a/modules/proxmox-stack/firewall.tf
+++ b/modules/proxmox-stack/firewall.tf
@@ -62,6 +62,7 @@ module "firewall" {
   vikunja_container_ids  = local.vikunja_container_ids
   authelia_container_ids = local.authelia_container_ids
   zammad_container_ids   = local.zammad_container_ids
+  homarr_container_ids   = local.homarr_container_ids
 
   # Ingress (Traefik HA) containers (ingress tag) — define-disabled guest firewall
   # that pre-allows keepalived VRRP + 80/443 so a later enforcement flip is safe.

--- a/modules/proxmox-stack/ingress.tf
+++ b/modules/proxmox-stack/ingress.tf
@@ -42,6 +42,7 @@ locals {
     homeassistant     = { backend = "homeassistant", port = local.pipeline_constants.service_ports.homeassistant_web, sso = false } # companion apps auth natively
     openproject       = { backend = "openproject", port = local.pipeline_constants.service_ports.openproject_web }
     prometheus        = { backend = "prometheus", port = local.pipeline_constants.service_ports.prometheus_web }
+    homarr            = { backend = "homarr", port = local.pipeline_constants.service_ports.homarr_web }
     # llm is fronted as a load-balanced router pool (llm_router_backends below).
     chat   = { backend = "open-webui", port = local.pipeline_constants.service_ports.open_webui_web }
     qdrant = { backend = "qdrant", port = local.pipeline_constants.vector_db_ports.qdrant_http, sso = false } # vector API for agents/MCP

--- a/modules/proxmox-stack/locals-homarr.tf
+++ b/modules/proxmox-stack/locals-homarr.tf
@@ -1,0 +1,19 @@
+# Homarr tag-filter local — kept out of locals.tf so that file stays under the
+# shared _file-size workflow's 12 KB limit (locals merge across files in a
+# module, so this is a pure relocation with no behavior change). Consumed by the
+# firewall module call in firewall.tf. Same split as locals-vikunja.tf.
+
+locals {
+  # Homarr LXC (homarr tag) — dashboard, web UI on homarr_web (7575), sqlite on
+  # its own rootfs. modules/firewall opens 7575 to it from internal.
+  #
+  # This guest is the pilot for the community-scripts install-layer boundary
+  # (private docs ADR "Proxmox community-scripts — borrow the install step,
+  # nothing above it"). The borrowed installer supplies only the app install;
+  # this file, the firewall rules, the port constant and the ingress route are
+  # all still ours, which is the point the pilot is measuring.
+  homarr_container_ids = {
+    for k, v in var.containers : k => v.vm_id
+    if contains(coalesce(try(v.tags, null), []), "homarr")
+  }
+}


### PR DESCRIPTION
Adds the tofu wiring a container tagged `homarr` needs. No container is declared here — `deployment.json` is unchanged, so this is inert until one is added.

What it adds:

- `service_ports.homarr_web = 7575` in `modules/proxmox-stack/constants.tf`
- `modules/proxmox-stack/locals-homarr.tf` — tag filter producing `homarr_container_ids`
- `modules/firewall/homarr_rules.tf` — `homarr-svc` security group (7575 from internal), per-container firewall options with the dhcp allow, and the rule set (internal access, the service group, outbound internal/HTTPS/HTTP)
- `homarr_container_ids` variable on the firewall module, passed from `firewall.tf`
- an `ingress.tf` route so Traefik fronts it

Egress includes HTTPS and HTTP, unlike `vikunja`, because the app is installed at converge time from the GitHub API and release CDN rather than staged from the controller.

Verified: `tofu fmt -check -recursive` clean, `tofu init -backend=false && tofu validate` reports the configuration is valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WWQ1ASJkUVRrKkYjwWBX9c