### PR TITLE
feat(storage)!: name SMB accounts by role, never by login name

### DIFF
--- a/modules/proxmox-stack/tests/node_storage_smb.tftest.hcl
+++ b/modules/proxmox-stack/tests/node_storage_smb.tftest.hcl
@@ -71,8 +71,8 @@ run "valid_smb_datasets_accepted" {
         smb = {
           group_name = "nas"
           managed_users = [{
-            name                = "someuser"
-            password_secret_env = "SOMEUSER_SMB_PASSWORD"
+            secret_prefix = "smb_user"
+            unix_groups   = ["nas"]
           }]
         }
         pools = {
@@ -80,8 +80,9 @@ run "valid_smb_datasets_accepted" {
             datasets = {
               jdrive = {
                 smb = {
-                  share_name = "jdrive"
-                  comment    = "General file share"
+                  share_name  = "jdrive"
+                  comment     = "General file share"
+                  valid_users = "@nas"
                 }
               }
               timemachine = {
@@ -214,6 +215,123 @@ run "datasets_without_smb_unaffected" {
             }
           }
         }
+      }
+    }
+  }
+}
+
+# --- valid_users must name groups, never accounts ---------------------------
+#
+# The negative case is the one that matters: Samba reads a bare word as a
+# USERNAME, so a guard that accepts it would put a login name into both the
+# desired state and the rendered smb.conf.
+
+run "valid_users_naming_an_account_rejected" {
+  command = plan
+
+  variables {
+    node_storage = {
+      test-node = {
+        pools = {
+          bulk = {
+            datasets = {
+              jdrive = {
+                smb = {
+                  share_name  = "jdrive"
+                  valid_users = "someuser"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  expect_failures = [var.node_storage]
+}
+
+run "valid_users_with_one_bad_entry_in_a_list_rejected" {
+  command = plan
+
+  variables {
+    node_storage = {
+      test-node = {
+        pools = {
+          bulk = {
+            datasets = {
+              jdrive = {
+                smb = {
+                  share_name  = "jdrive"
+                  valid_users = "@nas, someuser"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  expect_failures = [var.node_storage]
+}
+
+run "valid_users_group_forms_accepted" {
+  command = plan
+
+  variables {
+    node_storage = {
+      test-node = {
+        pools = {
+          bulk = {
+            datasets = {
+              at_form   = { smb = { share_name = "a", valid_users = "@nas" } }
+              plus_form = { smb = { share_name = "b", valid_users = "+nas" } }
+              multi     = { smb = { share_name = "c", valid_users = "@nas, +staff" } }
+              unset     = { smb = { share_name = "d" } }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+# --- managed_users.secret_prefix must be unique within a node ---------------
+
+run "duplicate_secret_prefix_on_one_node_rejected" {
+  command = plan
+
+  variables {
+    node_storage = {
+      test-node = {
+        smb = {
+          managed_users = [
+            { secret_prefix = "smb_user" },
+            { secret_prefix = "smb_user" },
+          ]
+        }
+        pools = { bulk = { datasets = {} } }
+      }
+    }
+  }
+
+  expect_failures = [var.node_storage]
+}
+
+run "distinct_secret_prefixes_accepted" {
+  command = plan
+
+  variables {
+    node_storage = {
+      test-node = {
+        smb = {
+          managed_users = [
+            { secret_prefix = "smb_service_account", unix_groups = ["nas"] },
+            { secret_prefix = "smb_user", unix_groups = ["nas"] },
+          ]
+        }
+        pools = { bulk = { datasets = {} } }
       }
     }
   }

--- a/modules/proxmox-stack/variables-storage.tf
+++ b/modules/proxmox-stack/variables-storage.tf
@@ -102,12 +102,21 @@ variable "node_storage" {
       workgroup  = optional(string, "WORKGROUP")
       # macOS Finder/Time Machine integration (vfs_fruit). Harmless for non-Mac.
       macos_optimized = optional(bool, true)
+      # A login name is a credential, not a label: it is half of what an
+      # attacker needs and it is not rotatable once published. So the ACCOUNT
+      # is named here by its ROLE, and both the username and the password are
+      # read from the node's NAS secret at converge time as
+      # <secret_prefix>_username and <secret_prefix>_password.
+      #
+      # This is why there is no `name` field. An earlier revision had one, and
+      # it put the login name into the desired-state object, into the password
+      # secret's own FIELD name, and into every converge log line -- three
+      # publications of a value that can never be un-published.
       managed_users = optional(list(object({
-        name                = string
-        unix_groups         = optional(list(string))
-        shell               = optional(string)
-        create_home         = optional(bool)
-        password_secret_env = string
+        secret_prefix = string # e.g. "smb_service_account", "smb_user"
+        unix_groups   = optional(list(string))
+        shell         = optional(string)
+        create_home   = optional(bool)
       })), [])
     }))
     pools = map(object({
@@ -153,8 +162,11 @@ variable "node_storage" {
         # both the node and the dataset -- there is nothing left to select and no
         # way for a share to reference a dataset that does not exist.
         smb = optional(object({
-          share_name     = string
-          comment        = optional(string)
+          share_name = string
+          comment    = optional(string)
+          # Samba group syntax only ("@nas", "+nas") -- enforced below. A share
+          # must authorize by GROUP, never by naming an account, because the
+          # login name is a secret and this object is the desired state.
           valid_users    = optional(string)
           browsable      = optional(bool, true)
           read_only      = optional(bool, false)
@@ -171,6 +183,40 @@ variable "node_storage" {
     }))
   }))
   default = {}
+
+  # A share may authorize only by GROUP. Samba reads a bare word in
+  # valid_users as a USERNAME, so allowing one here would put a login name into
+  # the desired-state object and into the rendered smb.conf -- the exact
+  # publication `managed_users.secret_prefix` exists to prevent. "@grp" is a
+  # unix/NIS group and "+grp" forces the unix group; both are safe.
+  validation {
+    condition = alltrue([
+      for node, cfg in var.node_storage : alltrue([
+        for pool, p in cfg.pools : alltrue([
+          for ds, d in p.datasets :
+          d.smb == null || d.smb.valid_users == null ||
+          alltrue([
+            for u in split(",", d.smb.valid_users) :
+            startswith(trimspace(u), "@") || startswith(trimspace(u), "+")
+          ])
+        ])
+      ])
+    ])
+    error_message = "smb.valid_users must list only groups (\"@nas\" or \"+nas\"); a bare name is read by Samba as a username, and a login name must not appear in the desired state."
+  }
+
+  # Two accounts sharing a secret_prefix would resolve to the same OpenBao
+  # fields and silently collapse into one account.
+  validation {
+    condition = alltrue([
+      for node, cfg in var.node_storage :
+      cfg.smb == null ? true :
+      length(cfg.smb.managed_users) == length(distinct([
+        for u in cfg.smb.managed_users : u.secret_prefix
+      ]))
+    ])
+    error_message = "Each managed_users.secret_prefix must be unique within a node; duplicates resolve to the same OpenBao username/password fields."
+  }
 
   # A Time Machine share grows until its volume is full. Without a cap one
   # backup target quietly consumes the entire pool and takes every other


### PR DESCRIPTION
## Summary

A managed SMB account is declared by `secret_prefix` instead of `name`. The
username and the password are both read from the node's NAS secret as
`<secret_prefix>_username` and `<secret_prefix>_password`.

A login name is half of a credential and cannot be rotated once published,
so it does not belong in the desired state.

## Validations added

- `smb.valid_users` accepts only Samba group forms (`@nas`, `+nas`). Samba
  reads a bare word as a username, so a share that named an account would
  publish it again in the rendered config.
- `managed_users.secret_prefix` must be unique within a node; duplicates
  resolve to the same secret fields and collapse into one account.

## Verification

`tofu test` on the SMB suite: 11 passed, 0 failed. Each new validation has
both a rejecting case and a must-pass control, and each negative fixture is
shaped so that no other validation can fire — the rejection is attributable.

Whole-repo module suites: 4 suites, 318 assertions, all pass.

BREAKING CHANGE: `node_storage.<node>.smb.managed_users` entries take
`secret_prefix` in place of `name` and `password_secret_env`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking schema change around SMB credentials and share authorization. Risk is mainly misconfiguration or unpublished consumers still using `name`/`password_secret_env`, not runtime auth code.
> 
> **Overview**
> **Breaking:** `managed_users` no longer take `name` or `password_secret_env`. Accounts are declared by `secret_prefix`; username and password are both read from the node NAS secret as `<secret_prefix>_username` / `<secret_prefix>_password` so login names never land in Terraform desired state.
> 
> Adds two variable validations: `smb.valid_users` must be Samba group forms only (`@nas`, `+nas`), because a bare word is a username; and `secret_prefix` must be unique per node so two accounts cannot collapse onto the same OpenBao fields.
> 
> SMB tests cover both new guards with reject and accept cases, and the happy-path fixture now uses `secret_prefix` plus `valid_users = "@nas"`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ceb3b1ced974d0c0596be45a3418ab6f6f21481. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->